### PR TITLE
Adding appender/3 with conn, schema_name, table_name

### DIFF
--- a/lib/nif.ex
+++ b/lib/nif.ex
@@ -46,6 +46,9 @@ defmodule Duckdbex.NIF do
   @spec appender(connection(), binary()) :: {:ok, appender()} | {:error, reason()}
   def appender(_connection, _table_name), do: :erlang.nif_error(:not_loaded)
 
+  @spec appender(connection(), binary(), binary()) :: {:ok, appender()} | {:error, reason()}
+  def appender(_connection, _schema_name, _table_name), do: :erlang.nif_error(:not_loaded)
+
   @spec appender_add_row(appender(), list()) :: :ok | {:error, reason()}
   def appender_add_row(_appender, _row), do: :erlang.nif_error(:not_loaded)
 

--- a/test/nif/appender_test.exs
+++ b/test/nif/appender_test.exs
@@ -380,4 +380,32 @@ defmodule Duckdbex.Nif.AppenderTest do
 
     assert ^result = Duckdbex.NIF.fetch_all(r)
   end
+
+  test "appender schema table", %{conn: conn} do
+    {:ok, _} =
+      Duckdbex.NIF.query(conn, """
+          create schema schema_1;
+      """)
+
+    {:ok, _} =
+      Duckdbex.NIF.query(conn, """
+        CREATE TABLE schema_1.appender_test_1(
+          bigint BIGINT,
+        );
+      """)
+
+    assert {:ok, appender} = Duckdbex.NIF.appender(conn, "schema_1", "appender_test_1")
+
+    assert :ok =
+             Duckdbex.NIF.appender_add_row(appender, [
+               123,
+             ])
+
+    assert :ok = Duckdbex.NIF.appender_flush(appender)
+
+    {:ok, r} = Duckdbex.NIF.query(conn, "SELECT * FROM schema_1.appender_test_1;")
+
+    assert [[123]] =
+             Duckdbex.NIF.fetch_all(r)
+  end
 end


### PR DESCRIPTION
Previously initialising appender with "schema.table" appender/2 gave an error
Screenshot 2024-10-10 at 16 27 14
In this PR I added appender/3 definition with conn, schema_name, table_name, so that you can also specify the schema name