### PR TITLE
Prepared statements with complex types failling

### DIFF
--- a/test/nif/prepared_statement_test.exs
+++ b/test/nif/prepared_statement_test.exs
@@ -20,4 +20,106 @@ defmodule Duckdbex.Nif.PreparedStatementTest do
     assert {:ok, res} = NIF.execute_statement(stmt, [1])
     assert [[1]] = NIF.fetch_all(res)
   end
+
+  test "insert union without params", %{conn: conn} do
+    NIF.query(
+      conn,
+      """
+        CREATE TABLE test_table(
+          test_field UNION(single_text text, multiple_text text[])
+        );
+      """
+    )
+
+    assert {:ok, stmt} =
+             NIF.prepare_statement(
+               conn,
+               """
+                 INSERT INTO test_table (test_field)
+                 VALUES ('test')
+               """
+             )
+
+    assert {:ok, _res} = NIF.execute_statement(stmt)
+
+    assert {:ok, stmt} = NIF.prepare_statement(conn, "SELECT * FROM test_table;")
+    assert {:ok, res} = NIF.execute_statement(stmt)
+    assert [[%{"single_text" => "test"}]] = NIF.fetch_all(res)
+  end
+
+  test "insert union with params", %{conn: conn} do
+    NIF.query(
+      conn,
+      """
+        CREATE TABLE test_table(
+          test_field UNION(single_text text, multiple_text text[])
+        );
+      """
+    )
+
+    assert {:ok, stmt} =
+             NIF.prepare_statement(
+               conn,
+               """
+                 INSERT INTO test_table (test_field)
+                 VALUES (?)
+               """
+             )
+
+    assert {:ok, _res} = NIF.execute_statement(stmt, ["test"])
+
+    assert {:ok, stmt} = NIF.prepare_statement(conn, "SELECT * FROM test_table;")
+    assert {:ok, res} = NIF.execute_statement(stmt)
+    assert [[%{"single_text" => "test"}]] = NIF.fetch_all(res)
+  end
+
+  test "insert struct without params", %{conn: conn} do
+    NIF.query(conn, """
+      create type test_struct as struct(
+        test_field text
+      );
+    """)
+
+    NIF.query(conn, """
+      CREATE TABLE test_table(
+        test_struct test_struct
+      );
+    """)
+
+    assert {:ok, stmt} =
+             NIF.prepare_statement(conn, """
+               INSERT INTO test_table (test_struct)
+               VALUES (struct_pack(test_field := 'test'))
+             """)
+    assert {:ok, _res} = NIF.execute_statement(stmt)
+
+    assert {:ok, stmt} = NIF.prepare_statement(conn, "SELECT * FROM test_table;")
+    assert {:ok, res} = NIF.execute_statement(stmt)
+    assert [[%{"test_field" => "test"}]] = NIF.fetch_all(res)
+  end
+
+  test "insert struct with params", %{conn: conn} do
+    NIF.query(conn, """
+      create type test_struct as struct(
+        test_field text
+      );
+    """)
+
+    NIF.query(conn, """
+      CREATE TABLE test_table(
+        test_struct test_struct
+      );
+    """)
+
+    assert {:ok, stmt} =
+             NIF.prepare_statement(conn, """
+               INSERT INTO test_table (test_struct)
+               VALUES (struct_pack(test_field := ?))
+             """)
+    assert {:ok, _res} = NIF.execute_statement(stmt, ["test"])
+
+    assert {:ok, stmt} = NIF.prepare_statement(conn, "SELECT * FROM test_table;")
+    assert {:ok, res} = NIF.execute_statement(stmt)
+    assert [[%{"test_field" => "test"}]] = NIF.fetch_all(res)
+  end
 end


### PR DESCRIPTION
When trying to do prepared queries, the params do not get recognised and inserted appropriately
![Screenshot 2024-10-31 at 12 40 18](https://github.com/user-attachments/assets/0b00ec64-b94f-4440-a87f-c5062333da65)
