### PR TITLE
Handle special double cases

### DIFF
--- a/c_src/value_to_term.cpp
+++ b/c_src/value_to_term.cpp
@@ -49,7 +49,19 @@ bool nif::value_to_term(ErlNifEnv* env, const duckdb::Value& value, ERL_NIF_TERM
       }
     case duckdb::LogicalTypeId::DOUBLE: {
         auto a_double = value.GetValueUnsafe<double>();
-        sink = enif_make_double(env, a_double);
+
+        // Handle special floating-point cases
+        if (std::isinf(a_double)) {
+            if (a_double > 0) {
+                sink = make_atom(env, "infinity"); // Positive infinity
+            } else {
+                sink = make_atom(env, "-infinity"); // Negative infinity
+            }
+        } else if (std::isnan(a_double)) {
+            sink = make_atom(env, "nan"); // Handle NaN
+        } else {
+            sink = enif_make_double(env, a_double); // Regular double handling
+        }
         return true;
       }
     case duckdb::LogicalTypeId::DECIMAL: {

--- a/test/fetch_test.exs
+++ b/test/fetch_test.exs
@@ -25,6 +25,17 @@ defmodule Duckdbex.FetchTest do
     assert [] == Duckdbex.fetch_chunk(result_ref)
   end
 
+  test "divide by zero does not crash", %{conn: conn} do
+    {:ok, result_ref} = Duckdbex.query(conn, "SELECT 0/0")
+    assert [[:nan]] == Duckdbex.fetch_all(result_ref)
+
+    {:ok, result_ref} = Duckdbex.query(conn, "SELECT 1/0")
+    assert [[:infinity]] == Duckdbex.fetch_all(result_ref)
+
+    {:ok, result_ref} = Duckdbex.query(conn, "SELECT -1/0")
+    assert [[:"-infinity"]] == Duckdbex.fetch_all(result_ref)
+  end
+
   test "fetch_all", %{conn: conn} do
     {:ok, _} =
       Duckdbex.query(conn, """


### PR DESCRIPTION
This PR fixes argument errors on queries returning columns that are 'special' doubles (1/0, -1/0, and 0/0).