### PR TITLE
fix: Making query/2 actually use query. query/3 alias prepared statement

### DIFF
--- a/lib/duckdbex.ex
+++ b/lib/duckdbex.ex
@@ -102,6 +102,7 @@ defmodule Duckdbex do
 
   @doc """
   Issues a query to the database with parameters and returns a result reference.
+  This is a short cut for prepared statements.
 
   ## Examples
 
@@ -111,8 +112,11 @@ defmodule Duckdbex do
   """
   @spec query(connection(), binary(), list()) :: {:ok, query_result()} | {:error, reason()}
   def query(connection, sql_string, args)
-      when is_reference(connection) and is_binary(sql_string) and is_list(args),
-      do: Duckdbex.NIF.query(connection, sql_string, args)
+      when is_reference(connection) and is_binary(sql_string) and is_list(args) do
+    with {:ok, stmt_ref} <- Duckdbex.prepare_statement(connection, sql_string) do
+      Duckdbex.execute_statement(stmt_ref, args)
+    end
+  end
 
   @doc """
   Prepare the specified query, returning a reference to the prepared statement object


### PR DESCRIPTION
This is a WIP fix for https://github.com/AlexR2D2/duckdbex/issues/33

One issue that I see that I am not sure how to fix (or what is causing it?). Many tests are failing with:

```
iex(1)> {:ok, db} = Duckdbex.open()
{:ok, #Reference<0.3897877700.3279814681.175777>}
iex(2)> {:ok, conn} = Duckdbex.connection(db)
{:ok, #Reference<0.3897877700.3279814681.175785>}
iex(3)> {:ok, result} = Duckdbex.query(conn, "CREATE TABLE table1(col1 TIMESTAMP);")
** (MatchError) no match of right hand side value: {:error, "Parser Error: syntax error at or near \"xir_ۉU\"\nLINE 1: CREATE TABLE table1(col1 TIMESTAMP);xir_ۉU\n                                            ^"}
    (stdlib 6.0.1) erl_eval.erl:652: :erl_eval.expr/6
    iex:3: (file)
```

Also interestingly only a single resultset is returned for the MSR, so maybe this is not completely finished