### PR TITLE
Update to Duckdb release 1.3.1 and update build variants

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -42,7 +42,8 @@ jobs:
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
-          export CXXFLAGS="-I/usr/include/c++/10 -I/usr/include/x86_64-linux-gnu/c++/10"
+          # Force include cmath and set strict C++11 mode
+          export CXXFLAGS="-std=gnu++11 -include cmath"
           mix elixir_make.precompile
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -105,30 +106,29 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - name: Setup Visual Studio Build Tools
-        uses: microsoft/setup-msbuild@v1.1
       - name: Setup Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
-      - name: Install MSYS2
-        uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
-          update: true
-          install: >-
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-make
-            mingw-w64-x86_64-pkg-config
-            mingw-w64-x86_64-cmake
-      - name: Add MSYS2 to PATH
-        run: |
-          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Mix Test
+          arch: x64
+          sdk: 10.0.22000.0
+          vsversion: 2022
+          uwp: false
+          spectre: true
+      - name: Mix Get Deps
         run: |
           mix deps.get
+      - name: Mix Test
+        shell: cmd
+        env:
+          CL: "/Zp8 /GS /DWIN32 /D_WINDOWS /D_CRT_SECURE_NO_WARNINGS"
+          LINK: "/NOLOGO /MACHINE:X64 /SUBSYSTEM:CONSOLE"
+        run: |
           mix test
       - name: Create precompiled library
         shell: cmd
+        env:
+          CL: "/Zp8 /GS /DWIN32 /D_WINDOWS /D_CRT_SECURE_NO_WARNINGS"
+          LINK: "/NOLOGO /MACHINE:X64 /SUBSYSTEM:CONSOLE"
         run: |
           set ELIXIR_MAKE_CACHE_DIR=%CD%\cache
           mkdir %ELIXIR_MAKE_CACHE_DIR%

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -57,6 +57,52 @@ jobs:
           files: |
             cache/*.tar.gz
 
+  macos:
+    runs-on: ${{matrix.runner}}
+    name: Mac (${{ matrix.runner == 'macos-13' && 'Intel' || 'ARM' }}) Erlang/OTP ${{matrix.otp}} / Elixir
+    env:
+      MIX_ENV: "prod"
+    strategy:
+      matrix:
+        runner: ["macos-13", "macos-14"]
+        otp: ["25.0", "26.0"]
+        elixir: ["1.14.5"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: asdf-vm/actions/install@v2
+        with:
+          tool_versions: |
+            erlang ${{matrix.otp}}
+            elixir ${{matrix.elixir}}
+      - name: Install libomp
+        run: |
+          brew install libomp
+          mix local.hex --force
+          mix local.rebar --force
+      - name: Patch source code
+        run: |
+          echo '#include <cmath>' > temp_header.hpp
+          echo '#include <math.h>' >> temp_header.hpp
+          cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
+          mv value_to_term_new.cpp c_src/value_to_term.cpp
+          sed -i '' 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
+          sed -i '' 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
+      - name: Mix Test
+        run: |
+          mix deps.get
+          MIX_ENV=test mix test
+      - name: Create precompiled library
+        run: |
+          export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
+          mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
+          export CXXFLAGS="-std=c++11"
+          mix elixir_make.precompile
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ matrix.runner == 'macos-13' && 'cache/*x86_64*.tar.gz' || 'cache/*aarch64*.tar.gz' }}
+
   windows:
     name: Windows Erlang/OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     runs-on: windows-latest

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -3,14 +3,14 @@ name: precompile
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
 
 env:
-  DUCKDBEX_VERSION: "0.3.8"
-  DUCKDB_VERSION: "2.16"
+  DUCKDBEX_VERSION: "0.3.12"
+  DUCKDB_VERSION: "1.3.1"
 
 jobs:
   linux:
@@ -20,11 +20,11 @@ jobs:
       MIX_ENV: "prod"
     strategy:
       matrix:
-        otp: ["25.0", "26.0"]
-        elixir: ["1.14.5"]
+        otp: ["26.0", "27.0", "28.0"]
+        elixir: ["1.14.5", "1.18.4"]
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
@@ -45,13 +45,13 @@ jobs:
           key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
-      
+
       - name: Setup DuckDBex NIF
         run: |
           mkdir -p ~/.cache
           curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz -o ~/.cache/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz
           ls -la ~/.cache/
-          
+
       - name: Get Dependencies
         run: |
           mix deps.get
@@ -66,7 +66,7 @@ jobs:
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
             gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
             libstdc++-10-dev erlang-dev
-            
+
       - name: Patch source code
         run: |
           echo '#define _GLIBCXX_USE_C99_MATH 1' > temp_header.hpp
@@ -76,18 +76,18 @@ jobs:
           mv value_to_term_new.cpp c_src/value_to_term.cpp
           sed -i 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
           sed -i 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
-          
+
       - name: Mix Test
         run: |
           MIX_ENV=test mix test
-          
+
       - name: Create precompiled library
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
           export CXXFLAGS="-D_GNU_SOURCE -std=c++11"
           mix elixir_make.precompile
-          
+
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
@@ -102,11 +102,11 @@ jobs:
     strategy:
       matrix:
         runner: ["macos-13", "macos-14"]
-        otp: ["25.0", "26.0"]
-        elixir: ["1.14.5"]
+        otp: ["26.0", "27.0", "28.0"]
+        elixir: ["1.14.5", "1.18.4"]
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: asdf-vm/actions/install@v2
         with:
           tool_versions: |
@@ -117,7 +117,7 @@ jobs:
         run: |
           mix local.hex --force
           mix local.rebar --force
-            
+
       - name: Cache mix deps
         uses: actions/cache@v3
         with:
@@ -128,7 +128,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.runner }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.runner }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
-            
+
       - name: Setup DuckDBex NIF
         run: |
           mkdir -p ~/Library/Caches
@@ -145,11 +145,11 @@ jobs:
           # Wait a moment to ensure NIF is available
           sleep 5
           ls -la ~/Library/Caches/
-            
+
       - name: Install libomp
         run: |
           brew install libomp
-          
+
       - name: Patch source code
         run: |
           echo '#include <cmath>' > temp_header.hpp
@@ -158,104 +158,20 @@ jobs:
           mv value_to_term_new.cpp c_src/value_to_term.cpp
           sed -i '' 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
           sed -i '' 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
-          
+
       - name: Mix Test
         run: |
           MIX_ENV=test mix test
-          
+
       - name: Create precompiled library
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
           export CXXFLAGS="-std=c++11"
           mix elixir_make.precompile
-          
+
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             ${{ matrix.runner == 'macos-13' && 'cache/*x86_64*.tar.gz' || 'cache/*aarch64*.tar.gz' }}
-
-  windows:
-    name: Windows Erlang/OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
-    runs-on: windows-latest
-    env:
-      MIX_ENV: "prod"
-    strategy:
-      matrix:
-        otp: ["25.0", "26.0"]
-        elixir: ["1.14.5"]
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Cache mix deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            deps
-            _build
-            ~\AppData\Local\duckdbex-nif-*
-          key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
-            
-      - name: Setup DuckDBex NIF
-        shell: cmd
-        run: |
-          mkdir %USERPROFILE%\AppData\Local
-          curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-%DUCKDB_VERSION%-x86_64-windows-%DUCKDBEX_VERSION%.tar.gz -o %USERPROFILE%\AppData\Local\duckdbex-nif-%DUCKDB_VERSION%-x86_64-windows-%DUCKDBEX_VERSION%.tar.gz
-      
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-          
-      - name: Setup Visual Studio Dev Environment
-        uses: microsoft/setup-msbuild@v1.1
-        
-      - name: Setup Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1
-            
-      - name: Setup Mix
-        shell: cmd
-        run: |
-          mix local.hex --force
-          mix local.rebar --force
-          
-      - name: Get Dependencies
-        shell: cmd
-        run: |
-          mix deps.get
-          # Wait a moment to ensure NIF is available
-          timeout /t 5
-          dir %USERPROFILE%\AppData\Local
-        
-      - name: Patch source code
-        shell: cmd
-        run: |
-          echo #define _USE_MATH_DEFINES > temp_header.hpp
-          echo #include ^<cmath^> >> temp_header.hpp
-          type temp_header.hpp c_src\value_to_term.cpp > value_to_term_new.cpp
-          move /y value_to_term_new.cpp c_src\value_to_term.cpp
-          
-      - name: Run Tests
-        shell: cmd
-        run: |
-          set CXX=cl.exe
-          set CXXFLAGS=/EHsc /MP
-          mix test
-          
-      - name: Create precompiled library
-        shell: cmd
-        run: |
-          set ELIXIR_MAKE_CACHE_DIR=%CD%\cache
-          mkdir %ELIXIR_MAKE_CACHE_DIR%
-          set CXX=cl.exe
-          set CXXFLAGS=/EHsc /MP
-          mix elixir_make.precompile
-          
-      - uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            cache/*-windows-*.tar.gz

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -148,16 +148,16 @@ jobs:
           cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
           mv value_to_term_new.cpp c_src/value_to_term.cpp
       - name: Run Tests
-        shell: msys2 {0}
+        shell: cmd
         run: |
-          export CXXFLAGS="-D_GNU_SOURCE -std=gnu++11"
+          set CXXFLAGS=-D_GNU_SOURCE -std=gnu++11
           mix test
       - name: Create precompiled library
-        shell: msys2 {0}
+        shell: cmd
         run: |
-          export ELIXIR_MAKE_CACHE_DIR="$(pwd)/cache"
-          mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
-          export CXXFLAGS="-D_GNU_SOURCE -std=gnu++11"
+          set ELIXIR_MAKE_CACHE_DIR=%CD%\cache
+          mkdir %ELIXIR_MAKE_CACHE_DIR%
+          set CXXFLAGS=-D_GNU_SOURCE -std=gnu++11
           mix elixir_make.precompile
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -20,8 +20,17 @@ jobs:
       MIX_ENV: "prod"
     strategy:
       matrix:
-        otp: ["26.0", "27.0", "28.0"]
-        elixir: ["1.14.5", "1.18.4"]
+        include:
+          - otp: "26.0"
+            elixir: "1.16.3"
+          - otp: "26.0"
+            elixir: "1.17.3"
+          - otp: "27.0"
+            elixir: "1.17.3"
+          - otp: "27.0"
+            elixir: "1.18.2"
+          - otp: "28.0"
+            elixir: "1.18.4"
     steps:
       - uses: actions/checkout@v3
 
@@ -101,9 +110,37 @@ jobs:
       MIX_ENV: "prod"
     strategy:
       matrix:
-        runner: ["macos-13", "macos-14"]
-        otp: ["26.0", "27.0", "28.0"]
-        elixir: ["1.14.5", "1.18.4"]
+        include:
+          - runner: "macos-13"
+            otp: "26.0"
+            elixir: "1.16.3"
+          - runner: "macos-13"
+            otp: "26.0"
+            elixir: "1.17.3"
+          - runner: "macos-13"
+            otp: "27.0"
+            elixir: "1.17.3"
+          - runner: "macos-13"
+            otp: "27.0"
+            elixir: "1.18.2"
+          - runner: "macos-13"
+            otp: "28.0"
+            elixir: "1.18.4"
+          - runner: "macos-14"
+            otp: "26.0"
+            elixir: "1.16.3"
+          - runner: "macos-14"
+            otp: "26.0"
+            elixir: "1.17.3"
+          - runner: "macos-14"
+            otp: "27.0"
+            elixir: "1.17.3"
+          - runner: "macos-14"
+            otp: "27.0"
+            elixir: "1.18.2"
+          - runner: "macos-14"
+            otp: "28.0"
+            elixir: "1.18.4"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+env:
+  DUCKDBEX_VERSION: "0.3.8"
+  DUCKDB_VERSION: "2.16"
+
 jobs:
   linux:
     name: Linux Erlang/OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
@@ -20,10 +24,28 @@ jobs:
         elixir: ["1.14.5"]
     steps:
       - uses: actions/checkout@v3
+      
+      - name: Cache mix deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+            ~/.cache/duckdbex-nif-*
+          key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
+      
+      - name: Setup DuckDBex NIF
+        run: |
+          mkdir -p ~/.cache
+          curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz -o ~/.cache/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz
+      
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+          
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -31,6 +53,7 @@ jobs:
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
             gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
             libstdc++-10-dev erlang-dev
+            
       - name: Patch source code
         run: |
           echo '#define _GLIBCXX_USE_C99_MATH 1' > temp_header.hpp
@@ -38,19 +61,21 @@ jobs:
           echo '#include <math.h>' >> temp_header.hpp
           cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
           mv value_to_term_new.cpp c_src/value_to_term.cpp
-          # Also replace the isinf/isnan calls directly
           sed -i 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
           sed -i 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
+          
       - name: Mix Test
         run: |
           mix deps.get
           MIX_ENV=test mix test
+          
       - name: Create precompiled library
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
           export CXXFLAGS="-D_GNU_SOURCE -std=c++11"
           mix elixir_make.precompile
+          
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
@@ -69,16 +94,39 @@ jobs:
         elixir: ["1.14.5"]
     steps:
       - uses: actions/checkout@v3
+      
+      - name: Cache mix deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+            ~/Library/Caches/duckdbex-nif-*
+          key: ${{ runner.os }}-${{ matrix.runner }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.runner }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
+            
+      - name: Setup DuckDBex NIF
+        run: |
+          mkdir -p ~/Library/Caches
+          if [ "${{ matrix.runner }}" = "macos-13" ]; then
+            curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-x86_64-darwin-${DUCKDBEX_VERSION}.tar.gz -o ~/Library/Caches/duckdbex-nif-${DUCKDB_VERSION}-x86_64-darwin-${DUCKDBEX_VERSION}.tar.gz
+          else
+            curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-aarch64-darwin-${DUCKDBEX_VERSION}.tar.gz -o ~/Library/Caches/duckdbex-nif-${DUCKDB_VERSION}-aarch64-darwin-${DUCKDBEX_VERSION}.tar.gz
+          fi
+      
       - uses: asdf-vm/actions/install@v2
         with:
           tool_versions: |
             erlang ${{matrix.otp}}
             elixir ${{matrix.elixir}}
+            
       - name: Install libomp
         run: |
           brew install libomp
           mix local.hex --force
           mix local.rebar --force
+          
       - name: Patch source code
         run: |
           echo '#include <cmath>' > temp_header.hpp
@@ -87,16 +135,19 @@ jobs:
           mv value_to_term_new.cpp c_src/value_to_term.cpp
           sed -i '' 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
           sed -i '' 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
+          
       - name: Mix Test
         run: |
           mix deps.get
           MIX_ENV=test mix test
+          
       - name: Create precompiled library
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
           export CXXFLAGS="-std=c++11"
           mix elixir_make.precompile
+          
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
@@ -114,10 +165,29 @@ jobs:
         elixir: ["1.14.5"]
     steps:
       - uses: actions/checkout@v3
+      
+      - name: Cache mix deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+            ~\AppData\Local\duckdbex-nif-*
+          key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
+            
+      - name: Setup DuckDBex NIF
+        shell: cmd
+        run: |
+          mkdir %USERPROFILE%\AppData\Local
+          curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-%DUCKDB_VERSION%-x86_64-windows-%DUCKDBEX_VERSION%.tar.gz -o %USERPROFILE%\AppData\Local\duckdbex-nif-%DUCKDB_VERSION%-x86_64-windows-%DUCKDBEX_VERSION%.tar.gz
+      
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+          
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -132,14 +202,17 @@ jobs:
             mingw-w64-x86_64-pkg-config
             base-devel
             git
+            
       - name: Setup Mix
         shell: cmd
         run: |
           mix local.hex --force
           mix local.rebar --force
+          
       - name: Get Dependencies
         shell: cmd
         run: mix deps.get
+        
       - name: Patch source code
         shell: msys2 {0}
         run: |
@@ -147,11 +220,13 @@ jobs:
           echo '#include <cmath>' >> temp_header.hpp
           cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
           mv value_to_term_new.cpp c_src/value_to_term.cpp
+          
       - name: Run Tests
         shell: cmd
         run: |
           set CXXFLAGS=-D_GNU_SOURCE -std=gnu++11
           mix test
+          
       - name: Create precompiled library
         shell: cmd
         run: |
@@ -159,6 +234,7 @@ jobs:
           mkdir %ELIXIR_MAKE_CACHE_DIR%
           set CXXFLAGS=-D_GNU_SOURCE -std=gnu++11
           mix elixir_make.precompile
+          
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -32,7 +32,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential automake autoconf pkg-config bc m4 unzip zip \
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
-            gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
+            gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
+            libstdc++-10-dev erlang-dev
       - name: Mix Test
         run: |
           mix deps.get
@@ -41,6 +42,7 @@ jobs:
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
+          export CXXFLAGS="-I/usr/include/c++/10 -I/usr/include/x86_64-linux-gnu/c++/10"
           mix elixir_make.precompile
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -103,10 +105,10 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - name: Setup Visual Studio Shell
-        uses: egor-tensin/vs-shell@v2
-        with:
-          arch: x64
+      - name: Setup Visual Studio Build Tools
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Setup Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Install MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -126,9 +128,10 @@ jobs:
           mix deps.get
           mix test
       - name: Create precompiled library
+        shell: cmd
         run: |
-          $env:ELIXIR_MAKE_CACHE_DIR = "$(Get-Location)\cache"
-          New-Item -ItemType Directory -Force -Path $env:ELIXIR_MAKE_CACHE_DIR
+          set ELIXIR_MAKE_CACHE_DIR=%CD%\cache
+          mkdir %ELIXIR_MAKE_CACHE_DIR%
           mix elixir_make.precompile
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -55,18 +55,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
 
-      - name: Setup DuckDBex NIF
-        run: |
-          mkdir -p ~/.cache
-          curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz -o ~/.cache/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz
-          ls -la ~/.cache/
-
       - name: Get Dependencies
         run: |
+          export ELIXIR_MAKE_FORCE_BUILD=1
           mix deps.get
-          # Wait a moment to ensure NIF is available
-          sleep 5
-          ls -la ~/.cache/
 
       - name: Install system dependencies
         run: |
@@ -95,6 +87,7 @@ jobs:
 
       - name: Mix Test
         run: |
+          export ELIXIR_MAKE_FORCE_BUILD=1
           MIX_ENV=test mix test
 
       - uses: softprops/action-gh-release@v1
@@ -166,22 +159,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.runner }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
 
-      - name: Setup DuckDBex NIF
-        run: |
-          mkdir -p ~/Library/Caches
-          if [ "${{ matrix.runner }}" = "macos-13" ]; then
-            curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-x86_64-darwin-${DUCKDBEX_VERSION}.tar.gz -o ~/Library/Caches/duckdbex-nif-${DUCKDB_VERSION}-x86_64-darwin-${DUCKDBEX_VERSION}.tar.gz
-          else
-            curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-aarch64-darwin-${DUCKDBEX_VERSION}.tar.gz -o ~/Library/Caches/duckdbex-nif-${DUCKDB_VERSION}-aarch64-darwin-${DUCKDBEX_VERSION}.tar.gz
-          fi
-          ls -la ~/Library/Caches/
-
       - name: Get Dependencies
         run: |
+          export ELIXIR_MAKE_FORCE_BUILD=1
           mix deps.get
-          # Wait a moment to ensure NIF is available
-          sleep 5
-          ls -la ~/Library/Caches/
 
       - name: Install libomp
         run: |
@@ -205,6 +186,7 @@ jobs:
 
       - name: Mix Test
         run: |
+          export ELIXIR_MAKE_FORCE_BUILD=1
           MIX_ENV=test mix test
 
       - uses: softprops/action-gh-release@v1

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -25,6 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+
+      - name: Setup Mix
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+
       - name: Cache mix deps
         uses: actions/cache@v3
         with:
@@ -40,12 +50,15 @@ jobs:
         run: |
           mkdir -p ~/.cache
           curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz -o ~/.cache/duckdbex-nif-${DUCKDB_VERSION}-x86_64-linux-gnu-${DUCKDBEX_VERSION}.tar.gz
-      
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
+          ls -la ~/.cache/
           
+      - name: Get Dependencies
+        run: |
+          mix deps.get
+          # Wait a moment to ensure NIF is available
+          sleep 5
+          ls -la ~/.cache/
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -66,7 +79,6 @@ jobs:
           
       - name: Mix Test
         run: |
-          mix deps.get
           MIX_ENV=test mix test
           
       - name: Create precompiled library
@@ -95,6 +107,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
+      - uses: asdf-vm/actions/install@v2
+        with:
+          tool_versions: |
+            erlang ${{matrix.otp}}
+            elixir ${{matrix.elixir}}
+
+      - name: Setup Mix
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+            
       - name: Cache mix deps
         uses: actions/cache@v3
         with:
@@ -114,18 +137,18 @@ jobs:
           else
             curl -L https://github.com/AlexR2D2/duckdbex/releases/latest/download/duckdbex-nif-${DUCKDB_VERSION}-aarch64-darwin-${DUCKDBEX_VERSION}.tar.gz -o ~/Library/Caches/duckdbex-nif-${DUCKDB_VERSION}-aarch64-darwin-${DUCKDBEX_VERSION}.tar.gz
           fi
-      
-      - uses: asdf-vm/actions/install@v2
-        with:
-          tool_versions: |
-            erlang ${{matrix.otp}}
-            elixir ${{matrix.elixir}}
+          ls -la ~/Library/Caches/
+
+      - name: Get Dependencies
+        run: |
+          mix deps.get
+          # Wait a moment to ensure NIF is available
+          sleep 5
+          ls -la ~/Library/Caches/
             
       - name: Install libomp
         run: |
           brew install libomp
-          mix local.hex --force
-          mix local.rebar --force
           
       - name: Patch source code
         run: |
@@ -138,7 +161,6 @@ jobs:
           
       - name: Mix Test
         run: |
-          mix deps.get
           MIX_ENV=test mix test
           
       - name: Create precompiled library
@@ -188,20 +210,11 @@ jobs:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
           
-      - uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: >-
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-gcc-libs
-            mingw-w64-x86_64-gdb
-            mingw-w64-x86_64-make
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-tools-git
-            mingw-w64-x86_64-pkg-config
-            base-devel
-            git
+      - name: Setup Visual Studio Dev Environment
+        uses: microsoft/setup-msbuild@v1.1
+        
+      - name: Setup Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
             
       - name: Setup Mix
         shell: cmd
@@ -211,20 +224,25 @@ jobs:
           
       - name: Get Dependencies
         shell: cmd
-        run: mix deps.get
+        run: |
+          mix deps.get
+          # Wait a moment to ensure NIF is available
+          timeout /t 5
+          dir %USERPROFILE%\AppData\Local
         
       - name: Patch source code
-        shell: msys2 {0}
+        shell: cmd
         run: |
-          echo '#define _USE_MATH_DEFINES' > temp_header.hpp
-          echo '#include <cmath>' >> temp_header.hpp
-          cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
-          mv value_to_term_new.cpp c_src/value_to_term.cpp
+          echo #define _USE_MATH_DEFINES > temp_header.hpp
+          echo #include ^<cmath^> >> temp_header.hpp
+          type temp_header.hpp c_src\value_to_term.cpp > value_to_term_new.cpp
+          move /y value_to_term_new.cpp c_src\value_to_term.cpp
           
       - name: Run Tests
         shell: cmd
         run: |
-          set CXXFLAGS=-D_GNU_SOURCE -std=gnu++11
+          set CXX=cl.exe
+          set CXXFLAGS=/EHsc /MP
           mix test
           
       - name: Create precompiled library
@@ -232,7 +250,8 @@ jobs:
         run: |
           set ELIXIR_MAKE_CACHE_DIR=%CD%\cache
           mkdir %ELIXIR_MAKE_CACHE_DIR%
-          set CXXFLAGS=-D_GNU_SOURCE -std=gnu++11
+          set CXX=cl.exe
+          set CXXFLAGS=/EHsc /MP
           mix elixir_make.precompile
           
       - uses: softprops/action-gh-release@v1

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -86,16 +86,16 @@ jobs:
           sed -i 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
           sed -i 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
 
-      - name: Mix Test
-        run: |
-          MIX_ENV=test mix test
-
       - name: Create precompiled library
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
           export CXXFLAGS="-D_GNU_SOURCE -std=c++11"
           mix elixir_make.precompile
+
+      - name: Mix Test
+        run: |
+          MIX_ENV=test mix test
 
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -196,16 +196,16 @@ jobs:
           sed -i '' 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
           sed -i '' 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
 
-      - name: Mix Test
-        run: |
-          MIX_ENV=test mix test
-
       - name: Create precompiled library
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
           export CXXFLAGS="-std=c++11"
           mix elixir_make.precompile
+
+      - name: Mix Test
+        run: |
+          MIX_ENV=test mix test
 
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -75,8 +75,6 @@ jobs:
           echo '#include <math.h>' >> temp_header.hpp
           cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
           mv value_to_term_new.cpp c_src/value_to_term.cpp
-          sed -i 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
-          sed -i 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
 
       - name: Create precompiled library
         run: |
@@ -119,6 +117,9 @@ jobs:
           - runner: "macos-14"
             otp: "27.0"
             elixir: "1.18.2"
+          - runner: "macos-14"
+            otp: "28.0"
+            elixir: "1.18.4"
     steps:
       - uses: actions/checkout@v3
 
@@ -160,8 +161,6 @@ jobs:
           echo '#include <math.h>' >> temp_header.hpp
           cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
           mv value_to_term_new.cpp c_src/value_to_term.cpp
-          sed -i '' 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
-          sed -i '' 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
 
       - name: Create precompiled library
         run: |

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -34,6 +34,13 @@ jobs:
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
             gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
             libstdc++-10-dev erlang-dev
+      - name: Patch source code
+        run: |
+          # Ensure cmath is included and functions are available
+          echo '#include <cmath>' > temp_header.hpp
+          echo 'namespace std { using ::isinf; using ::isnan; }' >> temp_header.hpp
+          cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
+          mv value_to_term_new.cpp c_src/value_to_term.cpp
       - name: Mix Test
         run: |
           mix deps.get
@@ -42,8 +49,8 @@ jobs:
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
-          # Force include cmath and set strict C++11 mode
-          export CXXFLAGS="-std=gnu++11 -include cmath"
+          # Define _GNU_SOURCE to ensure all math functions are available
+          export CXXFLAGS="-D_GNU_SOURCE -std=gnu++11"
           mix elixir_make.precompile
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -96,6 +103,9 @@ jobs:
     runs-on: windows-latest
     env:
       MIX_ENV: "prod"
+    defaults:
+      run:
+        shell: msys2 {0}
     strategy:
       matrix:
         otp: ["25.0", "26.0"]
@@ -106,32 +116,40 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - name: Setup Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1
+      - uses: msys2/setup-msys2@v2
         with:
-          arch: x64
-          sdk: 10.0.22000.0
-          vsversion: 2022
-          uwp: false
-          spectre: true
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-gcc-libs
+            mingw-w64-x86_64-gdb
+            mingw-w64-x86_64-make
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-tools-git
+            mingw-w64-x86_64-pkg-config
+            base-devel
+            git
       - name: Mix Get Deps
         run: |
+          mix local.hex --force
+          mix local.rebar --force
           mix deps.get
-      - name: Mix Test
-        shell: cmd
-        env:
-          CL: "/Zp8 /GS /DWIN32 /D_WINDOWS /D_CRT_SECURE_NO_WARNINGS"
-          LINK: "/NOLOGO /MACHINE:X64 /SUBSYSTEM:CONSOLE"
+      - name: Patch source code
         run: |
+          echo '#include <cmath>' > temp_header.hpp
+          echo 'namespace std { using ::isinf; using ::isnan; }' >> temp_header.hpp
+          cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
+          mv value_to_term_new.cpp c_src/value_to_term.cpp
+      - name: Mix Test
+        run: |
+          export CXXFLAGS="-D_GNU_SOURCE -std=gnu++11"
           mix test
       - name: Create precompiled library
-        shell: cmd
-        env:
-          CL: "/Zp8 /GS /DWIN32 /D_WINDOWS /D_CRT_SECURE_NO_WARNINGS"
-          LINK: "/NOLOGO /MACHINE:X64 /SUBSYSTEM:CONSOLE"
         run: |
-          set ELIXIR_MAKE_CACHE_DIR=%CD%\cache
-          mkdir %ELIXIR_MAKE_CACHE_DIR%
+          export ELIXIR_MAKE_CACHE_DIR="$(pwd)/cache"
+          mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
+          export CXXFLAGS="-D_GNU_SOURCE -std=gnu++11"
           mix elixir_make.precompile
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -66,7 +66,7 @@ jobs:
           sudo apt-get install -y build-essential automake autoconf pkg-config bc m4 unzip zip \
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
             gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
-            libstdc++-10-dev erlang-dev
+            libstdc++-10-dev erlang-dev ccache
 
       - name: Patch source code
         run: |
@@ -82,7 +82,10 @@ jobs:
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
+          export CC="ccache gcc"
+          export CXX="ccache g++"
           export CXXFLAGS="-D_GNU_SOURCE -std=c++11"
+          export MAKEFLAGS="-j$(nproc)"
           mix elixir_make.precompile
 
       - name: Mix Test
@@ -108,32 +111,14 @@ jobs:
             otp: "26.0"
             elixir: "1.16.3"
           - runner: "macos-13"
-            otp: "26.0"
-            elixir: "1.17.3"
-          - runner: "macos-13"
-            otp: "27.0"
-            elixir: "1.17.3"
-          - runner: "macos-13"
             otp: "27.0"
             elixir: "1.18.2"
-          - runner: "macos-13"
-            otp: "28.0"
-            elixir: "1.18.4"
           - runner: "macos-14"
             otp: "26.0"
             elixir: "1.16.3"
           - runner: "macos-14"
-            otp: "26.0"
-            elixir: "1.17.3"
-          - runner: "macos-14"
-            otp: "27.0"
-            elixir: "1.17.3"
-          - runner: "macos-14"
             otp: "27.0"
             elixir: "1.18.2"
-          - runner: "macos-14"
-            otp: "28.0"
-            elixir: "1.18.4"
     steps:
       - uses: actions/checkout@v3
 
@@ -164,9 +149,10 @@ jobs:
           export ELIXIR_MAKE_FORCE_BUILD=1
           mix deps.get
 
-      - name: Install libomp
+      - name: Install libomp and ccache
         run: |
-          brew install libomp
+          brew install libomp ccache
+          echo "$(brew --prefix)/bin" >> $GITHUB_PATH
 
       - name: Patch source code
         run: |
@@ -181,7 +167,10 @@ jobs:
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
+          export CC="ccache clang"
+          export CXX="ccache clang++"
           export CXXFLAGS="-std=c++11"
+          export MAKEFLAGS="-j$(sysctl -n hw.ncpu)"
           mix elixir_make.precompile
 
       - name: Mix Test

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           files: |
             cache/*.tar.gz
+
   macos:
     runs-on: ${{matrix.runner}}
     # Homebrew supports versioned Erlang/OTP but not Elixir
@@ -86,3 +87,51 @@ jobs:
         with:
           files: |
             ${{ matrix.runner == 'macos-13' && 'cache/*x86_64*.tar.gz' || 'cache/*aarch64*.tar.gz' }}
+
+  windows:
+    name: Windows Erlang/OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    runs-on: windows-latest
+    env:
+      MIX_ENV: "prod"
+    strategy:
+      matrix:
+        otp: ["25.0", "26.0"]
+        elixir: ["1.14.5"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - name: Setup Visual Studio Shell
+        uses: egor-tensin/vs-shell@v2
+        with:
+          arch: x64
+      - name: Install MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-make
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-cmake
+      - name: Add MSYS2 to PATH
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Mix Test
+        run: |
+          mix deps.get
+          mix test
+      - name: Create precompiled library
+        run: |
+          $env:ELIXIR_MAKE_CACHE_DIR = "$(Get-Location)\cache"
+          New-Item -ItemType Directory -Force -Path $env:ELIXIR_MAKE_CACHE_DIR
+          mix elixir_make.precompile
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            cache/*-windows-*.tar.gz

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -16,9 +16,6 @@ jobs:
       MIX_ENV: "prod"
     strategy:
       matrix:
-        # Elixir 1.14.5 is first version compatible with OTP 26
-        # NIF versions change according to
-        # https://github.com/erlang/otp/blob/dd57c853a324a9572a9e5ce227d8675ff004c6fe/erts/emulator/beam/erl_nif.h#L33
         otp: ["25.0", "26.0"]
         elixir: ["1.14.5"]
     steps:
@@ -27,7 +24,7 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - name: Install system dependecies
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential automake autoconf pkg-config bc m4 unzip zip \
@@ -36,11 +33,14 @@ jobs:
             libstdc++-10-dev erlang-dev
       - name: Patch source code
         run: |
-          # Ensure cmath is included and functions are available
-          echo '#include <cmath>' > temp_header.hpp
-          echo 'namespace std { using ::isinf; using ::isnan; }' >> temp_header.hpp
+          echo '#define _GLIBCXX_USE_C99_MATH 1' > temp_header.hpp
+          echo '#include <cmath>' >> temp_header.hpp
+          echo '#include <math.h>' >> temp_header.hpp
           cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
           mv value_to_term_new.cpp c_src/value_to_term.cpp
+          # Also replace the isinf/isnan calls directly
+          sed -i 's/std::isinf/std::isfinite/g' c_src/value_to_term.cpp
+          sed -i 's/std::isnan/std::isfinite/g' c_src/value_to_term.cpp
       - name: Mix Test
         run: |
           mix deps.get
@@ -49,8 +49,7 @@ jobs:
         run: |
           export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
-          # Define _GNU_SOURCE to ensure all math functions are available
-          export CXXFLAGS="-D_GNU_SOURCE -std=gnu++11"
+          export CXXFLAGS="-D_GNU_SOURCE -std=c++11"
           mix elixir_make.precompile
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -58,54 +57,11 @@ jobs:
           files: |
             cache/*.tar.gz
 
-  macos:
-    runs-on: ${{matrix.runner}}
-    # Homebrew supports versioned Erlang/OTP but not Elixir
-    # It's a deliberate design decision from Homebrew to
-    # only support versioned distrinutions for certin packages
-    name: Mac (${{ matrix.runner == 'macos-13' && 'Intel' || 'ARM' }}) Erlang/OTP ${{matrix.otp}} / Elixir
-    env:
-      MIX_ENV: "prod"
-    strategy:
-      matrix:
-        runner: ["macos-13", "macos-14"]
-        otp: ["25.0", "26.0"]
-        elixir: ["1.14.5"]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: asdf-vm/actions/install@v2
-        with:
-          tool_versions: |
-            erlang ${{matrix.otp}}
-            elixir ${{matrix.elixir}}
-      - name: Install libomp
-        run: |
-          brew install libomp
-          mix local.hex --force
-          mix local.rebar --force
-      - name: Mix Test
-        run: |
-          mix deps.get
-          MIX_ENV=test mix test
-      - name: Create precompiled library
-        run: |
-          export ELIXIR_MAKE_CACHE_DIR=$(pwd)/cache
-          mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"
-          mix elixir_make.precompile
-      - uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            ${{ matrix.runner == 'macos-13' && 'cache/*x86_64*.tar.gz' || 'cache/*aarch64*.tar.gz' }}
-
   windows:
     name: Windows Erlang/OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     runs-on: windows-latest
     env:
       MIX_ENV: "prod"
-    defaults:
-      run:
-        shell: msys2 {0}
     strategy:
       matrix:
         otp: ["25.0", "26.0"]
@@ -130,22 +86,28 @@ jobs:
             mingw-w64-x86_64-pkg-config
             base-devel
             git
-      - name: Mix Get Deps
+      - name: Setup Mix
+        shell: cmd
         run: |
           mix local.hex --force
           mix local.rebar --force
-          mix deps.get
+      - name: Get Dependencies
+        shell: cmd
+        run: mix deps.get
       - name: Patch source code
+        shell: msys2 {0}
         run: |
-          echo '#include <cmath>' > temp_header.hpp
-          echo 'namespace std { using ::isinf; using ::isnan; }' >> temp_header.hpp
+          echo '#define _USE_MATH_DEFINES' > temp_header.hpp
+          echo '#include <cmath>' >> temp_header.hpp
           cat temp_header.hpp c_src/value_to_term.cpp > value_to_term_new.cpp
           mv value_to_term_new.cpp c_src/value_to_term.cpp
-      - name: Mix Test
+      - name: Run Tests
+        shell: msys2 {0}
         run: |
           export CXXFLAGS="-D_GNU_SOURCE -std=gnu++11"
           mix test
       - name: Create precompiled library
+        shell: msys2 {0}
         run: |
           export ELIXIR_MAKE_CACHE_DIR="$(pwd)/cache"
           mkdir -p "${ELIXIR_MAKE_CACHE_DIR}"

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ duckdbex-*.tar
 .claude/
 .elixir_ls/
 CLAUDE.md
+notes/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ duckdbex-*.tar
 
 # Temporary files for e.g. tests
 /tmp
+.claude/
+.elixir_ls/
+CLAUDE.md

--- a/c_src/duckdb/duckdb.hpp
+++ b/c_src/duckdb/duckdb.hpp
@@ -10,11 +10,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #pragma once
 #define DUCKDB_AMALGAMATION 1
-#define DUCKDB_SOURCE_ID "7c039464e4"
-#define DUCKDB_VERSION "v1.2.2"
+#define DUCKDB_SOURCE_ID "v1.3.1"
+#define DUCKDB_VERSION "v1.3.1"
 #define DUCKDB_MAJOR_VERSION 1
-#define DUCKDB_MINOR_VERSION 2
-#define DUCKDB_PATCH_VERSION "2"
+#define DUCKDB_MINOR_VERSION 3
+#define DUCKDB_PATCH_VERSION "1"
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -66,18 +66,52 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 
+
+
 #include <sstream>
+
+#define DUCKDB_BASE_STD
+
+namespace duckdb_base_std {
+using ::std::basic_stringstream;
+using ::std::stringstream;
+using ::std::wstringstream;
+} // namespace duckdb_base_std
+
 #include <string>
+#include <locale>
 
 namespace duckdb {
 using std::string;
-using std::stringstream;
+} // namespace duckdb
+
+namespace duckdb {
+
+template <class charT, class traits = std::char_traits<charT>, class Allocator = std::allocator<charT>>
+class basic_stringstream : public duckdb_base_std::basic_stringstream<charT, traits, Allocator> {
+public:
+	using original = duckdb_base_std::basic_stringstream<charT, traits, Allocator>;
+
+	explicit basic_stringstream(std::ios_base::openmode which = std::ios_base::out | std::ios_base::in)
+	    : original(which) {
+		this->imbue(std::locale::classic());
+	}
+	explicit basic_stringstream(const std::basic_string<charT, traits, Allocator> &s,
+	                            std::ios_base::openmode which = std::ios_base::out | std::ios_base::in)
+	    : original(s, which) {
+		this->imbue(std::locale::classic());
+	}
+	basic_stringstream(const basic_stringstream &) = delete;
+	basic_stringstream(basic_stringstream &&rhs) noexcept;
+};
+
+typedef basic_stringstream<char> stringstream;
 } // namespace duckdb
 
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/main/winapi.hpp
+// duckdb/common/winapi.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -165,6 +199,7 @@ DUCKDB_API void DuckDBAssertInternal(bool condition, const char *condition_name,
 }
 
 #define D_ASSERT(condition) duckdb::DuckDBAssertInternal(bool(condition), #condition, __FILE__, __LINE__)
+#define D_ASSERT_IS_ENABLED
 
 #endif
 
@@ -216,6 +251,9 @@ typedef const data_t *const_data_ptr_t;
 typedef uint32_t sel_t;
 //! Type used for transaction timestamps
 typedef idx_t transaction_t;
+
+//! Type used to identify connections
+typedef idx_t connection_t;
 
 //! Type used for column identifiers
 typedef idx_t column_t;
@@ -557,6 +595,8 @@ public:
 	DUCKDB_API static unordered_map<string, string> InitializeExtraInfo(const string &subtype,
 	                                                                    optional_idx error_location);
 
+	//! Whether this exception type can occur during execution of a query
+	DUCKDB_API static bool IsExecutionError(ExceptionType type);
 	DUCKDB_API static string ToJSON(ExceptionType type, const string &message);
 	DUCKDB_API static string ToJSON(ExceptionType type, const string &message,
 	                                const unordered_map<string, string> &extra_info);
@@ -628,6 +668,9 @@ public:
 	explicit OutOfMemoryException(const string &msg, ARGS... params)
 	    : OutOfMemoryException(ConstructMessage(msg, params...)) {
 	}
+
+private:
+	string ExtendOutOfMemoryError(const string &msg);
 };
 
 class SyntaxException : public Exception {
@@ -865,15 +908,27 @@ struct MemorySafety {
 } // namespace duckdb
 
 
+
 #include <memory>
+
+#define DUCKDB_BASE_STD
+
+namespace duckdb_base_std {
+using ::std::make_shared;
+using ::std::shared_ptr;
+using ::std::unique_ptr;
+// using ::std::make_unique;
+} // namespace duckdb_base_std
+
+
 #include <type_traits>
 
 namespace duckdb {
 
 template <class DATA_TYPE, class DELETER = std::default_delete<DATA_TYPE>, bool SAFE = true>
-class unique_ptr : public std::unique_ptr<DATA_TYPE, DELETER> { // NOLINT: naming
+class unique_ptr : public duckdb_base_std::unique_ptr<DATA_TYPE, DELETER> { // NOLINT: naming
 public:
-	using original = std::unique_ptr<DATA_TYPE, DELETER>;
+	using original = duckdb_base_std::unique_ptr<DATA_TYPE, DELETER>;
 	using original::original; // NOLINT
 	using pointer = typename original::pointer;
 
@@ -915,11 +970,37 @@ public:
 	}
 };
 
-// FIXME: DELETER is defined, but we use std::default_delete???
-template <class DATA_TYPE, class DELETER, bool SAFE>
-class unique_ptr<DATA_TYPE[], DELETER, SAFE> : public std::unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>> {
+template <class DATA_TYPE, class DELETER>
+class unique_ptr<DATA_TYPE[], DELETER, true> : public duckdb_base_std::unique_ptr<DATA_TYPE[], DELETER> {
 public:
-	using original = std::unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>>;
+	using original = duckdb_base_std::unique_ptr<DATA_TYPE[], DELETER>;
+	using original::original;
+
+private:
+	static inline void AssertNotNull(const bool null) {
+#if defined(DUCKDB_DEBUG_NO_SAFETY) || defined(DUCKDB_CLANG_TIDY)
+		return;
+#else
+		if (DUCKDB_UNLIKELY(null)) {
+			throw duckdb::InternalException("Attempted to dereference unique_ptr that is NULL!");
+		}
+#endif
+	}
+
+public:
+	typename std::add_lvalue_reference<DATA_TYPE>::type operator[](size_t __i) const { // NOLINT: hiding on purpose
+		const auto ptr = original::get();
+		if (MemorySafety<true>::ENABLED) {
+			AssertNotNull(!ptr);
+		}
+		return ptr[__i];
+	}
+};
+
+template <class DATA_TYPE, class DELETER, bool SAFE>
+class unique_ptr<DATA_TYPE[], DELETER, SAFE> : public duckdb_base_std::unique_ptr<DATA_TYPE[], DELETER> {
+public:
+	using original = duckdb_base_std::unique_ptr<DATA_TYPE[], DELETER>;
 	using original::original;
 
 private:
@@ -944,10 +1025,10 @@ public:
 };
 
 template <typename T>
-using unique_array = unique_ptr<T[], std::default_delete<T>, true>;
+using unique_array = unique_ptr<T[], std::default_delete<T[]>, true>;
 
 template <typename T>
-using unsafe_unique_array = unique_ptr<T[], std::default_delete<T>, false>;
+using unsafe_unique_array = unique_ptr<T[], std::default_delete<T[]>, false>;
 
 template <typename T>
 using unsafe_unique_ptr = unique_ptr<T, std::default_delete<T>, false>;
@@ -982,7 +1063,11 @@ DUCKDB_API bool IsInvalidCatalog(const string &str);
 
 //! Special value used to signify the ROW ID of a table
 DUCKDB_API extern const column_t COLUMN_IDENTIFIER_ROW_ID;
+//! Special value used to signify an empty column (used for e.g. COUNT(*))
+DUCKDB_API extern const column_t COLUMN_IDENTIFIER_EMPTY;
+DUCKDB_API extern const column_t VIRTUAL_COLUMN_START;
 DUCKDB_API bool IsRowIdColumnId(column_t column_id);
+DUCKDB_API bool IsVirtualColumn(column_t column_id);
 
 //! The maximum row identifier used in tables
 extern const row_t MAX_ROW_ID;
@@ -1658,7 +1743,7 @@ inline
 shared_ptr<DATA_TYPE>
 make_shared_ptr(ARGS&&... args) // NOLINT: mimic std style
 {
-	return shared_ptr<DATA_TYPE>(std::make_shared<DATA_TYPE>(std::forward<ARGS>(args)...));
+	return shared_ptr<DATA_TYPE>(duckdb_base_std::make_shared<DATA_TYPE>(std::forward<ARGS>(args)...));
 }
 
 template<class DATA_TYPE, class... ARGS>
@@ -1670,31 +1755,31 @@ make_unsafe_uniq(ARGS&&... args) // NOLINT: mimic std style
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>
 make_uniq_array(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>(new DATA_TYPE[n]());
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>(new DATA_TYPE[n]());
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>
 make_uniq_array_uninitialized(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>(new DATA_TYPE[n]);
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>(new DATA_TYPE[n]);
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>
 make_unsafe_uniq_array(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>(new DATA_TYPE[n]());
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>(new DATA_TYPE[n]());
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>
 make_unsafe_uniq_array_uninitialized(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>(new DATA_TYPE[n]);
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>(new DATA_TYPE[n]);
 }
 
 template<class DATA_TYPE, class... ARGS>
@@ -1772,21 +1857,27 @@ constexpr T MinValue(T a, T b) {
 	return a < b ? a : b;
 }
 
+//! Like std::clamp (C++17), returns v if within bounds, else nearest bound
+template <typename T>
+constexpr T ClampValue(T v, T min, T max) {
+	return MinValue(MaxValue(v, min), max);
+}
+
 template <typename T>
 T AbsValue(T a) {
 	return a < 0 ? -a : a;
 }
 
-//! Align value (ceiling)
-template<class T, T val=8>
+//! Align value (ceiling) (not for pointer types)
+template<class T, T val=8, typename = typename std::enable_if<!std::is_pointer<T>::value>::type>
 static inline T AlignValue(T n) {
 	return ((n + (val - 1)) / val) * val;
 }
 
-template<uintptr_t alignment>
-inline data_ptr_t AlignValue(data_ptr_t addr) {
+template<uintptr_t alignment, class T>
+inline T *AlignPointer(T *addr) {
 	static_assert((alignment & (alignment - 1)) == 0, "'alignment' has to be a power of 2");
-	return reinterpret_cast<data_ptr_t>((reinterpret_cast<uintptr_t>(addr) + alignment - 1) & ~(alignment - 1));
+	return reinterpret_cast<T *>((reinterpret_cast<uintptr_t>(addr) + alignment - 1) & ~(alignment - 1));
 }
 
 template<class T, T val=8>
@@ -2222,6 +2313,10 @@ public:
 		return index == rhs.index;
 	}
 
+	inline bool operator!=(const optional_idx &rhs) const {
+		return index != rhs.index;
+	}
+
 private:
 	idx_t index;
 };
@@ -2230,9 +2325,11 @@ private:
 
 
 namespace duckdb {
+class ParsedExpression;
 
 class QueryErrorContext {
 public:
+	QueryErrorContext(const ParsedExpression &expr); // NOLINT: allow implicit conversion from expression
 	explicit QueryErrorContext(optional_idx query_location_p = optional_idx()) : query_location(query_location_p) {
 	}
 
@@ -2249,6 +2346,7 @@ public:
 
 
 namespace duckdb {
+struct EntryLookupInfo;
 
 class CatalogException : public Exception {
 public:
@@ -2263,6 +2361,7 @@ public:
 	    : CatalogException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(error_context)) {
 	}
 
+	static CatalogException MissingEntry(const EntryLookupInfo &lookup_info, const string &suggestion);
 	static CatalogException MissingEntry(CatalogType type, const string &name, const string &suggestion,
 	                                     QueryErrorContext context = QueryErrorContext());
 	static CatalogException MissingEntry(const string &type, const string &name, const vector<string> &suggestions,
@@ -2556,6 +2655,9 @@ struct LogicalType {
 		}
 		return false;
 	}
+	inline bool IsUnknown() const {
+		return id_ == LogicalTypeId::UNKNOWN;
+	}
 
 	inline shared_ptr<ExtraTypeInfo> GetAuxInfoShrPtr() const {
 		return type_info_;
@@ -2605,7 +2707,9 @@ struct LogicalType {
 	}
 	DUCKDB_API string ToString() const;
 	DUCKDB_API bool IsIntegral() const;
+	DUCKDB_API bool IsFloating() const;
 	DUCKDB_API bool IsNumeric() const;
+	DUCKDB_API static bool IsNumeric(LogicalTypeId type);
 	DUCKDB_API bool IsTemporal() const;
 	DUCKDB_API hash_t Hash() const;
 	DUCKDB_API void SetAlias(string alias);
@@ -2630,6 +2734,9 @@ struct LogicalType {
 	DUCKDB_API bool GetDecimalProperties(uint8_t &width, uint8_t &scale) const;
 
 	DUCKDB_API void Verify() const;
+
+	DUCKDB_API bool IsSigned() const;
+	DUCKDB_API bool IsUnsigned() const;
 
 	DUCKDB_API bool IsValid() const;
 	DUCKDB_API bool IsComplete() const;
@@ -2940,7 +3047,6 @@ struct hash<duckdb::uhugeint_t> {
 //
 //
 //===----------------------------------------------------------------------===//
-
 
 
 
@@ -3277,6 +3383,50 @@ using std::set;
 } // namespace duckdb
 
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/complex_json.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+#include <unordered_map>
+#include <string>
+
+
+
+namespace duckdb {
+
+//! Custom struct to handle both strings and nested JSON objects
+struct ComplexJSON {
+	//! Constructor for string values
+	explicit ComplexJSON(const string &str);
+	//! Basic empty constructor
+	ComplexJSON();
+	//! Adds Object to the underlying map, also sets the is_object flag to True
+	void AddObject(const string &key, unique_ptr<ComplexJSON> object);
+	//! Gets a ComplexJSON object from the map
+	ComplexJSON &GetObject(const string &key);
+	//! Gets a string version of the underlying ComplexJSON object from the map
+	string GetValue(const string &key) const;
+	//! Recursive function for GetValue
+	static string GetValueRecursive(const ComplexJSON &child);
+	//! Flattens this json to a top level key -> nested json
+	unordered_map<string, string> Flatten() const;
+
+private:
+	//! Basic string value, in case this is the last value of a nested json
+	string str_value;
+	//! If this is a complex json a map of key/value
+	unordered_map<string, unique_ptr<ComplexJSON>> obj_value;
+	//! If this json is an object (i.e., map or not)
+	bool is_object;
+};
+
+} // namespace duckdb
 
 #include <cstring>
 
@@ -3428,6 +3578,9 @@ public:
 	DUCKDB_API static void URLDecodeBuffer(const char *input, idx_t input_size, char *output,
 	                                       bool plus_to_space = false);
 
+	//! BOM skipping (https://en.wikipedia.org/wiki/Byte_order_mark)
+	DUCKDB_API static void SkipBOM(const char *buffer_ptr, const idx_t &buffer_size, idx_t &buffer_pos);
+
 	DUCKDB_API static idx_t ToUnsigned(const string &str);
 
 	template <class T>
@@ -3480,6 +3633,9 @@ public:
 
 	//! Case insensitive equals
 	DUCKDB_API static bool CIEquals(const string &l1, const string &l2);
+
+	//! Case insensitive equals (null-terminated strings)
+	DUCKDB_API static bool CIEquals(const char *l1, idx_t l1_size, const char *l2, idx_t l2_size);
 
 	//! Case insensitive compare
 	DUCKDB_API static bool CILessThan(const string &l1, const string &l2);
@@ -3558,18 +3714,22 @@ public:
 	}
 
 	//! JSON method that parses a { string: value } JSON blob
-	//! NOTE: this method ONLY parses a JSON {"key": "value"} object, it does not support ANYTHING else
 	//! NOTE: this method is not efficient
 	//! NOTE: this method is used in Exception construction - as such it does NOT throw on invalid JSON, instead an
 	//! empty map is returned
-	DUCKDB_API static unordered_map<string, string> ParseJSONMap(const string &json);
+	//! Parses complex (i.e., nested) Json maps, it also parses invalid JSONs, as a pure string.
+	DUCKDB_API static unique_ptr<ComplexJSON> ParseJSONMap(const string &json, bool ignore_errors = false);
+
 	//! JSON method that constructs a { string: value } JSON map
 	//! This is the inverse of ParseJSONMap
 	//! NOTE: this method is not efficient
 	DUCKDB_API static string ExceptionToJSONMap(ExceptionType type, const string &message,
 	                                            const unordered_map<string, string> &map);
 
+	//! Transforms an unordered map to a JSON string
 	DUCKDB_API static string ToJSONMap(const unordered_map<string, string> &map);
+	//! Transforms an complex JSON to a JSON string
+	DUCKDB_API static string ToComplexJSONMap(const ComplexJSON &complex_json);
 
 	DUCKDB_API static string GetFileName(const string &file_path);
 	DUCKDB_API static string GetFileExtension(const string &file_name);
@@ -3692,7 +3852,24 @@ struct timestamp_tz_t : public timestamp_t { // NOLINT
 	}
 };
 
-enum class TimestampCastResult : uint8_t { SUCCESS, ERROR_INCORRECT_FORMAT, ERROR_NON_UTC_TIMEZONE, ERROR_RANGE };
+enum class TimestampCastResult : uint8_t {
+	SUCCESS,
+	ERROR_INCORRECT_FORMAT,
+	ERROR_NON_UTC_TIMEZONE,
+	ERROR_RANGE,
+	STRICT_UTC
+};
+
+struct TimestampComponents {
+	int32_t year;
+	int32_t month;
+	int32_t day;
+
+	int32_t hour;
+	int32_t minute;
+	int32_t second;
+	int32_t microsecond;
+};
 
 //! The static Timestamp class holds helper functions for the timestamp types.
 class Timestamp {
@@ -3711,8 +3888,10 @@ public:
 	DUCKDB_API static TimestampCastResult TryConvertTimestampTZ(const char *str, idx_t len, timestamp_t &result,
 	                                                            bool &has_offset, string_t &tz,
 	                                                            optional_ptr<int32_t> nanos = nullptr);
+	//! Strict Timestamp does not accept offsets.
 	DUCKDB_API static TimestampCastResult TryConvertTimestamp(const char *str, idx_t len, timestamp_t &result,
-	                                                          optional_ptr<int32_t> nanos = nullptr);
+	                                                          optional_ptr<int32_t> nanos = nullptr,
+	                                                          bool strict = false);
 	DUCKDB_API static TimestampCastResult TryConvertTimestamp(const char *str, idx_t len, timestamp_ns_t &result);
 	DUCKDB_API static timestamp_t FromCString(const char *str, idx_t len, optional_ptr<int32_t> nanos = nullptr);
 	//! Convert a date object to a string in the format "YYYY-MM-DD hh:mm:ss"
@@ -3778,8 +3957,12 @@ public:
 	//! Convert a timestamp to a Julian Day
 	DUCKDB_API static double GetJulianDay(timestamp_t timestamp);
 
-	DUCKDB_API static bool TryParseUTCOffset(const char *str, idx_t &pos, idx_t len, int &hour_offset,
-	                                         int &minute_offset);
+	//! Decompose a timestamp into its components
+	DUCKDB_API static TimestampComponents GetComponents(timestamp_t timestamp);
+	DUCKDB_API static time_t ToTimeT(timestamp_t);
+	DUCKDB_API static timestamp_t FromTimeT(time_t);
+
+	DUCKDB_API static bool TryParseUTCOffset(const char *str, idx_t &pos, idx_t len, int &hh, int &mm, int &ss);
 
 	DUCKDB_API static string FormatError(const string &str);
 	DUCKDB_API static string FormatError(string_t str);
@@ -3871,6 +4054,198 @@ struct hash<duckdb::timestamp_tz_t> {
 
 
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/datetime.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+#include <functional>
+
+namespace duckdb {
+
+//! Type used to represent time (microseconds)
+struct dtime_t { // NOLINT
+	int64_t micros;
+
+	dtime_t() = default;
+	explicit inline dtime_t(int64_t micros_p) : micros(micros_p) {
+	}
+	inline dtime_t &operator=(int64_t micros_p) {
+		micros = micros_p;
+		return *this;
+	}
+
+	// explicit conversion
+	explicit inline operator int64_t() const {
+		return micros;
+	}
+	explicit inline operator double() const {
+		return static_cast<double>(micros);
+	}
+
+	// comparison operators
+	inline bool operator==(const dtime_t &rhs) const {
+		return micros == rhs.micros;
+	};
+	inline bool operator!=(const dtime_t &rhs) const {
+		return micros != rhs.micros;
+	};
+	inline bool operator<=(const dtime_t &rhs) const {
+		return micros <= rhs.micros;
+	};
+	inline bool operator<(const dtime_t &rhs) const {
+		return micros < rhs.micros;
+	};
+	inline bool operator>(const dtime_t &rhs) const {
+		return micros > rhs.micros;
+	};
+	inline bool operator>=(const dtime_t &rhs) const {
+		return micros >= rhs.micros;
+	};
+
+	// arithmetic operators
+	inline dtime_t operator+(const int64_t &micros) const {
+		return dtime_t(this->micros + micros);
+	};
+	inline dtime_t operator+(const double &micros) const {
+		return dtime_t(this->micros + int64_t(micros));
+	};
+	inline dtime_t operator-(const int64_t &micros) const {
+		return dtime_t(this->micros - micros);
+	};
+	inline dtime_t operator*(const idx_t &copies) const {
+		return dtime_t(this->micros * UnsafeNumericCast<int64_t>(copies));
+	};
+	inline dtime_t operator/(const idx_t &copies) const {
+		return dtime_t(this->micros / UnsafeNumericCast<int64_t>(copies));
+	};
+	inline int64_t operator-(const dtime_t &other) const {
+		return this->micros - other.micros;
+	};
+
+	// in-place operators
+	inline dtime_t &operator+=(const int64_t &micros) {
+		this->micros += micros;
+		return *this;
+	};
+	inline dtime_t &operator-=(const int64_t &micros) {
+		this->micros -= micros;
+		return *this;
+	};
+	inline dtime_t &operator+=(const dtime_t &other) {
+		this->micros += other.micros;
+		return *this;
+	};
+
+	// special values
+	static inline dtime_t allballs() { // NOLINT
+		return dtime_t(0);
+	} // NOLINT
+};
+
+struct dtime_tz_t { // NOLINT
+	static constexpr const int TIME_BITS = 40;
+	static constexpr const int OFFSET_BITS = 24;
+	static constexpr const uint64_t OFFSET_MASK = ~uint64_t(0) >> TIME_BITS;
+	static constexpr const int32_t MAX_OFFSET = 16 * 60 * 60 - 1; // ±15:59:59
+	static constexpr const int32_t MIN_OFFSET = -MAX_OFFSET;
+	static constexpr const uint64_t OFFSET_MICROS = 1000000;
+
+	uint64_t bits;
+
+	//	Offsets are reverse ordered e.g., 13:00:00+01 < 12:00:00+00 < 11:00:00-01
+	//	Because we encode them as the low order bits,
+	//	they are also biased into an unsigned integer: (-16, 16) => (32, 0)
+	static inline uint64_t encode_offset(int32_t offset) { // NOLINT
+		return uint64_t(MAX_OFFSET - offset);
+	}
+	static inline int32_t decode_offset(uint64_t bits) { // NOLINT
+		return MAX_OFFSET - int32_t(bits & OFFSET_MASK);
+	}
+
+	static inline uint64_t encode_micros(int64_t micros) { // NOLINT
+		return encode_micros(UnsafeNumericCast<uint64_t>(micros));
+	}
+	static inline uint64_t encode_micros(uint64_t micros) { // NOLINT
+		return micros << OFFSET_BITS;
+	}
+	static inline int64_t decode_micros(uint64_t bits) { // NOLINT
+		return int64_t(bits >> OFFSET_BITS);
+	}
+
+	dtime_tz_t() = default;
+
+	inline dtime_tz_t(dtime_t t, int32_t offset) : bits(encode_micros(t.micros) | encode_offset(offset)) {
+	}
+	explicit inline dtime_tz_t(uint64_t bits_p) : bits(bits_p) {
+	}
+
+	inline dtime_t time() const { // NOLINT
+		return dtime_t(decode_micros(bits));
+	}
+
+	inline int32_t offset() const { // NOLINT
+		return decode_offset(bits);
+	}
+
+	//	Times are compared after adjusting to offset +00:00:00, e.g., 13:01:00+01 > 12:00:00+00
+	//	Because we encode them as the high order bits,
+	//	they are biased by the maximum offset: (0, 24) => (0, 56)
+	inline uint64_t sort_key() const { // NOLINT
+		return bits + encode_micros((bits & OFFSET_MASK) * OFFSET_MICROS);
+	}
+
+	// comparison operators
+	inline bool operator==(const dtime_tz_t &rhs) const {
+		return bits == rhs.bits;
+	};
+	inline bool operator!=(const dtime_tz_t &rhs) const {
+		return bits != rhs.bits;
+	};
+	inline bool operator<=(const dtime_tz_t &rhs) const {
+		return sort_key() <= rhs.sort_key();
+	};
+	inline bool operator<(const dtime_tz_t &rhs) const {
+		return sort_key() < rhs.sort_key();
+	};
+	inline bool operator>(const dtime_tz_t &rhs) const {
+		return sort_key() > rhs.sort_key();
+	};
+	inline bool operator>=(const dtime_tz_t &rhs) const {
+		return sort_key() >= rhs.sort_key();
+	};
+};
+
+} // namespace duckdb
+
+namespace std {
+
+//! Time
+template <>
+struct hash<duckdb::dtime_t> {
+	std::size_t operator()(const duckdb::dtime_t &k) const {
+		using std::hash;
+		return hash<int64_t>()((int64_t)k);
+	}
+};
+
+template <>
+struct hash<duckdb::dtime_tz_t> {
+	std::size_t operator()(const duckdb::dtime_tz_t &k) const {
+		using std::hash;
+		return hash<uint64_t>()(k.bits);
+	}
+};
+} // namespace std
+
 
 namespace duckdb {
 
@@ -3924,6 +4299,8 @@ template <>
 DUCKDB_API hash_t Hash(string_t val);
 template <>
 DUCKDB_API hash_t Hash(interval_t val);
+template <>
+DUCKDB_API hash_t Hash(dtime_tz_t val);
 DUCKDB_API hash_t Hash(const char *val, size_t size);
 DUCKDB_API hash_t Hash(uint8_t *val, size_t size);
 
@@ -4010,6 +4387,12 @@ public:
 
 	idx_t GetSize() const {
 		return value.inlined.length;
+	}
+
+	void SetSizeAndFinalize(uint32_t size) {
+		value.inlined.length = size;
+		Finalize();
+		VerifyCharacters();
 	}
 
 	bool Empty() const {
@@ -4377,189 +4760,6 @@ struct hash<duckdb::date_t> {
 } // namespace std
 
 
-
-
-
-
-#include <functional>
-
-namespace duckdb {
-
-//! Type used to represent time (microseconds)
-struct dtime_t { // NOLINT
-	int64_t micros;
-
-	dtime_t() = default;
-	explicit inline dtime_t(int64_t micros_p) : micros(micros_p) {
-	}
-	inline dtime_t &operator=(int64_t micros_p) {
-		micros = micros_p;
-		return *this;
-	}
-
-	// explicit conversion
-	explicit inline operator int64_t() const {
-		return micros;
-	}
-	explicit inline operator double() const {
-		return static_cast<double>(micros);
-	}
-
-	// comparison operators
-	inline bool operator==(const dtime_t &rhs) const {
-		return micros == rhs.micros;
-	};
-	inline bool operator!=(const dtime_t &rhs) const {
-		return micros != rhs.micros;
-	};
-	inline bool operator<=(const dtime_t &rhs) const {
-		return micros <= rhs.micros;
-	};
-	inline bool operator<(const dtime_t &rhs) const {
-		return micros < rhs.micros;
-	};
-	inline bool operator>(const dtime_t &rhs) const {
-		return micros > rhs.micros;
-	};
-	inline bool operator>=(const dtime_t &rhs) const {
-		return micros >= rhs.micros;
-	};
-
-	// arithmetic operators
-	inline dtime_t operator+(const int64_t &micros) const {
-		return dtime_t(this->micros + micros);
-	};
-	inline dtime_t operator+(const double &micros) const {
-		return dtime_t(this->micros + int64_t(micros));
-	};
-	inline dtime_t operator-(const int64_t &micros) const {
-		return dtime_t(this->micros - micros);
-	};
-	inline dtime_t operator*(const idx_t &copies) const {
-		return dtime_t(this->micros * UnsafeNumericCast<int64_t>(copies));
-	};
-	inline dtime_t operator/(const idx_t &copies) const {
-		return dtime_t(this->micros / UnsafeNumericCast<int64_t>(copies));
-	};
-	inline int64_t operator-(const dtime_t &other) const {
-		return this->micros - other.micros;
-	};
-
-	// in-place operators
-	inline dtime_t &operator+=(const int64_t &micros) {
-		this->micros += micros;
-		return *this;
-	};
-	inline dtime_t &operator-=(const int64_t &micros) {
-		this->micros -= micros;
-		return *this;
-	};
-	inline dtime_t &operator+=(const dtime_t &other) {
-		this->micros += other.micros;
-		return *this;
-	};
-
-	// special values
-	static inline dtime_t allballs() { // NOLINT
-		return dtime_t(0);
-	} // NOLINT
-};
-
-struct dtime_tz_t { // NOLINT
-	static constexpr const int TIME_BITS = 40;
-	static constexpr const int OFFSET_BITS = 24;
-	static constexpr const uint64_t OFFSET_MASK = ~uint64_t(0) >> TIME_BITS;
-	static constexpr const int32_t MAX_OFFSET = 16 * 60 * 60 - 1; // ±15:59:59
-	static constexpr const int32_t MIN_OFFSET = -MAX_OFFSET;
-	static constexpr const uint64_t OFFSET_MICROS = 1000000;
-
-	uint64_t bits;
-
-	//	Offsets are reverse ordered e.g., 13:00:00+01 < 12:00:00+00 < 11:00:00-01
-	//	Because we encode them as the low order bits,
-	//	they are also biased into an unsigned integer: (-16, 16) => (32, 0)
-	static inline uint64_t encode_offset(int32_t offset) { // NOLINT
-		return uint64_t(MAX_OFFSET - offset);
-	}
-	static inline int32_t decode_offset(uint64_t bits) { // NOLINT
-		return MAX_OFFSET - int32_t(bits & OFFSET_MASK);
-	}
-
-	static inline uint64_t encode_micros(int64_t micros) { // NOLINT
-		return encode_micros(UnsafeNumericCast<uint64_t>(micros));
-	}
-	static inline uint64_t encode_micros(uint64_t micros) { // NOLINT
-		return micros << OFFSET_BITS;
-	}
-	static inline int64_t decode_micros(uint64_t bits) { // NOLINT
-		return int64_t(bits >> OFFSET_BITS);
-	}
-
-	dtime_tz_t() = default;
-
-	inline dtime_tz_t(dtime_t t, int32_t offset) : bits(encode_micros(t.micros) | encode_offset(offset)) {
-	}
-	explicit inline dtime_tz_t(uint64_t bits_p) : bits(bits_p) {
-	}
-
-	inline dtime_t time() const { // NOLINT
-		return dtime_t(decode_micros(bits));
-	}
-
-	inline int32_t offset() const { // NOLINT
-		return decode_offset(bits);
-	}
-
-	//	Times are compared after adjusting to offset +00:00:00, e.g., 13:01:00+01 > 12:00:00+00
-	//	Because we encode them as the high order bits,
-	//	they are biased by the maximum offset: (0, 24) => (0, 56)
-	inline uint64_t sort_key() const { // NOLINT
-		return bits + encode_micros((bits & OFFSET_MASK) * OFFSET_MICROS);
-	}
-
-	// comparison operators
-	inline bool operator==(const dtime_tz_t &rhs) const {
-		return bits == rhs.bits;
-	};
-	inline bool operator!=(const dtime_tz_t &rhs) const {
-		return bits != rhs.bits;
-	};
-	inline bool operator<=(const dtime_tz_t &rhs) const {
-		return sort_key() <= rhs.sort_key();
-	};
-	inline bool operator<(const dtime_tz_t &rhs) const {
-		return sort_key() < rhs.sort_key();
-	};
-	inline bool operator>(const dtime_tz_t &rhs) const {
-		return sort_key() > rhs.sort_key();
-	};
-	inline bool operator>=(const dtime_tz_t &rhs) const {
-		return sort_key() >= rhs.sort_key();
-	};
-};
-
-} // namespace duckdb
-
-namespace std {
-
-//! Time
-template <>
-struct hash<duckdb::dtime_t> {
-	std::size_t operator()(const duckdb::dtime_t &k) const {
-		using std::hash;
-		return hash<int64_t>()((int64_t)k);
-	}
-};
-
-template <>
-struct hash<duckdb::dtime_tz_t> {
-	std::size_t operator()(const duckdb::dtime_tz_t &k) const {
-		using std::hash;
-		return hash<uint64_t>()(k.bits);
-	}
-};
-} // namespace std
-
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -4579,6 +4779,7 @@ struct dtime_t;     // NOLINT: literal casing
 struct date_t;      // NOLINT: literal casing
 struct dtime_tz_t;  // NOLINT: literal casing
 struct timestamp_t; // NOLINT: literal casing
+struct TimestampComponents;
 
 class Serializer;
 class Deserializer;
@@ -4701,13 +4902,16 @@ public:
 	static int64_t GetMilli(const interval_t &val);
 
 	//! Get Interval in microseconds
+	static bool TryGetMicro(const interval_t &val, int64_t &micros);
 	static int64_t GetMicro(const interval_t &val);
 
 	//! Get Interval in Nanoseconds
 	static int64_t GetNanoseconds(const interval_t &val);
 
-	//! Returns the age between two timestamps (including 30 day months)
+	//! Returns the age between two timestamps (including months)
 	static interval_t GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2);
+	//! Returns the age between two timestamp components
+	static interval_t GetAge(TimestampComponents ts1, TimestampComponents ts2, bool is_negative);
 
 	//! Returns the exact difference between two timestamps (days and seconds)
 	static interval_t GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2);
@@ -4792,6 +4996,245 @@ struct hash<duckdb::interval_t> {
 };
 } // namespace std
 
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/insertion_order_preserving_map.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/case_insensitive_map.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/unordered_set.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+#include <unordered_set>
+
+namespace duckdb {
+using std::unordered_set;
+}
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/map.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+#include <map>
+
+namespace duckdb {
+using std::map;
+using std::multimap;
+} // namespace duckdb
+
+
+namespace duckdb {
+
+struct CaseInsensitiveStringHashFunction {
+	uint64_t operator()(const string &str) const {
+		return StringUtil::CIHash(str);
+	}
+};
+
+struct CaseInsensitiveStringEquality {
+	bool operator()(const string &a, const string &b) const {
+		return StringUtil::CIEquals(a, b);
+	}
+};
+
+template <typename T>
+using case_insensitive_map_t =
+    unordered_map<string, T, CaseInsensitiveStringHashFunction, CaseInsensitiveStringEquality>;
+
+using case_insensitive_set_t = unordered_set<string, CaseInsensitiveStringHashFunction, CaseInsensitiveStringEquality>;
+
+struct CaseInsensitiveStringCompare {
+	bool operator()(const string &s1, const string &s2) const {
+		return StringUtil::CILessThan(s1, s2);
+	}
+};
+
+template <typename T>
+using case_insensitive_tree_t = map<string, T, CaseInsensitiveStringCompare>;
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <typename V>
+class InsertionOrderPreservingMap {
+public:
+	typedef vector<pair<string, V>> VECTOR_TYPE; // NOLINT: matching name of std
+	typedef string key_type;                     // NOLINT: matching name of std
+
+public:
+	InsertionOrderPreservingMap() {
+	}
+
+private:
+	VECTOR_TYPE map;
+	case_insensitive_map_t<idx_t> map_idx;
+
+public:
+	vector<string> Keys() const {
+		vector<string> keys;
+		keys.resize(this->size());
+		for (auto &kv : map_idx) {
+			keys[kv.second] = kv.first;
+		}
+
+		return keys;
+	}
+
+	typename VECTOR_TYPE::iterator begin() { // NOLINT: match stl API
+		return map.begin();
+	}
+
+	typename VECTOR_TYPE::iterator end() { // NOLINT: match stl API
+		return map.end();
+	}
+
+	typename VECTOR_TYPE::const_iterator begin() const { // NOLINT: match stl API
+		return map.begin();
+	}
+
+	typename VECTOR_TYPE::const_iterator end() const { // NOLINT: match stl API
+		return map.end();
+	}
+
+	typename VECTOR_TYPE::reverse_iterator rbegin() { // NOLINT: match stl API
+		return map.rbegin();
+	}
+
+	typename VECTOR_TYPE::reverse_iterator rend() { // NOLINT: match stl API
+		return map.rend();
+	}
+
+	typename VECTOR_TYPE::iterator find(const string &key) { // NOLINT: match stl API
+		auto entry = map_idx.find(key);
+		if (entry == map_idx.end()) {
+			return map.end();
+		}
+		return map.begin() + static_cast<typename VECTOR_TYPE::difference_type>(entry->second);
+	}
+
+	typename VECTOR_TYPE::const_iterator find(const string &key) const { // NOLINT: match stl API
+		auto entry = map_idx.find(key);
+		if (entry == map_idx.end()) {
+			return map.end();
+		}
+		return map.begin() + static_cast<typename VECTOR_TYPE::difference_type>(entry->second);
+	}
+
+	idx_t size() const { // NOLINT: match stl API
+		return map_idx.size();
+	}
+
+	bool empty() const { // NOLINT: match stl API
+		return map_idx.empty();
+	}
+
+	void resize(idx_t nz) { // NOLINT: match stl API
+		map.resize(nz);
+	}
+
+	void insert(const string &key, V &&value) { // NOLINT: match stl API
+		if (contains(key)) {
+			return;
+		}
+		map.emplace_back(key, std::move(value));
+		map_idx[key] = map.size() - 1;
+	}
+
+	void insert(const string &key, const V &value) { // NOLINT: match stl API
+		if (contains(key)) {
+			return;
+		}
+		map.emplace_back(key, value);
+		map_idx[key] = map.size() - 1;
+	}
+
+	void insert(pair<string, V> &&value) { // NOLINT: match stl API
+		auto &key = value.first;
+		if (contains(key)) {
+			return;
+		}
+		map_idx[key] = map.size();
+		map.push_back(std::move(value));
+	}
+
+	void erase(typename VECTOR_TYPE::iterator it) { // NOLINT: match stl API
+		auto key = it->first;
+		auto idx = map_idx[key];
+		map.erase(it);
+		map_idx.erase(key);
+		for (auto &kv : map_idx) {
+			if (kv.second > idx) {
+				kv.second--;
+			}
+		}
+	}
+
+	bool contains(const string &key) const { // NOLINT: match stl API
+		return map_idx.find(key) != map_idx.end();
+	}
+
+	const V &at(const string &key) const { // NOLINT: match stl API
+		return map[map_idx.at(key)].second;
+	}
+
+	V &operator[](const string &key) {
+		if (!contains(key)) {
+			auto v = V();
+			insert(key, std::move(v));
+		}
+		return map[map_idx[key]].second;
+	}
+
+	bool operator==(const InsertionOrderPreservingMap &other) const {
+		return map == other.map && map_idx == other.map_idx;
+	}
+
+	bool operator!=(const InsertionOrderPreservingMap &other) const {
+		return !(*this == other);
+	}
+};
+
+} // namespace duckdb
 
 
 namespace duckdb {
@@ -4951,7 +5394,7 @@ public:
 	DUCKDB_API static Value MAP(const LogicalType &key_type, const LogicalType &value_type, vector<Value> keys,
 	                            vector<Value> values);
 	//! Create a map value from a set of key-value pairs
-	DUCKDB_API static Value MAP(const unordered_map<string, string> &kv_pairs);
+	DUCKDB_API static Value MAP(const InsertionOrderPreservingMap<string> &kv_pairs);
 
 	//! Create a union value from a selected value and a tag from a set of alternatives.
 	DUCKDB_API static Value UNION(child_list_t<LogicalType> members, uint8_t tag, Value value);
@@ -4983,9 +5426,6 @@ public:
 	// type of the value. Only use this if you know what you are doing.
 	template <class T>
 	T GetValueUnsafe() const;
-	//! Returns a reference to the internal value. This can only be used for primitive types.
-	template <class T>
-	T &GetReferenceUnsafe();
 
 	//! Return a copy of this value
 	Value Copy() const {
@@ -5458,7 +5898,7 @@ public:
 	//! (optional) comment on this entry
 	Value comment;
 	//! (optional) extra data associated with this entry
-	unordered_map<string, string> tags;
+	InsertionOrderPreservingMap<string> tags;
 
 private:
 	//! Child entry
@@ -5471,6 +5911,7 @@ public:
 	virtual unique_ptr<CatalogEntry> AlterEntry(CatalogTransaction transaction, AlterInfo &info);
 	virtual void UndoAlter(ClientContext &context, AlterInfo &info);
 	virtual void Rollback(CatalogEntry &prev_entry);
+	virtual void OnDrop();
 
 	virtual unique_ptr<CatalogEntry> Copy(ClientContext &context) const;
 
@@ -5695,22 +6136,6 @@ private:
 } // namespace duckdb
 
 
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/map.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-#include <map>
-
-namespace duckdb {
-using std::map;
-using std::multimap;
-} // namespace duckdb
 
 //===----------------------------------------------------------------------===//
 //                         DuckDB
@@ -5746,21 +6171,6 @@ using std::unique_lock;
 
 
 
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/unordered_set.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-#include <unordered_set>
-
-namespace duckdb {
-using std::unordered_set;
-}
 
 
 namespace duckdb {
@@ -5788,6 +6198,60 @@ using reference_set_t = unordered_set<reference<T>, ReferenceHashFunction<T>, Re
 
 } // namespace duckdb
 
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/entry_lookup_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+class BoundAtClause;
+
+struct EntryLookupInfo {
+public:
+	EntryLookupInfo(CatalogType catalog_type, const string &name,
+	                QueryErrorContext error_context = QueryErrorContext());
+	EntryLookupInfo(CatalogType catalog_type, const string &name, optional_ptr<BoundAtClause> at_clause,
+	                QueryErrorContext error_context);
+	EntryLookupInfo(const EntryLookupInfo &parent, const string &name);
+	EntryLookupInfo(const EntryLookupInfo &parent, optional_ptr<BoundAtClause> at_clause);
+
+public:
+	CatalogType GetCatalogType() const;
+	const string &GetEntryName() const;
+	const QueryErrorContext &GetErrorContext() const;
+	const optional_ptr<BoundAtClause> GetAtClause() const;
+
+	static EntryLookupInfo SchemaLookup(const EntryLookupInfo &parent, const string &schema_name);
+
+private:
+	CatalogType catalog_type;
+	const string &name;
+	optional_ptr<BoundAtClause> at_clause;
+	QueryErrorContext error_context;
+};
+
+//! Return value of Catalog::LookupEntry
+struct CatalogEntryLookup {
+	optional_ptr<SchemaCatalogEntry> schema;
+	optional_ptr<CatalogEntry> entry;
+	ErrorData error;
+
+	DUCKDB_API bool Found() const {
+		return entry;
+	}
+};
+
+} // namespace duckdb
 
 
 #include <functional>
@@ -5834,6 +6298,7 @@ struct SimilarCatalogEntry;
 class Binder;
 class LogicalOperator;
 class PhysicalOperator;
+class PhysicalPlanGenerator;
 class LogicalCreateIndex;
 class LogicalCreateTable;
 class LogicalInsert;
@@ -5841,17 +6306,6 @@ class LogicalDelete;
 class LogicalUpdate;
 class CreateStatement;
 class CatalogEntryRetriever;
-
-//! Return value of Catalog::LookupEntry
-struct CatalogEntryLookup {
-	optional_ptr<SchemaCatalogEntry> schema;
-	optional_ptr<CatalogEntry> entry;
-	ErrorData error;
-
-	DUCKDB_API bool Found() const {
-		return entry;
-	}
-};
 
 //! The Catalog object represents the catalog of the database.
 class Catalog {
@@ -5886,6 +6340,8 @@ public:
 		return false;
 	}
 	virtual void Initialize(bool load_builtin) = 0;
+	virtual void Initialize(optional_ptr<ClientContext> context, bool load_builtin);
+	virtual void FinalizeLoad(optional_ptr<ClientContext> context);
 
 	bool IsSystemCatalog() const;
 	bool IsTemporaryCatalog() const;
@@ -5979,63 +6435,65 @@ public:
 	//! Drops an entry from the catalog
 	DUCKDB_API void DropEntry(ClientContext &context, DropInfo &info);
 
+	DUCKDB_API virtual optional_ptr<SchemaCatalogEntry> LookupSchema(CatalogTransaction transaction,
+	                                                                 const EntryLookupInfo &schema_lookup,
+	                                                                 OnEntryNotFound if_not_found) = 0;
+
 	//! Returns the schema object with the specified name, or throws an exception if it does not exist
-	DUCKDB_API SchemaCatalogEntry &GetSchema(ClientContext &context, const string &name,
-	                                         QueryErrorContext error_context = QueryErrorContext());
-	DUCKDB_API optional_ptr<SchemaCatalogEntry> GetSchema(ClientContext &context, const string &name,
-	                                                      OnEntryNotFound if_not_found,
-	                                                      QueryErrorContext error_context = QueryErrorContext());
+	DUCKDB_API SchemaCatalogEntry &GetSchema(ClientContext &context, const EntryLookupInfo &schema_lookup);
+	DUCKDB_API optional_ptr<SchemaCatalogEntry> GetSchema(ClientContext &context, const EntryLookupInfo &schema_lookup,
+	                                                      OnEntryNotFound if_not_found);
 	//! Overloadable method for giving warnings on ambiguous naming id.tab due to a database and schema with name id
-	DUCKDB_API virtual bool CheckAmbiguousCatalogOrSchema(ClientContext &context, const string &name) {
-		return !!GetSchema(context, name, OnEntryNotFound::RETURN_NULL);
-	}
-	DUCKDB_API SchemaCatalogEntry &GetSchema(CatalogTransaction transaction, const string &name,
-	                                         QueryErrorContext error_context = QueryErrorContext());
-	DUCKDB_API virtual optional_ptr<SchemaCatalogEntry>
-	GetSchema(CatalogTransaction transaction, const string &schema_name, OnEntryNotFound if_not_found,
-	          QueryErrorContext error_context = QueryErrorContext()) = 0;
+	DUCKDB_API virtual bool CheckAmbiguousCatalogOrSchema(ClientContext &context, const string &schema);
+
+	DUCKDB_API SchemaCatalogEntry &GetSchema(ClientContext &context, const string &schema);
+	DUCKDB_API SchemaCatalogEntry &GetSchema(CatalogTransaction transaction, const string &schema);
+	DUCKDB_API SchemaCatalogEntry &GetSchema(CatalogTransaction transaction, const EntryLookupInfo &schema_lookup);
 	DUCKDB_API static SchemaCatalogEntry &GetSchema(ClientContext &context, const string &catalog_name,
-	                                                const string &schema_name,
-	                                                QueryErrorContext error_context = QueryErrorContext());
+	                                                const EntryLookupInfo &schema_lookup);
+	DUCKDB_API optional_ptr<SchemaCatalogEntry> GetSchema(ClientContext &context, const string &schema,
+	                                                      OnEntryNotFound if_not_found);
+	DUCKDB_API optional_ptr<SchemaCatalogEntry> GetSchema(CatalogTransaction transaction, const string &schema,
+	                                                      OnEntryNotFound if_not_found);
 	DUCKDB_API static optional_ptr<SchemaCatalogEntry> GetSchema(ClientContext &context, const string &catalog_name,
-	                                                             const string &schema_name,
-	                                                             OnEntryNotFound if_not_found,
-	                                                             QueryErrorContext error_context = QueryErrorContext());
+	                                                             const EntryLookupInfo &schema_lookup,
+	                                                             OnEntryNotFound if_not_found);
+	DUCKDB_API static SchemaCatalogEntry &GetSchema(ClientContext &context, const string &catalog_name,
+	                                                const string &schema);
+	DUCKDB_API static optional_ptr<SchemaCatalogEntry> GetSchema(ClientContext &context, const string &catalog_name,
+	                                                             const string &schema, OnEntryNotFound if_not_found);
 	DUCKDB_API static optional_ptr<SchemaCatalogEntry> GetSchema(CatalogEntryRetriever &retriever,
-	                                                             const string &catalog_name, const string &schema_name,
-	                                                             OnEntryNotFound if_not_found,
-	                                                             QueryErrorContext error_context = QueryErrorContext());
+	                                                             const string &catalog_name,
+	                                                             const EntryLookupInfo &schema_lookup,
+	                                                             OnEntryNotFound if_not_found);
 	//! Scans all the schemas in the system one-by-one, invoking the callback for each entry
 	DUCKDB_API virtual void ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) = 0;
 
 	//! Gets the "schema.name" entry of the specified type, if entry does not exist behavior depends on OnEntryNotFound
-	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(ClientContext &context, CatalogType type, const string &schema,
-	                                               const string &name, OnEntryNotFound if_not_found,
-	                                               QueryErrorContext error_context = QueryErrorContext());
-	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(CatalogEntryRetriever &retriever, CatalogType type,
+	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &schema,
+	                                               const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
+	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(ClientContext &context, CatalogType catalog_type,
 	                                               const string &schema, const string &name,
-	                                               OnEntryNotFound if_not_found,
-	                                               QueryErrorContext error_context = QueryErrorContext());
-	DUCKDB_API CatalogEntry &GetEntry(ClientContext &context, CatalogType type, const string &schema,
-	                                  const string &name, QueryErrorContext error_context = QueryErrorContext());
+	                                               OnEntryNotFound if_not_found);
+	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(CatalogEntryRetriever &retriever, const string &schema,
+	                                               const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
+	DUCKDB_API CatalogEntry &GetEntry(ClientContext &context, const string &schema, const EntryLookupInfo &lookup_info);
 	//! Gets the "catalog.schema.name" entry of the specified type, if entry does not exist behavior depends on
 	//! OnEntryNotFound
-	DUCKDB_API static optional_ptr<CatalogEntry> GetEntry(ClientContext &context, CatalogType type,
-	                                                      const string &catalog, const string &schema,
-	                                                      const string &name, OnEntryNotFound if_not_found,
-	                                                      QueryErrorContext error_context = QueryErrorContext());
-	DUCKDB_API static optional_ptr<CatalogEntry> GetEntry(CatalogEntryRetriever &retriever, CatalogType type,
-	                                                      const string &catalog, const string &schema,
-	                                                      const string &name, OnEntryNotFound if_not_found,
-	                                                      QueryErrorContext error_context = QueryErrorContext());
-	DUCKDB_API static CatalogEntry &GetEntry(ClientContext &context, CatalogType type, const string &catalog,
-	                                         const string &schema, const string &name,
-	                                         QueryErrorContext error_context = QueryErrorContext());
+	DUCKDB_API static optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &catalog,
+	                                                      const string &schema, const EntryLookupInfo &lookup_info,
+	                                                      OnEntryNotFound if_not_found);
+	DUCKDB_API static optional_ptr<CatalogEntry> GetEntry(CatalogEntryRetriever &retriever, const string &catalog,
+	                                                      const string &schema, const EntryLookupInfo &lookup_info,
+	                                                      OnEntryNotFound if_not_found);
+	DUCKDB_API static CatalogEntry &GetEntry(ClientContext &context, const string &catalog, const string &schema,
+	                                         const EntryLookupInfo &lookup_info);
 
 	template <class T>
 	optional_ptr<T> GetEntry(ClientContext &context, const string &schema_name, const string &name,
 	                         OnEntryNotFound if_not_found, QueryErrorContext error_context = QueryErrorContext()) {
-		auto entry = GetEntry(context, T::Type, schema_name, name, if_not_found, error_context);
+		EntryLookupInfo lookup_info(T::Type, name, error_context);
+		auto entry = GetEntry(context, schema_name, lookup_info, if_not_found);
 		if (!entry) {
 			return nullptr;
 		}
@@ -6044,12 +6502,18 @@ public:
 		}
 		return &entry->template Cast<T>();
 	}
+
 	template <class T>
 	T &GetEntry(ClientContext &context, const string &schema_name, const string &name,
 	            QueryErrorContext error_context = QueryErrorContext()) {
 		auto entry = GetEntry<T>(context, schema_name, name, OnEntryNotFound::THROW_EXCEPTION, error_context);
 		return *entry;
 	}
+
+	static CatalogEntry &GetEntry(ClientContext &context, CatalogType catalog_type, const string &catalog_name,
+	                              const string &schema_name, const string &name);
+	CatalogEntry &GetEntry(ClientContext &context, CatalogType catalog_type, const string &schema_name,
+	                       const string &name);
 
 	//! Append a scalar or aggregate function to the catalog
 	DUCKDB_API optional_ptr<CatalogEntry> AddFunction(ClientContext &context, CreateFunctionInfo &info);
@@ -6058,14 +6522,16 @@ public:
 	DUCKDB_API void Alter(CatalogTransaction transaction, AlterInfo &info);
 	DUCKDB_API void Alter(ClientContext &context, AlterInfo &info);
 
-	virtual unique_ptr<PhysicalOperator> PlanCreateTableAs(ClientContext &context, LogicalCreateTable &op,
-	                                                       unique_ptr<PhysicalOperator> plan) = 0;
-	virtual unique_ptr<PhysicalOperator> PlanInsert(ClientContext &context, LogicalInsert &op,
-	                                                unique_ptr<PhysicalOperator> plan) = 0;
-	virtual unique_ptr<PhysicalOperator> PlanDelete(ClientContext &context, LogicalDelete &op,
-	                                                unique_ptr<PhysicalOperator> plan) = 0;
-	virtual unique_ptr<PhysicalOperator> PlanUpdate(ClientContext &context, LogicalUpdate &op,
-	                                                unique_ptr<PhysicalOperator> plan) = 0;
+	virtual PhysicalOperator &PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner,
+	                                            LogicalCreateTable &op, PhysicalOperator &plan) = 0;
+	virtual PhysicalOperator &PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
+	                                     optional_ptr<PhysicalOperator> plan) = 0;
+	virtual PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
+	                                     PhysicalOperator &plan) = 0;
+	virtual PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op);
+	virtual PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
+	                                     PhysicalOperator &plan) = 0;
+	virtual PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op);
 	virtual unique_ptr<LogicalOperator> BindCreateIndex(Binder &binder, CreateStatement &stmt, TableCatalogEntry &table,
 	                                                    unique_ptr<LogicalOperator> plan);
 	virtual unique_ptr<LogicalOperator> BindAlterAddIndex(Binder &binder, TableCatalogEntry &table_entry,
@@ -6078,6 +6544,9 @@ public:
 
 	virtual bool InMemory() = 0;
 	virtual string GetDBPath() = 0;
+	virtual bool SupportsTimeTravel() const {
+		return false;
+	}
 
 	//! Whether or not this catalog should search a specific type with the standard priority
 	DUCKDB_API virtual CatalogLookupBehavior CatalogTypeLookupRule(CatalogType type) const {
@@ -6102,7 +6571,8 @@ public:
 	static optional_ptr<T> GetEntry(ClientContext &context, const string &catalog_name, const string &schema_name,
 	                                const string &name, OnEntryNotFound if_not_found,
 	                                QueryErrorContext error_context = QueryErrorContext()) {
-		auto entry = GetEntry(context, T::Type, catalog_name, schema_name, name, if_not_found, error_context);
+		EntryLookupInfo lookup_info(T::Type, name, error_context);
+		auto entry = GetEntry(context, catalog_name, schema_name, lookup_info, if_not_found);
 		if (!entry) {
 			return nullptr;
 		}
@@ -6136,6 +6606,9 @@ public:
 	static bool AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType type, const string &entry_name);
 	DUCKDB_API static bool TryAutoLoad(ClientContext &context, const string &extension_name) noexcept;
 
+	//! Called when the catalog is detached
+	DUCKDB_API virtual void OnDetach(ClientContext &context);
+
 protected:
 	//! Reference to the database
 	AttachedDatabase &db;
@@ -6146,40 +6619,36 @@ protected:
 
 public:
 	//! Lookup an entry using TryLookupEntry, throws if entry not found and if_not_found == THROW_EXCEPTION
-	CatalogEntryLookup LookupEntry(CatalogEntryRetriever &retriever, CatalogType type, const string &schema,
-	                               const string &name, OnEntryNotFound if_not_found,
-	                               QueryErrorContext error_context = QueryErrorContext());
+	CatalogEntryLookup LookupEntry(CatalogEntryRetriever &retriever, const string &schema,
+	                               const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
 
 private:
 	//! Lookup an entry in the schema, returning a lookup with the entry and schema if they exist
-	CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction, CatalogType type, const string &schema,
-	                                          const string &name);
+	CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction, const string &schema,
+	                                          const EntryLookupInfo &lookup_info);
 	//! Calls LookupEntryInternal on the schema, trying other schemas if the schema is invalid. Sets
 	//! CatalogEntryLookup->error depending on if_not_found when no entry is found
-	CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, CatalogType type, const string &schema,
-	                                  const string &name, OnEntryNotFound if_not_found,
-	                                  QueryErrorContext error_context = QueryErrorContext());
-	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, vector<CatalogLookup> &lookups,
-	                                         CatalogType type, const string &name, OnEntryNotFound if_not_found,
-	                                         QueryErrorContext error_context = QueryErrorContext());
-	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, CatalogType type, const string &catalog,
-	                                         const string &schema, const string &name, OnEntryNotFound if_not_found,
-	                                         QueryErrorContext error_context);
+	CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const string &schema,
+	                                  const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
+	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const vector<CatalogLookup> &lookups,
+	                                         const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
+	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
+	                                         const string &schema, const EntryLookupInfo &lookup_info,
+	                                         OnEntryNotFound if_not_found);
 
 	//! Looks for a Catalog with a DefaultTable that matches the lookup
-	static CatalogEntryLookup TryLookupDefaultTable(CatalogEntryRetriever &retriever, CatalogType type,
-	                                                const string &catalog, const string &schema, const string &name,
-	                                                OnEntryNotFound if_not_found, QueryErrorContext error_context);
+	static CatalogEntryLookup TryLookupDefaultTable(CatalogEntryRetriever &retriever, const string &catalog,
+	                                                const string &schema, const EntryLookupInfo &lookup_info,
+	                                                OnEntryNotFound if_not_found);
 
 	//! Return an exception with did-you-mean suggestion.
-	static CatalogException CreateMissingEntryException(CatalogEntryRetriever &retriever, const string &entry_name,
-	                                                    CatalogType type,
-	                                                    const reference_set_t<SchemaCatalogEntry> &schemas,
-	                                                    QueryErrorContext error_context);
+	static CatalogException CreateMissingEntryException(CatalogEntryRetriever &retriever,
+	                                                    const EntryLookupInfo &lookup_info,
+	                                                    const reference_set_t<SchemaCatalogEntry> &schemas);
 
 	//! Return the close entry name, the distance and the belonging schema.
-	static vector<SimilarCatalogEntry> SimilarEntriesInSchemas(ClientContext &context, const string &entry_name,
-	                                                           CatalogType type,
+	static vector<SimilarCatalogEntry> SimilarEntriesInSchemas(ClientContext &context,
+	                                                           const EntryLookupInfo &lookup_info,
 	                                                           const reference_set_t<SchemaCatalogEntry> &schemas);
 
 	virtual void DropSchema(ClientContext &context, DropInfo &info) = 0;
@@ -6294,11 +6763,12 @@ enum class DebugInitialize : uint8_t { NO_INITIALIZE = 0, DEBUG_ZERO_INITIALIZE 
 
 namespace duckdb {
 class Allocator;
+class BlockManager;
 struct FileHandle;
 
-enum class FileBufferType : uint8_t { BLOCK = 1, MANAGED_BUFFER = 2, TINY_BUFFER = 3 };
+enum class FileBufferType : uint8_t { BLOCK = 1, MANAGED_BUFFER = 2, TINY_BUFFER = 3, EXTERNAL_FILE = 4 };
 
-static constexpr idx_t FILE_BUFFER_TYPE_COUNT = 3;
+static constexpr idx_t FILE_BUFFER_TYPE_COUNT = 4;
 
 //! The FileBuffer represents a buffer that can be read or written to a Direct IO FileHandle.
 class FileBuffer {
@@ -6307,7 +6777,8 @@ public:
 	//! (typically 8 bytes). On return, this->AllocSize() >= this->size >= user_size.
 	//! Our allocation size will always be page-aligned, which is necessary to support
 	//! DIRECT_IO
-	FileBuffer(Allocator &allocator, FileBufferType type, uint64_t user_size);
+	FileBuffer(Allocator &allocator, FileBufferType type, uint64_t user_size, idx_t block_header_size);
+	FileBuffer(Allocator &allocator, FileBufferType type, BlockManager &block_manager);
 	FileBuffer(FileBuffer &source, FileBufferType type);
 
 	virtual ~FileBuffer();
@@ -6316,7 +6787,7 @@ public:
 	//! The buffer that users can write to
 	data_ptr_t buffer;
 	//! The user-facing size of the buffer.
-	//! This is equivalent to internal_size - BLOCK_HEADER_SIZE.
+	//! This is equivalent to internal_size - block_header_size.
 	uint64_t size;
 
 public:
@@ -6333,7 +6804,9 @@ public:
 
 	// Same rules as the constructor. We add room for a header, in addition to
 	// the requested user bytes. We then sector-align the result.
-	void Resize(uint64_t user_size);
+	void ResizeInternal(uint64_t user_size, uint64_t block_header_size);
+	void Resize(uint64_t user_size, BlockManager &block_manager);
+	void Resize(BlockManager &block_manager);
 
 	uint64_t AllocSize() const {
 		return internal_size;
@@ -6350,7 +6823,7 @@ public:
 		idx_t header_size;
 	};
 
-	MemoryRequirement CalculateMemory(uint64_t user_size);
+	MemoryRequirement CalculateMemory(uint64_t user_size, uint64_t block_header_size) const;
 	void Initialize(DebugInitialize info);
 
 protected:
@@ -6546,6 +7019,43 @@ public:
 
 } // namespace duckdb
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/open_file_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct ExtendedOpenFileInfo {
+	unordered_map<string, Value> options;
+};
+
+struct OpenFileInfo {
+	OpenFileInfo() = default;
+	OpenFileInfo(string path_p) // NOLINT: allow implicit conversion from string
+	    : path(std::move(path_p)) {
+	}
+
+	string path;
+	shared_ptr<ExtendedOpenFileInfo> extended_info;
+
+public:
+	bool operator<(const OpenFileInfo &rhs) const {
+		return path < rhs.path;
+	}
+};
+
+} // namespace duckdb
+
 #include <functional>
 
 #undef CreateDirectory
@@ -6558,6 +7068,8 @@ class ClientContext;
 class DatabaseInstance;
 class FileOpener;
 class FileSystem;
+class FileHandleLogger;
+class Logger;
 
 enum class FileType {
 	//! Regular file
@@ -6584,8 +7096,12 @@ public:
 	FileHandle(const FileHandle &) = delete;
 	DUCKDB_API virtual ~FileHandle();
 
+	// Read at [nr_bytes] bytes into [buffer], and return the bytes actually read.
+	// File offset will be changed, which advances for number of bytes read.
 	DUCKDB_API int64_t Read(void *buffer, idx_t nr_bytes);
 	DUCKDB_API int64_t Write(void *buffer, idx_t nr_bytes);
+	// Read at [nr_bytes] bytes into [buffer].
+	// File offset will not be changed.
 	DUCKDB_API void Read(void *buffer, idx_t nr_bytes, idx_t location);
 	DUCKDB_API void Write(void *buffer, idx_t nr_bytes, idx_t location);
 	DUCKDB_API void Seek(idx_t location);
@@ -6603,6 +7119,8 @@ public:
 	DUCKDB_API bool OnDiskFile();
 	DUCKDB_API idx_t GetFileSize();
 	DUCKDB_API FileType GetType();
+
+	DUCKDB_API void TryAddLogger(FileOpener &opener);
 
 	//! Closes the file handle.
 	DUCKDB_API virtual void Close() = 0;
@@ -6630,6 +7148,8 @@ public:
 	FileSystem &file_system;
 	string path;
 	FileOpenFlags flags;
+
+	shared_ptr<Logger> logger;
 };
 
 class FileSystem {
@@ -6643,6 +7163,8 @@ public:
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                                   optional_ptr<FileOpener> opener = nullptr);
+	DUCKDB_API unique_ptr<FileHandle> OpenFile(const OpenFileInfo &path, FileOpenFlags flags,
+	                                           optional_ptr<FileOpener> opener = nullptr);
 
 	//! Read exactly nr_bytes from the specified location in the file. Fails if nr_bytes could not be read. This is
 	//! equivalent to calling SetFilePointer(location) followed by calling Read().
@@ -6663,6 +7185,9 @@ public:
 	DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
 	//! Returns the file last modified time of a file handle, returns timespec with zero on all attributes on error
 	DUCKDB_API virtual time_t GetLastModifiedTime(FileHandle &handle);
+	//! Returns a tag that uniquely identifies the version of the file,
+	//! used for checking cache invalidation for CachingFileSystem httpfs files
+	DUCKDB_API virtual string GetVersionTag(FileHandle &handle);
 	//! Returns the file type of the attached handle
 	DUCKDB_API virtual FileType GetFileType(FileHandle &handle);
 	//! Truncate a file to a maximum size of new_size, new_size should be smaller than or equal to the current size of
@@ -6673,6 +7198,8 @@ public:
 	DUCKDB_API virtual bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener = nullptr);
 	//! Create a directory if it does not exist
 	DUCKDB_API virtual void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr);
+	//! Helper function that uses DirectoryExists and CreateDirectory to ensure all directories in path are created
+	DUCKDB_API virtual void CreateDirectoriesRecursive(const string &path, optional_ptr<FileOpener> opener = nullptr);
 	//! Recursively remove a directory and all files in it
 	DUCKDB_API virtual void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr);
 
@@ -6680,6 +7207,8 @@ public:
 	DUCKDB_API virtual bool ListFiles(const string &directory,
 	                                  const std::function<void(const string &, bool)> &callback,
 	                                  FileOpener *opener = nullptr);
+	DUCKDB_API bool ListFiles(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+	                          optional_ptr<FileOpener> opener = nullptr);
 
 	//! Move a file from source path to the target, StorageManager relies on this being an atomic action for ACID
 	//! properties
@@ -6691,6 +7220,8 @@ public:
 	DUCKDB_API virtual bool IsPipe(const string &filename, optional_ptr<FileOpener> opener = nullptr);
 	//! Remove a file from disk
 	DUCKDB_API virtual void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
+	//! Remvoe a file from disk if it exists - if it does not exist, return false
+	DUCKDB_API virtual bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
 	//! Sync a file handle to disk
 	DUCKDB_API virtual void FileSync(FileHandle &handle);
 	//! Sets the working directory
@@ -6731,9 +7262,9 @@ public:
 	//! Whether there is a glob in the string
 	DUCKDB_API static bool HasGlob(const string &str);
 	//! Runs a glob on the file system, returning a list of matching files
-	DUCKDB_API virtual vector<string> Glob(const string &path, FileOpener *opener = nullptr);
-	DUCKDB_API vector<string> GlobFiles(const string &path, ClientContext &context,
-	                                    FileGlobOptions options = FileGlobOptions::DISALLOW_EMPTY);
+	DUCKDB_API virtual vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr);
+	DUCKDB_API vector<OpenFileInfo> GlobFiles(const string &path, ClientContext &context,
+	                                          FileGlobOptions options = FileGlobOptions::DISALLOW_EMPTY);
 
 	//! registers a sub-file system to handle certain file name prefixes, e.g. http:// etc.
 	DUCKDB_API virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs);
@@ -6741,6 +7272,10 @@ public:
 
 	//! Unregister a sub-filesystem by name
 	DUCKDB_API virtual void UnregisterSubSystem(const string &name);
+
+	// !Extract a sub-filesystem by name, with ownership transfered, return nullptr if not registered or the subsystem
+	// has been disabled.
+	DUCKDB_API virtual unique_ptr<FileSystem> ExtractSubSystem(const string &name);
 
 	//! List registered sub-filesystems, including builtin ones
 	DUCKDB_API virtual vector<string> ListSubSystems();
@@ -6775,6 +7310,18 @@ public:
 	DUCKDB_API static bool IsRemoteFile(const string &path, string &extension);
 
 	DUCKDB_API virtual void SetDisabledFileSystems(const vector<string> &names);
+
+	DUCKDB_API static bool IsDirectory(const OpenFileInfo &info);
+
+protected:
+	DUCKDB_API virtual unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,
+	                                                           optional_ptr<FileOpener> opener);
+	DUCKDB_API virtual bool SupportsOpenFileExtended() const;
+
+	DUCKDB_API virtual bool ListFilesExtended(const string &directory,
+	                                          const std::function<void(OpenFileInfo &info)> &callback,
+	                                          optional_ptr<FileOpener> opener);
+	DUCKDB_API virtual bool SupportsListFilesExtended() const;
 
 public:
 	template <class TARGET>
@@ -6925,6 +7472,177 @@ string VectorTypeToString(VectorType type);
 
 
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/allocator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+class Allocator;
+class AttachedDatabase;
+class ClientContext;
+class DatabaseInstance;
+class ExecutionContext;
+class ThreadContext;
+
+struct AllocatorDebugInfo;
+
+enum class AllocatorFreeType { REQUIRES_FREE, DOES_NOT_REQUIRE_FREE };
+
+struct PrivateAllocatorData {
+	PrivateAllocatorData();
+	virtual ~PrivateAllocatorData();
+
+	AllocatorFreeType free_type = AllocatorFreeType::REQUIRES_FREE;
+	unique_ptr<AllocatorDebugInfo> debug_info;
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+typedef data_ptr_t (*allocate_function_ptr_t)(PrivateAllocatorData *private_data, idx_t size);
+typedef void (*free_function_ptr_t)(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);
+typedef data_ptr_t (*reallocate_function_ptr_t)(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t old_size,
+                                                idx_t size);
+
+class AllocatedData {
+public:
+	DUCKDB_API AllocatedData();
+	DUCKDB_API AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size);
+	DUCKDB_API ~AllocatedData();
+	// disable copy constructors
+	AllocatedData(const AllocatedData &other) = delete;
+	AllocatedData &operator=(const AllocatedData &) = delete;
+	//! enable move constructors
+	DUCKDB_API AllocatedData(AllocatedData &&other) noexcept;
+	DUCKDB_API AllocatedData &operator=(AllocatedData &&) noexcept;
+
+	data_ptr_t get() { // NOLINT: matching std style
+		return pointer;
+	}
+	operator bool() const { // NOLINT: missing explicit
+		return pointer != nullptr;
+	}
+	const_data_ptr_t get() const { // NOLINT: matching std style
+		return pointer;
+	}
+	idx_t GetSize() const {
+		return allocated_size;
+	}
+	bool IsSet() {
+		return pointer;
+	}
+	void Reset();
+
+private:
+	optional_ptr<Allocator> allocator;
+	data_ptr_t pointer;
+	idx_t allocated_size;
+};
+
+class Allocator {
+	// 281TB ought to be enough for anybody
+	static constexpr const idx_t MAXIMUM_ALLOC_SIZE = 281474976710656ULL;
+
+public:
+	DUCKDB_API Allocator();
+	DUCKDB_API Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
+	                     reallocate_function_ptr_t reallocate_function_p,
+	                     unique_ptr<PrivateAllocatorData> private_data);
+	Allocator &operator=(Allocator &&allocator) noexcept = delete;
+	DUCKDB_API ~Allocator();
+
+	DUCKDB_API data_ptr_t AllocateData(idx_t size);
+	DUCKDB_API void FreeData(data_ptr_t pointer, idx_t size);
+	DUCKDB_API data_ptr_t ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t new_size);
+
+	AllocatedData Allocate(idx_t size) {
+		return AllocatedData(*this, AllocateData(size), size);
+	}
+	static data_ptr_t DefaultAllocate(PrivateAllocatorData *private_data, idx_t size);
+	static void DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);
+	static data_ptr_t DefaultReallocate(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t old_size,
+	                                    idx_t size);
+	static Allocator &Get(ClientContext &context);
+	static Allocator &Get(DatabaseInstance &db);
+	static Allocator &Get(AttachedDatabase &db);
+
+	PrivateAllocatorData *GetPrivateData() {
+		return private_data.get();
+	}
+
+	DUCKDB_API static Allocator &DefaultAllocator();
+	DUCKDB_API static shared_ptr<Allocator> &DefaultAllocatorReference();
+
+	static bool SupportsFlush();
+	static optional_idx DecayDelay();
+	static void ThreadFlush(bool allocator_background_threads, idx_t threshold, idx_t thread_count);
+	static void ThreadIdle();
+	static void FlushAll();
+	static void SetBackgroundThreads(bool enable);
+
+private:
+	allocate_function_ptr_t allocate_function;
+	free_function_ptr_t free_function;
+	reallocate_function_ptr_t reallocate_function;
+
+	unique_ptr<PrivateAllocatorData> private_data;
+};
+
+template <class T>
+T *AllocateArray(idx_t size) {
+	return (T *)Allocator::DefaultAllocator().AllocateData(size * sizeof(T));
+}
+
+template <class T>
+void DeleteArray(T *ptr, idx_t size) {
+	Allocator::DefaultAllocator().FreeData(data_ptr_cast(ptr), size * sizeof(T));
+}
+
+template <typename T, typename... ARGS>
+T *AllocateObject(ARGS &&... args) {
+	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
+	return new (data) T(std::forward<ARGS>(args)...);
+}
+
+template <typename T>
+void DestroyObject(T *ptr) {
+	ptr->~T();
+	Allocator::DefaultAllocator().FreeData(data_ptr_cast(ptr), sizeof(T));
+}
+
+//! The BufferAllocator is a wrapper around the global allocator class that sends any allocations made through the
+//! buffer manager. This makes the buffer manager aware of the memory usage, allowing it to potentially free
+//! other blocks to make space in memory.
+//! Note that there is a cost to doing so (several atomic operations will be performed on allocation/free).
+//! As such this class should be used primarily for larger allocations.
+struct BufferAllocator {
+	DUCKDB_API static Allocator &Get(ClientContext &context);
+	DUCKDB_API static Allocator &Get(DatabaseInstance &db);
+	DUCKDB_API static Allocator &Get(AttachedDatabase &db);
+};
+
+} // namespace duckdb
+
 
 
 
@@ -6963,7 +7681,7 @@ class VectorBuffer;
 struct SelectionData {
 	DUCKDB_API explicit SelectionData(idx_t count);
 
-	unsafe_unique_array<sel_t> owned_data;
+	AllocatedData owned_data;
 };
 
 struct SelectionVector {
@@ -7016,11 +7734,11 @@ public:
 	}
 	void Initialize(idx_t count = STANDARD_VECTOR_SIZE) {
 		selection_data = make_shared_ptr<SelectionData>(count);
-		sel_vector = selection_data->owned_data.get();
+		sel_vector = reinterpret_cast<sel_t *>(selection_data->owned_data.get());
 	}
 	void Initialize(buffer_ptr<SelectionData> data) {
 		selection_data = std::move(data);
-		sel_vector = selection_data->owned_data.get();
+		sel_vector = reinterpret_cast<sel_t *>(selection_data->owned_data.get());
 	}
 	void Initialize(const SelectionVector &other) {
 		selection_data = other.selection_data;
@@ -7059,6 +7777,7 @@ public:
 		return sel_vector;
 	}
 	void Verify(idx_t count, idx_t vector_size) const;
+	void Sort(idx_t count);
 
 private:
 	sel_t *sel_vector;
@@ -7236,7 +7955,7 @@ struct TemplatedValidityMask {
 public:
 	static constexpr const idx_t BITS_PER_VALUE = ValidityBuffer::BITS_PER_VALUE;
 	static constexpr const idx_t STANDARD_ENTRY_COUNT = (STANDARD_VECTOR_SIZE + (BITS_PER_VALUE - 1)) / BITS_PER_VALUE;
-	static constexpr const idx_t STANDARD_MASK_SIZE = STANDARD_ENTRY_COUNT * sizeof(validity_t);
+	static constexpr const idx_t STANDARD_MASK_SIZE = STANDARD_ENTRY_COUNT * sizeof(V);
 
 public:
 	inline TemplatedValidityMask() : validity_mask(nullptr), capacity(STANDARD_VECTOR_SIZE) {
@@ -7285,16 +8004,11 @@ public:
 			auto entry = GetValidityEntry(entry_idx++);
 			// Handle ragged end (if not exactly multiple of BITS_PER_VALUE)
 			if (entry_idx == entry_count && count % BITS_PER_VALUE != 0) {
-				idx_t idx_in_entry;
-				GetEntryIndex(count, entry_idx, idx_in_entry);
-				for (idx_t i = 0; i < idx_in_entry; ++i) {
-					valid += idx_t(RowIsValid(entry, i));
-				}
-				break;
-			}
-
-			// Handle all set
-			if (AllValid(entry)) {
+				const auto shift = BITS_PER_VALUE - (count % BITS_PER_VALUE);
+				const auto mask = ValidityBuffer::MAX_ENTRY >> shift;
+				entry &= mask;
+			} else if (AllValid(entry)) {
+				// Handle all set
 				valid += BITS_PER_VALUE;
 				continue;
 			}
@@ -7361,7 +8075,7 @@ public:
 		D_ASSERT(validity_mask);
 		idx_t entry_idx, idx_in_entry;
 		GetEntryIndex(row_idx, entry_idx, idx_in_entry);
-		auto entry = GetValidityEntry(entry_idx);
+		auto entry = GetValidityEntryUnsafe(entry_idx);
 		return RowIsValid(entry, idx_in_entry);
 	}
 
@@ -7691,176 +8405,6 @@ private:
 
 
 
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/allocator.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-
-
-namespace duckdb {
-class Allocator;
-class AttachedDatabase;
-class ClientContext;
-class DatabaseInstance;
-class ExecutionContext;
-class ThreadContext;
-
-struct AllocatorDebugInfo;
-
-enum class AllocatorFreeType { REQUIRES_FREE, DOES_NOT_REQUIRE_FREE };
-
-struct PrivateAllocatorData {
-	PrivateAllocatorData();
-	virtual ~PrivateAllocatorData();
-
-	AllocatorFreeType free_type = AllocatorFreeType::REQUIRES_FREE;
-	unique_ptr<AllocatorDebugInfo> debug_info;
-
-	template <class TARGET>
-	TARGET &Cast() {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<TARGET &>(*this);
-	}
-	template <class TARGET>
-	const TARGET &Cast() const {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-};
-
-typedef data_ptr_t (*allocate_function_ptr_t)(PrivateAllocatorData *private_data, idx_t size);
-typedef void (*free_function_ptr_t)(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);
-typedef data_ptr_t (*reallocate_function_ptr_t)(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t old_size,
-                                                idx_t size);
-
-class AllocatedData {
-public:
-	DUCKDB_API AllocatedData();
-	DUCKDB_API AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size);
-	DUCKDB_API ~AllocatedData();
-	// disable copy constructors
-	AllocatedData(const AllocatedData &other) = delete;
-	AllocatedData &operator=(const AllocatedData &) = delete;
-	//! enable move constructors
-	DUCKDB_API AllocatedData(AllocatedData &&other) noexcept;
-	DUCKDB_API AllocatedData &operator=(AllocatedData &&) noexcept;
-
-	data_ptr_t get() { // NOLINT: matching std style
-		return pointer;
-	}
-	operator bool() const { // NOLINT: missing explicit
-		return pointer != nullptr;
-	}
-	const_data_ptr_t get() const { // NOLINT: matching std style
-		return pointer;
-	}
-	idx_t GetSize() const {
-		return allocated_size;
-	}
-	bool IsSet() {
-		return pointer;
-	}
-	void Reset();
-
-private:
-	optional_ptr<Allocator> allocator;
-	data_ptr_t pointer;
-	idx_t allocated_size;
-};
-
-class Allocator {
-	// 281TB ought to be enough for anybody
-	static constexpr const idx_t MAXIMUM_ALLOC_SIZE = 281474976710656ULL;
-
-public:
-	DUCKDB_API Allocator();
-	DUCKDB_API Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
-	                     reallocate_function_ptr_t reallocate_function_p,
-	                     unique_ptr<PrivateAllocatorData> private_data);
-	Allocator &operator=(Allocator &&allocator) noexcept = delete;
-	DUCKDB_API ~Allocator();
-
-	DUCKDB_API data_ptr_t AllocateData(idx_t size);
-	DUCKDB_API void FreeData(data_ptr_t pointer, idx_t size);
-	DUCKDB_API data_ptr_t ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t new_size);
-
-	AllocatedData Allocate(idx_t size) {
-		return AllocatedData(*this, AllocateData(size), size);
-	}
-	static data_ptr_t DefaultAllocate(PrivateAllocatorData *private_data, idx_t size);
-	static void DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);
-	static data_ptr_t DefaultReallocate(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t old_size,
-	                                    idx_t size);
-	static Allocator &Get(ClientContext &context);
-	static Allocator &Get(DatabaseInstance &db);
-	static Allocator &Get(AttachedDatabase &db);
-
-	PrivateAllocatorData *GetPrivateData() {
-		return private_data.get();
-	}
-
-	DUCKDB_API static Allocator &DefaultAllocator();
-	DUCKDB_API static shared_ptr<Allocator> &DefaultAllocatorReference();
-
-	static bool SupportsFlush();
-	static optional_idx DecayDelay();
-	static void ThreadFlush(bool allocator_background_threads, idx_t threshold, idx_t thread_count);
-	static void ThreadIdle();
-	static void FlushAll();
-	static void SetBackgroundThreads(bool enable);
-
-private:
-	allocate_function_ptr_t allocate_function;
-	free_function_ptr_t free_function;
-	reallocate_function_ptr_t reallocate_function;
-
-	unique_ptr<PrivateAllocatorData> private_data;
-};
-
-template <class T>
-T *AllocateArray(idx_t size) {
-	return (T *)Allocator::DefaultAllocator().AllocateData(size * sizeof(T));
-}
-
-template <class T>
-void DeleteArray(T *ptr, idx_t size) {
-	Allocator::DefaultAllocator().FreeData(data_ptr_cast(ptr), size * sizeof(T));
-}
-
-template <typename T, typename... ARGS>
-T *AllocateObject(ARGS &&... args) {
-	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
-	return new (data) T(std::forward<ARGS>(args)...);
-}
-
-template <typename T>
-void DestroyObject(T *ptr) {
-	ptr->~T();
-	Allocator::DefaultAllocator().FreeData(data_ptr_cast(ptr), sizeof(T));
-}
-
-//! The BufferAllocator is a wrapper around the global allocator class that sends any allocations made through the
-//! buffer manager. This makes the buffer manager aware of the memory usage, allowing it to potentially free
-//! other blocks to make space in memory.
-//! Note that there is a cost to doing so (several atomic operations will be performed on allocation/free).
-//! As such this class should be used primarily for larger allocations.
-struct BufferAllocator {
-	DUCKDB_API static Allocator &Get(ClientContext &context);
-	DUCKDB_API static Allocator &Get(DatabaseInstance &db);
-	DUCKDB_API static Allocator &Get(AttachedDatabase &db);
-};
-
-} // namespace duckdb
 
 
 
@@ -7886,7 +8430,16 @@ public:
 	DUCKDB_API explicit ArenaAllocator(Allocator &allocator, idx_t initial_capacity = ARENA_ALLOCATOR_INITIAL_CAPACITY);
 	DUCKDB_API ~ArenaAllocator();
 
-	DUCKDB_API data_ptr_t Allocate(idx_t size);
+	data_ptr_t Allocate(idx_t len) {
+		D_ASSERT(!head || head->current_position <= head->maximum_size);
+		if (!head || head->current_position + len > head->maximum_size) {
+			AllocateNewBlock(len);
+		}
+		D_ASSERT(head->current_position + len <= head->maximum_size);
+		auto result = head->data.get() + head->current_position;
+		head->current_position += len;
+		return result;
+	}
 	DUCKDB_API data_ptr_t Reallocate(data_ptr_t pointer, idx_t old_size, idx_t size);
 
 	DUCKDB_API data_ptr_t AllocateAligned(idx_t size);
@@ -7894,6 +8447,13 @@ public:
 
 	//! Increment the internal cursor (if required) so the next allocation is guaranteed to be aligned to 8 bytes
 	DUCKDB_API void AlignNext();
+
+	//! This shrinks the LAST allocation that was made using the allocator
+	//! Note that we can ONLY safely call this method if Allocate has been called previously with a size >= shrink_size
+	DUCKDB_API void ShrinkHead(idx_t shrink_size) const {
+		D_ASSERT(head && head->current_position >= shrink_size);
+		head->current_position -= shrink_size;
+	}
 
 	//! Resets the current head and destroys all previous arena chunks
 	DUCKDB_API void Reset();
@@ -7913,6 +8473,9 @@ public:
 	Allocator &GetAllocator() {
 		return arena_allocator;
 	}
+
+private:
+	void AllocateNewBlock(idx_t min_size);
 
 private:
 	//! Internal allocator that is used by the arena allocator
@@ -7959,6 +8522,10 @@ public:
 	DUCKDB_API idx_t SizeInBytes() const;
 	//! Total allocation size (cached)
 	DUCKDB_API idx_t AllocationSize() const;
+
+	DUCKDB_API ArenaAllocator &GetAllocator() {
+		return allocator;
+	}
 
 private:
 	ArenaAllocator allocator;
@@ -8008,6 +8575,14 @@ struct FileHandle;
 #ifndef DUCKDB_BLOCK_ALLOC_SIZE
 #define DUCKDB_BLOCK_ALLOC_SIZE DEFAULT_BLOCK_ALLOC_SIZE
 #endif
+//! The default block header size.
+#define DEFAULT_BLOCK_HEADER_STORAGE_SIZE 8ULL
+//! The default block header size.
+#define DEFAULT_ENCRYPTION_BLOCK_HEADER_SIZE 40ULL
+//! The configurable block allocation size.
+#ifndef DUCKDB_BLOCK_HEADER_STORAGE_SIZE
+#define DUCKDB_BLOCK_HEADER_STORAGE_SIZE DEFAULT_BLOCK_HEADER_STORAGE_SIZE
+#endif
 
 using block_id_t = int64_t;
 
@@ -8019,18 +8594,22 @@ struct Storage {
 	constexpr static idx_t FILE_HEADER_SIZE = 4096U;
 	//! The maximum row group size
 	constexpr static const idx_t MAX_ROW_GROUP_SIZE = 1ULL << 30ULL;
-
 	//! The minimum block allocation size. This is the minimum size we test in our nightly tests.
 	constexpr static idx_t MIN_BLOCK_ALLOC_SIZE = 16384ULL;
 	//! The maximum block allocation size. This is the maximum size currently supported by duckdb.
 	constexpr static idx_t MAX_BLOCK_ALLOC_SIZE = 262144ULL;
 	//! The default block header size for blocks written to storage.
 	constexpr static idx_t DEFAULT_BLOCK_HEADER_SIZE = sizeof(idx_t);
+	//! The default block header size for blocks written to storage.
+	constexpr static idx_t MAX_BLOCK_HEADER_SIZE = 128ULL;
+	//! Block header size for encrypted blocks (40 bytes)
+	constexpr static idx_t ENCRYPTED_BLOCK_HEADER_SIZE = 40ULL;
 	//! The default block size.
 	constexpr static idx_t DEFAULT_BLOCK_SIZE = DEFAULT_BLOCK_ALLOC_SIZE - DEFAULT_BLOCK_HEADER_SIZE;
 
 	//! Ensures that a user-provided block allocation size matches all requirements.
 	static void VerifyBlockAllocSize(const idx_t block_alloc_size);
+	static void VerifyBlockHeaderSize(const idx_t block_header_size);
 };
 
 //! The version number default, lower and upper bounds of the database storage format
@@ -8050,6 +8629,7 @@ struct MainHeader {
 	static constexpr idx_t MAGIC_BYTE_SIZE = 4;
 	static constexpr idx_t MAGIC_BYTE_OFFSET = Storage::DEFAULT_BLOCK_HEADER_SIZE;
 	static constexpr idx_t FLAG_COUNT = 4;
+	static constexpr uint64_t ENCRYPTED_DATABASE_FLAG = 1;
 	//! The magic bytes in front of the file should be "DUCK"
 	static const char MAGIC_BYTES[];
 	//! The version of the database
@@ -8063,6 +8643,10 @@ struct MainHeader {
 	}
 	string LibraryGitHash() {
 		return string(char_ptr_cast(library_git_hash), 0, MAX_VERSION_SIZE);
+	}
+
+	bool IsEncrypted() const {
+		return flags[0] == MainHeader::ENCRYPTED_DATABASE_FLAG;
 	}
 
 	void Write(WriteStream &ser);
@@ -8223,10 +8807,10 @@ public:
 	}
 	explicit VectorBuffer(idx_t data_size) : buffer_type(VectorBufferType::STANDARD_BUFFER) {
 		if (data_size > 0) {
-			data = make_unsafe_uniq_array_uninitialized<data_t>(data_size);
+			data = Allocator::DefaultAllocator().Allocate(data_size);
 		}
 	}
-	explicit VectorBuffer(unsafe_unique_array<data_t> data_p)
+	explicit VectorBuffer(AllocatedData &&data_p)
 	    : buffer_type(VectorBufferType::STANDARD_BUFFER), data(std::move(data_p)) {
 	}
 	virtual ~VectorBuffer() {
@@ -8239,7 +8823,7 @@ public:
 		return data.get();
 	}
 
-	void SetData(unsafe_unique_array<data_t> new_data) {
+	void SetData(AllocatedData &&new_data) {
 		data = std::move(new_data);
 	}
 
@@ -8272,7 +8856,7 @@ public:
 protected:
 	VectorBufferType buffer_type;
 	unique_ptr<VectorAuxiliaryData> aux_data;
-	unsafe_unique_array<data_t> data;
+	AllocatedData data;
 
 public:
 	template <class TARGET>
@@ -8349,6 +8933,25 @@ public:
 		return heap.EmptyString(len);
 	}
 
+	//! Allocate a buffer to store up to "len" bytes for a string
+	//! This can be turned into a proper string by using FinalizeBuffer afterwards
+	//! Note that alloc_len only has to be an upper bound, the final string may be smaller
+	data_ptr_t AllocateShrinkableBuffer(idx_t alloc_len) {
+		auto &allocator = heap.GetAllocator();
+		return allocator.Allocate(alloc_len);
+	}
+	//! Finalize a buffer allocated with AllocateShrinkableBuffer into a string of size str_len
+	//! str_len must be <= alloc_len
+	string_t FinalizeShrinkableBuffer(data_ptr_t buffer, idx_t alloc_len, idx_t str_len) {
+		auto &allocator = heap.GetAllocator();
+		D_ASSERT(str_len <= alloc_len);
+		D_ASSERT(buffer == allocator.GetHead()->data.get() + allocator.GetHead()->current_position - alloc_len);
+		bool is_not_inlined = str_len > string_t::INLINE_LENGTH;
+		idx_t shrink_count = alloc_len - (str_len * is_not_inlined);
+		allocator.ShrinkHead(shrink_count);
+		return string_t(const_char_ptr_cast(buffer), UnsafeNumericCast<uint32_t>(str_len));
+	}
+
 	void AddHeapReference(buffer_ptr<VectorBuffer> heap) {
 		references.push_back(std::move(heap));
 	}
@@ -8356,7 +8959,7 @@ public:
 private:
 	//! The string heap of this buffer
 	StringHeap heap;
-	// References to additional vector buffers referenced by this string buffer
+	//! References to additional vector buffers referenced by this string buffer
 	vector<buffer_ptr<VectorBuffer>> references;
 };
 
@@ -8480,6 +9083,7 @@ private:
 namespace duckdb {
 
 class VectorCache;
+class VectorStringBuffer;
 class VectorStructBuffer;
 class VectorListBuffer;
 struct SelCache;
@@ -8666,7 +9270,7 @@ public:
 	//! Returns a vector of ResizeInfo containing each (nested) vector to resize.
 	DUCKDB_API void FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multiplier);
 
-	DUCKDB_API void Serialize(Serializer &serializer, idx_t count);
+	DUCKDB_API void Serialize(Serializer &serializer, idx_t count, bool compressed_serialization = true);
 	DUCKDB_API void Deserialize(Deserializer &deserializer, idx_t count);
 
 	idx_t GetAllocationSize(idx_t cardinality) const;
@@ -8916,6 +9520,8 @@ struct StringVector {
 	//! Allocates an empty string of the specified size, and returns a writable pointer that can be used to store the
 	//! result of an operation
 	DUCKDB_API static string_t EmptyString(Vector &vector, idx_t len);
+	//! Returns a reference to the underlying VectorStringBuffer - throws an error if vector is not of type VARCHAR
+	DUCKDB_API static VectorStringBuffer &GetStringBuffer(Vector &vector);
 	//! Adds a reference to a handle that stores strings of this vector
 	DUCKDB_API static void AddHandle(Vector &vector, BufferHandle handle);
 	//! Adds a reference to an unspecified vector buffer that stores strings of this vector
@@ -9390,7 +9996,7 @@ public:
 	//! Vector to point back to the data owned by this DataChunk.
 	DUCKDB_API void Reset();
 
-	DUCKDB_API void Serialize(Serializer &serializer) const;
+	DUCKDB_API void Serialize(Serializer &serializer, bool compressed_serialization = true) const;
 	DUCKDB_API void Deserialize(Deserializer &source);
 
 	//! Hashes the DataChunk to the target vector
@@ -10729,53 +11335,6 @@ public:
 
 
 
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/case_insensitive_map.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-
-
-
-namespace duckdb {
-
-struct CaseInsensitiveStringHashFunction {
-	uint64_t operator()(const string &str) const {
-		return StringUtil::CIHash(str);
-	}
-};
-
-struct CaseInsensitiveStringEquality {
-	bool operator()(const string &a, const string &b) const {
-		return StringUtil::CIEquals(a, b);
-	}
-};
-
-template <typename T>
-using case_insensitive_map_t =
-    unordered_map<string, T, CaseInsensitiveStringHashFunction, CaseInsensitiveStringEquality>;
-
-using case_insensitive_set_t = unordered_set<string, CaseInsensitiveStringHashFunction, CaseInsensitiveStringEquality>;
-
-struct CaseInsensitiveStringCompare {
-	bool operator()(const string &s1, const string &s2) const {
-		return StringUtil::CILessThan(s1, s2);
-	}
-};
-
-template <typename T>
-using case_insensitive_tree_t = map<string, T, CaseInsensitiveStringCompare>;
-
-} // namespace duckdb
 
 
 namespace duckdb {
@@ -10913,6 +11472,8 @@ enum class ExpressionType : uint8_t {
 	OPERATOR_IS_NULL = 14,
 	// is not null operator
 	OPERATOR_IS_NOT_NULL = 15,
+	// unpack operator
+	OPERATOR_UNPACK = 16,
 
 	// -----------------------------
 	// Comparison Operators
@@ -11005,6 +11566,7 @@ enum class ExpressionType : uint8_t {
 	STRUCT_EXTRACT = 155,
 	ARRAY_CONSTRUCTOR = 156,
 	ARROW = 157,
+	OPERATOR_TRY = 158,
 
 	// -----------------------------
 	// Subquery IN/EXISTS
@@ -11437,6 +11999,7 @@ struct QualifiedName {
 	//! Parse the (optional) schema and a name from a string in the format of e.g. "schema"."table"; if there is no dot
 	//! the schema will be set to INVALID_SCHEMA
 	static QualifiedName Parse(const string &input);
+	static vector<string> ParseComponents(const string &input);
 	string ToString() const;
 };
 
@@ -11565,7 +12128,10 @@ protected:
 
 
 
+
 namespace duckdb {
+
+class StorageManager;
 
 enum class CompressionType : uint8_t {
 	COMPRESSION_AUTO = 0,
@@ -11583,10 +12149,12 @@ enum class CompressionType : uint8_t {
 	COMPRESSION_ZSTD = 12,
 	COMPRESSION_ROARING = 13,
 	COMPRESSION_EMPTY = 14, // internal only
-	COMPRESSION_COUNT       // This has to stay the last entry of the type!
+	COMPRESSION_DICT_FSST = 15,
+	COMPRESSION_COUNT // This has to stay the last entry of the type!
 };
 
-bool CompressionTypeIsDeprecated(CompressionType compression_type);
+bool CompressionTypeIsDeprecated(CompressionType compression_type,
+                                 optional_ptr<StorageManager> storage_manager = nullptr);
 vector<string> ListCompressionTypes(void);
 CompressionType CompressionTypeFromString(const string &str);
 string CompressionTypeToString(CompressionType type);
@@ -11756,6 +12324,7 @@ struct FunctionData {
 	DUCKDB_API virtual unique_ptr<FunctionData> Copy() const = 0;
 	DUCKDB_API virtual bool Equals(const FunctionData &other) const = 0;
 	DUCKDB_API static bool Equals(const FunctionData *left, const FunctionData *right);
+	DUCKDB_API virtual bool SupportStatementCache() const;
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -11800,15 +12369,24 @@ public:
 	//! Additional Information to specify function from it's name
 	string extra_info;
 
+	// Optional catalog name of the function
+	string catalog_name;
+
+	// Optional schema name of the function
+	string schema_name;
+
 public:
 	//! Returns the formatted string name(arg1, arg2, ...)
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments,
 	                                      const LogicalType &varargs = LogicalType::INVALID);
 	//! Returns the formatted string name(arg1, arg2..) -> return_type
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
-	                                      const LogicalType &varargs, const LogicalType &return_type);
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments, const LogicalType &varargs,
+	                                      const LogicalType &return_type);
 	//! Returns the formatted string name(arg1, arg2.., np1=a, np2=b, ...)
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments,
 	                                      const named_parameter_type_map_t &named_parameters);
 
 	//! Used in the bind to erase an argument from a function
@@ -12192,49 +12770,46 @@ public:
 	static int Sign(hugeint_t n);
 	static hugeint_t Abs(hugeint_t n);
 	// comparison operators
-	// note that everywhere here we intentionally use bitwise ops
-	// this is because they seem to be consistently much faster (benchmarked on a Macbook Pro)
 	static bool Equals(hugeint_t lhs, hugeint_t rhs) {
-		int lower_equals = lhs.lower == rhs.lower;
-		int upper_equals = lhs.upper == rhs.upper;
-		return lower_equals & upper_equals;
+		bool lower_equals = lhs.lower == rhs.lower;
+		bool upper_equals = lhs.upper == rhs.upper;
+		return lower_equals && upper_equals;
 	}
 
 	static bool NotEquals(hugeint_t lhs, hugeint_t rhs) {
-		int lower_not_equals = lhs.lower != rhs.lower;
-		int upper_not_equals = lhs.upper != rhs.upper;
-		return lower_not_equals | upper_not_equals;
+		return !Equals(lhs, rhs);
 	}
 
 	static bool GreaterThan(hugeint_t lhs, hugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger = lhs.lower > rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger = lhs.lower > rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger);
 	}
 
 	static bool GreaterThanEquals(hugeint_t lhs, hugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger_equals = lhs.lower >= rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger_equals);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger_equals = lhs.lower >= rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger_equals);
 	}
 
 	static bool LessThan(hugeint_t lhs, hugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller = lhs.lower < rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller = lhs.lower < rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller);
 	}
 
 	static bool LessThanEquals(hugeint_t lhs, hugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller_equals = lhs.lower <= rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller_equals);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller_equals = lhs.lower <= rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller_equals);
 	}
 
-	static const hugeint_t POWERS_OF_TEN[40];
+	static constexpr uint8_t CACHED_POWERS_OF_TEN = 39;
+	static const hugeint_t POWERS_OF_TEN[CACHED_POWERS_OF_TEN];
 };
 
 template <>
@@ -12831,7 +13406,7 @@ struct NumericStats {
 
 	//! Check whether or not a given comparison with a constant could possibly be satisfied by rows given the statistics
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const BaseStatistics &stats, ExpressionType comparison_type,
-	                                                     array_ptr<Value> constants);
+	                                                     array_ptr<const Value> constants);
 
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other_p);
 
@@ -12932,6 +13507,8 @@ struct StringStats {
 
 	//! Resets the max string length so HasMaxStringLength() is false
 	DUCKDB_API static void ResetMaxStringLength(BaseStatistics &stats);
+	//! Sets the max string length
+	DUCKDB_API static void SetMaxStringLength(BaseStatistics &stats, uint32_t length);
 	//! FIXME: make this part of Set on statistics
 	DUCKDB_API static void SetContainsUnicode(BaseStatistics &stats);
 
@@ -12941,7 +13518,7 @@ struct StringStats {
 	DUCKDB_API static string ToString(const BaseStatistics &stats);
 
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const BaseStatistics &stats, ExpressionType comparison_type,
-	                                                     array_ptr<Value> constants);
+	                                                     array_ptr<const Value> constants);
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const_data_ptr_t min_data, idx_t min_len,
 	                                                     const_data_ptr_t max_data, idx_t max_len,
 	                                                     ExpressionType comparison_type, const string &value);
@@ -13080,7 +13657,7 @@ private:
 	bool has_null;
 	//! Whether or not the segment can contain values that are not null
 	bool has_no_null;
-	// estimate that one may have even if distinct_stats==nullptr
+	//! estimate that one may have even if distinct_stats==nullptr
 	idx_t distinct_count;
 	//! Numeric and String stats
 	union {
@@ -13196,7 +13773,9 @@ typedef unique_ptr<FunctionLocalState> (*init_local_state_t)(ExpressionState &st
 //! The type to propagate statistics for this scalar function
 typedef unique_ptr<BaseStatistics> (*function_statistics_t)(ClientContext &context, FunctionStatisticsInput &input);
 //! The type to bind lambda-specific parameter types
-typedef LogicalType (*bind_lambda_function_t)(const idx_t parameter_idx, const LogicalType &list_child_type);
+typedef LogicalType (*bind_lambda_function_t)(ClientContext &context, const vector<LogicalType> &function_child_types,
+                                              idx_t parameter_idx);
+
 //! The type to bind lambda-specific parameter types
 typedef void (*get_modified_databases_t)(ClientContext &context, FunctionModifiedDatabasesInput &input);
 
@@ -15734,8 +16313,6 @@ struct StatementProperties {
 
 
 
-#include <utility>
-
 
 
 
@@ -15743,14 +16320,31 @@ namespace duckdb {
 
 enum class ArrowOffsetSize : uint8_t { REGULAR, LARGE };
 
+enum ArrowFormatVersion : uint8_t {
+	//! Base Version
+	V1_0 = 10,
+	//! Added 256-bit Decimal type.
+	V1_1 = 11,
+	//! Added MonthDayNano interval type.
+	V1_2 = 12,
+	//! Added Run-End Encoded Layout.
+	V1_3 = 13,
+	//! Added Variable-size Binary View Layout and the associated BinaryView and Utf8View types.
+	//! Added ListView Layout and the associated ListView and LargeListView types. Added Variadic buffers.
+	V1_4 = 14,
+	//! Expanded Decimal type bit widths to allow 32-bit and 64-bit types.
+	V1_5 = 15
+};
+
 //! A set of properties from the client context that can be used to interpret the query result
 struct ClientProperties {
-	ClientProperties(string time_zone_p, ArrowOffsetSize arrow_offset_size_p, bool arrow_use_list_view_p,
-	                 bool produce_arrow_string_view_p, bool lossless_conversion,
-	                 optional_ptr<ClientContext> client_context)
+	ClientProperties(string time_zone_p, const ArrowOffsetSize arrow_offset_size_p, const bool arrow_use_list_view_p,
+	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,
+	                 const ArrowFormatVersion arrow_output_version, const optional_ptr<ClientContext> client_context)
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
-	      arrow_lossless_conversion(lossless_conversion), client_context(client_context) {
+	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
+	      client_context(client_context) {
 	}
 
 	string time_zone = "UTC";
@@ -15758,6 +16352,7 @@ struct ClientProperties {
 	bool arrow_use_list_view = false;
 	bool produce_arrow_string_view = false;
 	bool arrow_lossless_conversion = false;
+	ArrowFormatVersion arrow_output_version = V1_0;
 	optional_ptr<ClientContext> client_context;
 };
 } // namespace duckdb
@@ -15884,6 +16479,9 @@ private:
 		QueryResultIterator &iterator;
 		idx_t row;
 
+		bool IsNull(idx_t col_idx) const {
+			return iterator.chunk->GetValue(col_idx, row).IsNull();
+		}
 		template <class T>
 		T GetValue(idx_t col_idx) const {
 			return iterator.chunk->GetValue(col_idx, row).GetValue<T>();
@@ -16077,13 +16675,18 @@ enum class PendingExecutionResult : uint8_t {
 
 
 
+
 namespace duckdb {
 
 class TaskErrorManager {
 public:
+	TaskErrorManager() : has_error(false) {
+	}
+
 	void PushError(ErrorData error) {
 		lock_guard<mutex> elock(error_lock);
 		this->exceptions.push_back(std::move(error));
+		has_error = true;
 	}
 
 	ErrorData GetError() {
@@ -16098,8 +16701,7 @@ public:
 	}
 
 	bool HasError() {
-		lock_guard<mutex> elock(error_lock);
-		return !exceptions.empty();
+		return has_error;
 	}
 
 	void ThrowException() {
@@ -16112,12 +16714,15 @@ public:
 	void Reset() {
 		lock_guard<mutex> elock(error_lock);
 		exceptions.clear();
+		has_error = false;
 	}
 
 private:
 	mutex error_lock;
 	//! Exceptions that occurred during the execution of the current query
 	vector<ErrorData> exceptions;
+	//! Lock-free error flag
+	atomic<bool> has_error;
 };
 } // namespace duckdb
 
@@ -16238,6 +16843,9 @@ enum class OperatorResultType : uint8_t { NEED_MORE_INPUT, HAVE_MORE_OUTPUT, FIN
 //! HAVE_MORE_OUTPUT means the operator contains more results.
 enum class OperatorFinalizeResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED };
 
+//! OperatorFinalResultType is used for the final call
+enum class OperatorFinalResultType : uint8_t { FINISHED, BLOCKED };
+
 //! SourceResultType is used to indicate the result of data being pulled out of a source.
 //! There are three possible results:
 //! HAVE_MORE_OUTPUT means the source has more output, this flag should only be set when data is returned, empty results
@@ -16319,6 +16927,7 @@ enum class PhysicalOperatorType : uint8_t {
 	COLUMN_DATA_SCAN,
 	CHUNK_SCAN,
 	RECURSIVE_CTE_SCAN,
+	RECURSIVE_RECURRING_CTE_SCAN,
 	CTE_SCAN,
 	DELIM_SCAN,
 	EXPRESSION_SCAN,
@@ -16341,6 +16950,7 @@ enum class PhysicalOperatorType : uint8_t {
 	// -----------------------------
 	UNION,
 	RECURSIVE_CTE,
+	RECURSIVE_KEY_CTE,
 	CTE,
 
 	// -----------------------------
@@ -16739,7 +17349,13 @@ struct ColumnIndex {
 		this->child_indexes.push_back(std::move(new_index));
 	}
 	bool IsRowIdColumn() const {
-		return index == DConstants::INVALID_INDEX;
+		return index == COLUMN_IDENTIFIER_ROW_ID;
+	}
+	bool IsEmptyColumn() const {
+		return index == COLUMN_IDENTIFIER_EMPTY;
+	}
+	bool IsVirtualColumn() const {
+		return index >= VIRTUAL_COLUMN_START;
 	}
 	void Serialize(Serializer &serializer) const;
 	static ColumnIndex Deserialize(Deserializer &deserializer);
@@ -16767,7 +17383,8 @@ enum class TableFilterType : uint8_t {
 	STRUCT_EXTRACT = 5,      // filter applies to child-column of struct
 	OPTIONAL_FILTER = 6,     // executing filter is not required for query correctness
 	IN_FILTER = 7,           // col IN (C1, C2, C3, ...)
-	DYNAMIC_FILTER = 8       // dynamic filters can be updated at run-time
+	DYNAMIC_FILTER = 8,      // dynamic filters can be updated at run-time
+	EXPRESSION_FILTER = 9    // an arbitrary expression
 };
 
 //! TableFilter represents a filter pushed down into the table scan.
@@ -16782,9 +17399,9 @@ public:
 
 public:
 	//! Returns true if the statistics indicate that the segment can contain values that satisfy that filter
-	virtual FilterPropagateResult CheckStatistics(BaseStatistics &stats) = 0;
-	virtual string ToString(const string &column_name) = 0;
-	string DebugToString();
+	virtual FilterPropagateResult CheckStatistics(BaseStatistics &stats) const = 0;
+	virtual string ToString(const string &column_name) const = 0;
+	string DebugToString() const;
 	virtual unique_ptr<TableFilter> Copy() const = 0;
 	virtual bool Equals(const TableFilter &other) const {
 		return filter_type == other.filter_type;
@@ -16812,9 +17429,11 @@ public:
 	}
 };
 
+//! The filters in here are non-composite (only need a single column to be evaluated)
+//! Conditions like `A = 2 OR B = 4` are not pushed into a TableFilterSet.
 class TableFilterSet {
 public:
-	unordered_map<idx_t, unique_ptr<TableFilter>> filters;
+	map<idx_t, unique_ptr<TableFilter>> filters;
 
 public:
 	void PushFilter(const ColumnIndex &col_idx, unique_ptr<TableFilter> filter);
@@ -16842,6 +17461,14 @@ public:
 			return false;
 		}
 		return left->Equals(*right);
+	}
+
+	unique_ptr<TableFilterSet> Copy() const {
+		auto copy = make_uniq<TableFilterSet>();
+		for (auto &it : filters) {
+			copy->filters.emplace(it.first, it.second->Copy());
+		}
+		return copy;
 	}
 
 	void Serialize(Serializer &serializer) const;
@@ -16891,8 +17518,8 @@ public:
 
 public:
 	ConjunctionOrFilter();
-	FilterPropagateResult CheckStatistics(BaseStatistics &stats) override;
-	string ToString(const string &column_name) override;
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
+	string ToString(const string &column_name) const override;
 	bool Equals(const TableFilter &other) const override;
 	unique_ptr<TableFilter> Copy() const override;
 	unique_ptr<Expression> ToExpression(const Expression &column) const override;
@@ -16908,8 +17535,8 @@ public:
 	ConjunctionAndFilter();
 
 public:
-	FilterPropagateResult CheckStatistics(BaseStatistics &stats) override;
-	string ToString(const string &column_name) override;
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
+	string ToString(const string &column_name) const override;
 	bool Equals(const TableFilter &other) const override;
 	unique_ptr<TableFilter> Copy() const override;
 	unique_ptr<Expression> ToExpression(const Expression &column) const override;
@@ -17235,158 +17862,6 @@ protected:
 } // namespace duckdb
 
 
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/insertion_order_preserving_map.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-
-
-
-
-namespace duckdb {
-
-template <typename V>
-class InsertionOrderPreservingMap {
-public:
-	typedef vector<pair<string, V>> VECTOR_TYPE; // NOLINT: matching name of std
-	typedef string key_type;                     // NOLINT: matching name of std
-
-public:
-	InsertionOrderPreservingMap() {
-	}
-
-private:
-	VECTOR_TYPE map;
-	case_insensitive_map_t<idx_t> map_idx;
-
-public:
-	vector<string> Keys() const {
-		vector<string> keys;
-		keys.resize(this->size());
-		for (auto &kv : map_idx) {
-			keys[kv.second] = kv.first;
-		}
-
-		return keys;
-	}
-
-	typename VECTOR_TYPE::iterator begin() { // NOLINT: match stl API
-		return map.begin();
-	}
-
-	typename VECTOR_TYPE::iterator end() { // NOLINT: match stl API
-		return map.end();
-	}
-
-	typename VECTOR_TYPE::const_iterator begin() const { // NOLINT: match stl API
-		return map.begin();
-	}
-
-	typename VECTOR_TYPE::const_iterator end() const { // NOLINT: match stl API
-		return map.end();
-	}
-
-	typename VECTOR_TYPE::reverse_iterator rbegin() { // NOLINT: match stl API
-		return map.rbegin();
-	}
-
-	typename VECTOR_TYPE::reverse_iterator rend() { // NOLINT: match stl API
-		return map.rend();
-	}
-
-	typename VECTOR_TYPE::iterator find(const string &key) { // NOLINT: match stl API
-		auto entry = map_idx.find(key);
-		if (entry == map_idx.end()) {
-			return map.end();
-		}
-		return map.begin() + static_cast<typename VECTOR_TYPE::difference_type>(entry->second);
-	}
-
-	typename VECTOR_TYPE::const_iterator find(const string &key) const { // NOLINT: match stl API
-		auto entry = map_idx.find(key);
-		if (entry == map_idx.end()) {
-			return map.end();
-		}
-		return map.begin() + static_cast<typename VECTOR_TYPE::difference_type>(entry->second);
-	}
-
-	idx_t size() const { // NOLINT: match stl API
-		return map_idx.size();
-	}
-
-	bool empty() const { // NOLINT: match stl API
-		return map_idx.empty();
-	}
-
-	void resize(idx_t nz) { // NOLINT: match stl API
-		map.resize(nz);
-	}
-
-	void insert(const string &key, V &&value) { // NOLINT: match stl API
-		if (contains(key)) {
-			return;
-		}
-		map.emplace_back(key, std::move(value));
-		map_idx[key] = map.size() - 1;
-	}
-
-	void insert(const string &key, const V &value) { // NOLINT: match stl API
-		if (contains(key)) {
-			return;
-		}
-		map.emplace_back(key, value);
-		map_idx[key] = map.size() - 1;
-	}
-
-	void insert(pair<string, V> &&value) { // NOLINT: match stl API
-		auto &key = value.first;
-		if (contains(key)) {
-			return;
-		}
-		map_idx[key] = map.size();
-		map.push_back(std::move(value));
-	}
-
-	void erase(typename VECTOR_TYPE::iterator it) { // NOLINT: match stl API
-		auto key = it->first;
-		auto idx = map_idx[key];
-		map.erase(it);
-		map_idx.erase(key);
-		for (auto &kv : map_idx) {
-			if (kv.second > idx) {
-				kv.second--;
-			}
-		}
-	}
-
-	bool contains(const string &key) const { // NOLINT: match stl API
-		return map_idx.find(key) != map_idx.end();
-	}
-
-	const V &at(const string &key) const { // NOLINT: match stl API
-		return map[map_idx.at(key)].second;
-	}
-
-	V &operator[](const string &key) {
-		if (!contains(key)) {
-			auto v = V();
-			insert(key, std::move(v));
-		}
-		return map[map_idx[key]].second;
-	}
-};
-
-} // namespace duckdb
 
 
 #include <algorithm>
@@ -17541,6 +18016,7 @@ public:
 	static void CopyRelationStats(RelationStats &to, const RelationStats &from);
 
 private:
+	static idx_t GetDistinctCount(LogicalGet &get, ClientContext &context, idx_t column_id);
 };
 
 } // namespace duckdb
@@ -17622,7 +18098,6 @@ public:
 class CardinalityEstimator {
 public:
 	static constexpr double DEFAULT_SEMI_ANTI_SELECTIVITY = 5;
-	static constexpr double DEFAULT_LT_GT_MULTIPLIER = 2.5;
 	explicit CardinalityEstimator() {};
 
 private:
@@ -17920,6 +18395,7 @@ public:
 
 
 
+
 namespace duckdb {
 class ClientContext;
 class Executor;
@@ -17960,6 +18436,13 @@ public:
 	virtual bool TaskBlockedOnResult() const {
 		return false;
 	}
+
+	virtual string TaskType() const {
+		return "UnnamedTask";
+	}
+
+public:
+	optional_ptr<ProducerToken> token;
 };
 
 } // namespace duckdb
@@ -18300,6 +18783,11 @@ struct OperatorSinkFinalizeInput {
 	InterruptState &interrupt_state;
 };
 
+struct OperatorFinalizeInput {
+	GlobalOperatorState &global_state;
+	InterruptState &interrupt_state;
+};
+
 struct OperatorSinkNextBatchInput {
 	GlobalSinkState &global_state;
 	LocalSinkState &local_state;
@@ -18360,10 +18848,14 @@ public:
 	virtual ~PhysicalOperator() {
 	}
 
+	// Delete copy constructors.
+	PhysicalOperator(const PhysicalOperator &other) = delete;
+	PhysicalOperator &operator=(const PhysicalOperator &) = delete;
+
 	//! The physical operator type
 	PhysicalOperatorType type;
 	//! The set of children of the operator
-	vector<unique_ptr<PhysicalOperator>> children;
+	vector<reference<PhysicalOperator>> children;
 	//! The types returned by this physical operator
 	vector<LogicalType> types;
 	//! The estimated cardinality of this physical operator
@@ -18409,12 +18901,18 @@ public:
 	                                   GlobalOperatorState &gstate, OperatorState &state) const;
 	virtual OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk,
 	                                                GlobalOperatorState &gstate, OperatorState &state) const;
+	virtual OperatorFinalResultType OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                                                 OperatorFinalizeInput &input) const;
 
 	virtual bool ParallelOperator() const {
 		return false;
 	}
 
 	virtual bool RequiresFinalExecute() const {
+		return false;
+	}
+
+	virtual bool RequiresOperatorFinalize() const {
 		return false;
 	}
 
@@ -18461,6 +18959,11 @@ public:
 	virtual ProgressData GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
 	                                     const ProgressData source_progress) const {
 		return source_progress;
+	}
+
+	virtual InsertionOrderPreservingMap<string> ExtraSourceParams(GlobalSourceState &gstate,
+	                                                              LocalSourceState &lstate) const {
+		return InsertionOrderPreservingMap<string>();
 	}
 
 public:
@@ -18601,10 +19104,13 @@ private:
 
 
 
+
+
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/planner/bind_context.hpp
+// duckdb/common/table_column.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -18614,6 +19120,60 @@ private:
 
 
 
+namespace duckdb {
+
+struct TableColumn {
+	TableColumn() = default;
+	TableColumn(string name_p, LogicalType type_p) : name(std::move(name_p)), type(std::move(type_p)) {
+	}
+
+	string name;
+	LogicalType type;
+
+	void Serialize(Serializer &serializer) const;
+	static TableColumn Deserialize(Deserializer &deserializer);
+};
+
+using virtual_column_map_t = unordered_map<column_t, TableColumn>;
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/partition_stats.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+//! How a table is partitioned by a given set of columns
+enum class TablePartitionInfo : uint8_t {
+	NOT_PARTITIONED,         // the table is not partitioned by the given set of columns
+	SINGLE_VALUE_PARTITIONS, // each partition has exactly one unique value (e.g. bounds = [1,1][2,2][3,3])
+	OVERLAPPING_PARTITIONS,  // the partitions overlap **only** at the boundaries (e.g. bounds = [1,2][2,3][3,4]
+	DISJOINT_PARTITIONS      // the partitions are disjoint (e.g. bounds = [1,2][3,4][5,6])
+};
+
+enum class CountType { COUNT_EXACT, COUNT_APPROXIMATE };
+
+struct PartitionStatistics {
+	PartitionStatistics();
+
+	//! The row id start
+	idx_t row_start;
+	//! The amount of rows in the partition
+	idx_t count;
+	//! Whether or not the count is exact or approximate
+	CountType count_type;
+};
+
+} // namespace duckdb
 
 //===----------------------------------------------------------------------===//
 //                         DuckDB
@@ -18661,4300 +19221,9 @@ public:
 
 	static BinderException ColumnNotFound(const string &name, const vector<string> &similar_bindings,
 	                                      QueryErrorContext context = QueryErrorContext());
-	static BinderException NoMatchingFunction(const string &name, const vector<LogicalType> &arguments,
-	                                          const vector<string> &candidates);
+	static BinderException NoMatchingFunction(const string &catalog_name, const string &schema_name, const string &name,
+	                                          const vector<LogicalType> &arguments, const vector<string> &candidates);
 	static BinderException Unsupported(ParsedExpression &expr, const string &message);
-};
-
-} // namespace duckdb
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/expression/columnref_expression.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-namespace duckdb {
-struct BindingAlias;
-
-//! Represents a reference to a column from either the FROM clause or from an
-//! alias
-class ColumnRefExpression : public ParsedExpression {
-public:
-	static constexpr const ExpressionClass TYPE = ExpressionClass::COLUMN_REF;
-
-public:
-	//! Specify both the column and table name
-	ColumnRefExpression(string column_name, string table_name);
-	//! Specify both the column and table alias
-	ColumnRefExpression(string column_name, const BindingAlias &alias);
-	//! Only specify the column name, the table name will be derived later
-	explicit ColumnRefExpression(string column_name);
-	//! Specify a set of names
-	explicit ColumnRefExpression(vector<string> column_names);
-
-	//! The stack of names in order of which they appear (column_names[0].column_names[1].column_names[2]....)
-	vector<string> column_names;
-
-public:
-	bool IsQualified() const;
-	const string &GetColumnName() const;
-	const string &GetTableName() const;
-	bool IsScalar() const override {
-		return false;
-	}
-
-	string GetName() const override;
-	string ToString() const override;
-
-	static bool Equal(const ColumnRefExpression &a, const ColumnRefExpression &b);
-	hash_t Hash() const override;
-
-	unique_ptr<ParsedExpression> Copy() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<ParsedExpression> Deserialize(Deserializer &deserializer);
-
-private:
-	ColumnRefExpression();
-};
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/qualified_name_set.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-namespace duckdb {
-
-struct QualifiedColumnHashFunction {
-	uint64_t operator()(const QualifiedColumnName &a) const {
-		// hash only on the column name - since we match based on the shortest possible match
-		return StringUtil::CIHash(a.column);
-	}
-};
-
-struct QualifiedColumnEquality {
-	bool operator()(const QualifiedColumnName &a, const QualifiedColumnName &b) const {
-		// qualified column names follow a prefix comparison
-		// so "tbl.i"  and "i" are equivalent, as are "schema.tbl.i" and "i"
-		// but "tbl.i" and "tbl2.i" are not equivalent
-		if (!a.catalog.empty() && !b.catalog.empty() && !StringUtil::CIEquals(a.catalog, b.catalog)) {
-			return false;
-		}
-		if (!a.schema.empty() && !b.schema.empty() && !StringUtil::CIEquals(a.schema, b.schema)) {
-			return false;
-		}
-		if (!a.table.empty() && !b.table.empty() && !StringUtil::CIEquals(a.table, b.table)) {
-			return false;
-		}
-		return StringUtil::CIEquals(a.column, b.column);
-	}
-};
-
-using qualified_column_set_t = unordered_set<QualifiedColumnName, QualifiedColumnHashFunction, QualifiedColumnEquality>;
-
-template <class T>
-using qualified_column_map_t =
-    unordered_map<QualifiedColumnName, T, QualifiedColumnHashFunction, QualifiedColumnEquality>;
-
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/planner/expression_binder.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/stack_checker.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-namespace duckdb {
-
-template <class RECURSIVE_CLASS>
-class StackChecker {
-public:
-	StackChecker(RECURSIVE_CLASS &recursive_class_p, idx_t stack_usage_p)
-	    : recursive_class(recursive_class_p), stack_usage(stack_usage_p) {
-		recursive_class.stack_depth += stack_usage;
-	}
-	~StackChecker() {
-		recursive_class.stack_depth -= stack_usage;
-	}
-	StackChecker(StackChecker &&other) noexcept
-	    : recursive_class(other.recursive_class), stack_usage(other.stack_usage) {
-		other.stack_usage = 0;
-	}
-	StackChecker(const StackChecker &) = delete;
-
-private:
-	RECURSIVE_CLASS &recursive_class;
-	idx_t stack_usage;
-};
-
-} // namespace duckdb
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/expression/bound_expression.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-namespace duckdb {
-
-//! BoundExpression is an intermediate dummy class used by the binder. It is a ParsedExpression but holds an Expression.
-//! It represents a successfully bound expression. It is used in the Binder to prevent re-binding of already bound parts
-//! when dealing with subqueries.
-class BoundExpression : public ParsedExpression {
-public:
-	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_EXPRESSION;
-
-public:
-	explicit BoundExpression(unique_ptr<Expression> expr);
-
-	unique_ptr<Expression> expr;
-
-public:
-	static unique_ptr<Expression> &GetExpression(ParsedExpression &expr);
-
-	string ToString() const override;
-
-	bool Equals(const BaseExpression &other) const override;
-	hash_t Hash() const override;
-
-	unique_ptr<ParsedExpression> Copy() const override;
-
-	void Serialize(Serializer &serializer) const override;
-};
-
-} // namespace duckdb
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/expression/lambdaref_expression.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-namespace duckdb {
-
-struct DummyBinding;
-
-//! Represents a reference to a lambda parameter
-class LambdaRefExpression : public ParsedExpression {
-public:
-	static constexpr const ExpressionClass TYPE = ExpressionClass::LAMBDA_REF;
-
-public:
-	//! Constructs a LambdaRefExpression from a lambda_idx and a column_name. We do not specify a table name,
-	//! because we use dummy tables to bind lambda parameters
-	LambdaRefExpression(idx_t lambda_idx, string column_name_p);
-
-	//! The index of the lambda parameter in the lambda_bindings vector
-	idx_t lambda_idx;
-	//! The name of the lambda parameter (in a specific Binding in lambda_bindings)
-	string column_name;
-
-public:
-	bool IsScalar() const override;
-	string GetName() const override;
-	string ToString() const override;
-	hash_t Hash() const override;
-	unique_ptr<ParsedExpression> Copy() const override;
-
-	//! Traverses the lambda_bindings to find a matching binding for the column_name
-	static unique_ptr<ParsedExpression> FindMatchingBinding(optional_ptr<vector<DummyBinding>> &lambda_bindings,
-	                                                        const string &parameter_name);
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<ParsedExpression> Deserialize(Deserializer &deserializer);
-};
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/tokens.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-namespace duckdb {
-
-//===--------------------------------------------------------------------===//
-// Statements
-//===--------------------------------------------------------------------===//
-class SQLStatement;
-
-class AlterStatement;
-class AttachStatement;
-class CallStatement;
-class CopyStatement;
-class CreateStatement;
-class DetachStatement;
-class DeleteStatement;
-class DropStatement;
-class ExtensionStatement;
-class InsertStatement;
-class SelectStatement;
-class TransactionStatement;
-class UpdateStatement;
-class UpdateExtensionsStatement;
-class PrepareStatement;
-class ExecuteStatement;
-class PragmaStatement;
-class ExplainStatement;
-class ExportStatement;
-class VacuumStatement;
-class RelationStatement;
-class SetStatement;
-class SetVariableStatement;
-class ResetVariableStatement;
-class LoadStatement;
-class LogicalPlanStatement;
-class MultiStatement;
-class CopyDatabaseStatement;
-
-//===--------------------------------------------------------------------===//
-// Query Node
-//===--------------------------------------------------------------------===//
-class QueryNode;
-class SelectNode;
-class SetOperationNode;
-class RecursiveCTENode;
-class CTENode;
-
-//===--------------------------------------------------------------------===//
-// Expressions
-//===--------------------------------------------------------------------===//
-class ParsedExpression;
-
-class BetweenExpression;
-class CaseExpression;
-class CastExpression;
-class CollateExpression;
-class ColumnRefExpression;
-class ComparisonExpression;
-class ConjunctionExpression;
-class ConstantExpression;
-class DefaultExpression;
-class FunctionExpression;
-class LambdaExpression;
-class OperatorExpression;
-class ParameterExpression;
-class PositionalReferenceExpression;
-class StarExpression;
-class SubqueryExpression;
-class WindowExpression;
-
-//===--------------------------------------------------------------------===//
-// Constraints
-//===--------------------------------------------------------------------===//
-class Constraint;
-
-class NotNullConstraint;
-class CheckConstraint;
-class UniqueConstraint;
-class ForeignKeyConstraint;
-
-//===--------------------------------------------------------------------===//
-// TableRefs
-//===--------------------------------------------------------------------===//
-class TableRef;
-
-class BaseTableRef;
-class JoinRef;
-class SubqueryRef;
-class TableFunctionRef;
-class EmptyTableRef;
-class ExpressionListRef;
-class ColumnDataRef;
-class PivotRef;
-class ShowRef;
-
-//===--------------------------------------------------------------------===//
-// Other
-//===--------------------------------------------------------------------===//
-class SampleOptions;
-
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/catalog_entry_retriever.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-#include <functional>
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/catalog_set.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/default/default_generator.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-namespace duckdb {
-class ClientContext;
-
-class DefaultGenerator {
-public:
-	explicit DefaultGenerator(Catalog &catalog);
-	virtual ~DefaultGenerator();
-
-	Catalog &catalog;
-	atomic<bool> created_all_entries;
-
-public:
-	//! Creates a default entry with the specified name, or returns nullptr if no such entry can be generated
-	virtual unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name);
-	virtual unique_ptr<CatalogEntry> CreateDefaultEntry(CatalogTransaction transaction, const string &entry_name);
-	//! Get a list of all default entries in the generator
-	virtual vector<string> GetDefaultEntries() = 0;
-};
-
-} // namespace duckdb
-
-
-
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/transaction/transaction.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/standard_entry.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/dependency_list.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/catalog_entry_map.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-namespace duckdb {
-class CatalogEntry;
-
-struct CatalogEntryHashFunction {
-	uint64_t operator()(const reference<CatalogEntry> &a) const {
-		std::hash<void *> hash_func;
-		return hash_func((void *)&a.get());
-	}
-};
-
-struct CatalogEntryEquality {
-	bool operator()(const reference<CatalogEntry> &a, const reference<CatalogEntry> &b) const {
-		return RefersToSameObject(a, b);
-	}
-};
-
-using catalog_entry_set_t = unordered_set<reference<CatalogEntry>, CatalogEntryHashFunction, CatalogEntryEquality>;
-
-template <typename T>
-using catalog_entry_map_t = unordered_map<reference<CatalogEntry>, T, CatalogEntryHashFunction, CatalogEntryEquality>;
-
-using catalog_entry_vector_t = vector<reference<CatalogEntry>>;
-
-} // namespace duckdb
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/dependency.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-namespace duckdb {
-class CatalogEntry;
-
-struct DependencyFlags {
-public:
-	DependencyFlags() : value(0) {
-	}
-	DependencyFlags(const DependencyFlags &other) : value(other.value) {
-	}
-	virtual ~DependencyFlags() = default;
-	DependencyFlags &operator=(const DependencyFlags &other) {
-		value = other.value;
-		return *this;
-	}
-	bool operator==(const DependencyFlags &other) const {
-		return other.value == value;
-	}
-	bool operator!=(const DependencyFlags &other) const {
-		return !(*this == other);
-	}
-
-public:
-	virtual string ToString() const = 0;
-
-protected:
-	template <uint8_t BIT>
-	bool IsSet() const {
-		static const uint8_t FLAG = (1 << BIT);
-		return (value & FLAG) == FLAG;
-	}
-	template <uint8_t BIT>
-	void Set() {
-		static const uint8_t FLAG = (1 << BIT);
-		value |= FLAG;
-	}
-	void Merge(uint8_t other) {
-		value |= other;
-	}
-	uint8_t Value() {
-		return value;
-	}
-
-private:
-	uint8_t value;
-};
-
-struct DependencySubjectFlags : public DependencyFlags {
-private:
-	static constexpr uint8_t OWNERSHIP = 0;
-
-public:
-	DependencySubjectFlags &Apply(DependencySubjectFlags other) {
-		Merge(other.Value());
-		return *this;
-	}
-
-public:
-	bool IsOwnership() const {
-		return IsSet<OWNERSHIP>();
-	}
-
-public:
-	DependencySubjectFlags &SetOwnership() {
-		Set<OWNERSHIP>();
-		return *this;
-	}
-
-public:
-	string ToString() const override {
-		string result;
-		if (IsOwnership()) {
-			result += "OWNS";
-		}
-		return result;
-	}
-};
-
-struct DependencyDependentFlags : public DependencyFlags {
-private:
-	static constexpr uint8_t BLOCKING = 0;
-	static constexpr uint8_t OWNED_BY = 1;
-
-public:
-	DependencyDependentFlags &Apply(DependencyDependentFlags other) {
-		Merge(other.Value());
-		return *this;
-	}
-
-public:
-	bool IsBlocking() const {
-		return IsSet<BLOCKING>();
-	}
-	bool IsOwnedBy() const {
-		return IsSet<OWNED_BY>();
-	}
-
-public:
-	DependencyDependentFlags &SetBlocking() {
-		Set<BLOCKING>();
-		return *this;
-	}
-	DependencyDependentFlags &SetOwnedBy() {
-		Set<OWNED_BY>();
-		return *this;
-	}
-
-public:
-	string ToString() const override {
-		string result;
-		if (IsBlocking()) {
-			result += "REGULAR";
-		} else {
-			result += "AUTOMATIC";
-		}
-		result += " | ";
-		if (IsOwnedBy()) {
-			result += "OWNED BY";
-		}
-		return result;
-	}
-};
-
-struct CatalogEntryInfo {
-public:
-	CatalogType type;
-	string schema;
-	string name;
-
-public:
-	bool operator==(const CatalogEntryInfo &other) const {
-		if (other.type != type) {
-			return false;
-		}
-		if (!StringUtil::CIEquals(other.schema, schema)) {
-			return false;
-		}
-		if (!StringUtil::CIEquals(other.name, name)) {
-			return false;
-		}
-		return true;
-	}
-
-public:
-	void Serialize(Serializer &serializer) const;
-	static CatalogEntryInfo Deserialize(Deserializer &deserializer);
-};
-
-struct Dependency {
-	Dependency(CatalogEntry &entry, // NOLINT: Allow implicit conversion from `CatalogEntry`
-	           DependencyDependentFlags flags = DependencyDependentFlags().SetBlocking())
-	    : entry(entry), flags(std::move(flags)) {
-	}
-
-	//! The catalog entry this depends on
-	reference<CatalogEntry> entry;
-	//! The type of dependency
-	DependencyDependentFlags flags;
-};
-
-struct DependencyHashFunction {
-	uint64_t operator()(const Dependency &a) const {
-		std::hash<void *> hash_func;
-		return hash_func((void *)&a.entry.get());
-	}
-};
-
-struct DependencyEquality {
-	bool operator()(const Dependency &a, const Dependency &b) const {
-		return RefersToSameObject(a.entry, b.entry);
-	}
-};
-using dependency_set_t = unordered_set<Dependency, DependencyHashFunction, DependencyEquality>;
-
-} // namespace duckdb
-
-
-namespace duckdb {
-class Catalog;
-class CatalogEntry;
-struct CreateInfo;
-class SchemaCatalogEntry;
-struct CatalogTransaction;
-class LogicalDependencyList;
-
-//! A minimal representation of a CreateInfo / CatalogEntry
-//! enough to look up the entry inside SchemaCatalogEntry::GetEntry
-struct LogicalDependency {
-public:
-	CatalogEntryInfo entry;
-	string catalog;
-
-public:
-	explicit LogicalDependency(CatalogEntry &entry);
-	LogicalDependency();
-	LogicalDependency(optional_ptr<Catalog> catalog, CatalogEntryInfo entry, string catalog_str);
-	bool operator==(const LogicalDependency &other) const;
-
-public:
-	void Serialize(Serializer &serializer) const;
-	static LogicalDependency Deserialize(Deserializer &deserializer);
-};
-
-struct LogicalDependencyHashFunction {
-	uint64_t operator()(const LogicalDependency &a) const;
-};
-
-struct LogicalDependencyEquality {
-	bool operator()(const LogicalDependency &a, const LogicalDependency &b) const;
-};
-
-//! The LogicalDependencyList containing LogicalDependency objects, not looked up in the catalog yet
-class LogicalDependencyList {
-	using create_info_set_t =
-	    unordered_set<LogicalDependency, LogicalDependencyHashFunction, LogicalDependencyEquality>;
-
-public:
-	DUCKDB_API void AddDependency(CatalogEntry &entry);
-	DUCKDB_API void AddDependency(const LogicalDependency &entry);
-	DUCKDB_API bool Contains(CatalogEntry &entry);
-
-public:
-	DUCKDB_API void VerifyDependencies(Catalog &catalog, const string &name);
-	void Serialize(Serializer &serializer) const;
-	static LogicalDependencyList Deserialize(Deserializer &deserializer);
-	bool operator==(const LogicalDependencyList &other) const;
-	const create_info_set_t &Set() const;
-
-private:
-	create_info_set_t set;
-};
-
-} // namespace duckdb
-
-
-namespace duckdb {
-class SchemaCatalogEntry;
-
-//! A StandardEntry is a catalog entry that is a member of a schema
-class StandardEntry : public InCatalogEntry {
-public:
-	StandardEntry(CatalogType type, SchemaCatalogEntry &schema, Catalog &catalog, string name)
-	    : InCatalogEntry(type, catalog, std::move(name)), schema(schema) {
-	}
-	~StandardEntry() override {
-	}
-
-	//! The schema the entry belongs to
-	SchemaCatalogEntry &schema;
-	//! The dependencies of the entry, can be empty
-	LogicalDependencyList dependencies;
-
-public:
-	SchemaCatalogEntry &ParentSchema() override {
-		return schema;
-	}
-	const SchemaCatalogEntry &ParentSchema() const override {
-		return schema;
-	}
-};
-
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/parsed_data/create_sequence_info.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/parsed_data/create_info.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/parsed_data/parse_info.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-namespace duckdb {
-
-enum class CatalogType : uint8_t;
-
-enum class ParseInfoType : uint8_t {
-	ALTER_INFO,
-	ATTACH_INFO,
-	COPY_INFO,
-	CREATE_INFO,
-	CREATE_SECRET_INFO,
-	DETACH_INFO,
-	DROP_INFO,
-	BOUND_EXPORT_DATA,
-	LOAD_INFO,
-	PRAGMA_INFO,
-	SHOW_SELECT_INFO,
-	TRANSACTION_INFO,
-	VACUUM_INFO,
-	COMMENT_ON_INFO,
-	COMMENT_ON_COLUMN_INFO,
-	COPY_DATABASE_INFO,
-	UPDATE_EXTENSIONS_INFO
-};
-
-struct ParseInfo {
-	explicit ParseInfo(ParseInfoType info_type) : info_type(info_type) {
-	}
-	virtual ~ParseInfo() {
-	}
-
-	ParseInfoType info_type;
-
-public:
-	template <class TARGET>
-	TARGET &Cast() {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<TARGET &>(*this);
-	}
-
-	template <class TARGET>
-	const TARGET &Cast() const {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-
-	virtual void Serialize(Serializer &serializer) const;
-	static unique_ptr<ParseInfo> Deserialize(Deserializer &deserializer);
-	static string QualifierToString(const string &catalog, const string &schema, const string &name);
-	static string TypeToString(CatalogType type);
-};
-
-} // namespace duckdb
-
-//-------------------------------------------------------------------------
-// This file is automatically generated by scripts/generate_enum_util.py
-// Do not edit this file manually, your changes will be overwritten
-// If you want to exclude an enum from serialization, add it to the blacklist in the script
-//
-// Note: The generated code will only work properly if the enum is a top level item in the duckdb namespace
-// If the enum is nested in a class, or in another namespace, the generated code will not compile.
-// You should move the enum to the duckdb namespace, manually write a specialization or add it to the blacklist
-//-------------------------------------------------------------------------
-
-
-
-
-#include <stdint.h>
-
-
-namespace duckdb {
-
-struct EnumUtil {
-    // String -> Enum
-    template <class T>
-    static T FromString(const char *value) = delete;
-
-    template <class T>
-    static T FromString(const string &value) { return FromString<T>(value.c_str()); }
-
-    // Enum -> String
-    template <class T>
-    static const char *ToChars(T value) = delete;
-
-    template <class T>
-    static string ToString(T value) { return string(ToChars<T>(value)); }
-};
-
-enum class ARTConflictType : uint8_t;
-
-enum class AccessMode : uint8_t;
-
-enum class AggregateCombineType : uint8_t;
-
-enum class AggregateDistinctDependent : uint8_t;
-
-enum class AggregateHandling : uint8_t;
-
-enum class AggregateOrderDependent : uint8_t;
-
-enum class AggregateType : uint8_t;
-
-enum class AlterForeignKeyType : uint8_t;
-
-enum class AlterScalarFunctionType : uint8_t;
-
-enum class AlterTableFunctionType : uint8_t;
-
-enum class AlterTableType : uint8_t;
-
-enum class AlterType : uint8_t;
-
-enum class AlterViewType : uint8_t;
-
-enum class AppenderType : uint8_t;
-
-enum class ArrowDateTimeType : uint8_t;
-
-enum class ArrowOffsetSize : uint8_t;
-
-enum class ArrowTypeInfoType : uint8_t;
-
-enum class ArrowVariableSizeType : uint8_t;
-
-enum class BinderType : uint8_t;
-
-enum class BindingMode : uint8_t;
-
-enum class BitpackingMode : uint8_t;
-
-enum class BlockState : uint8_t;
-
-enum class CAPIResultSetType : uint8_t;
-
-enum class CSVState : uint8_t;
-
-enum class CTEMaterialize : uint8_t;
-
-enum class CatalogLookupBehavior : uint8_t;
-
-enum class CatalogType : uint8_t;
-
-enum class CheckpointAbort : uint8_t;
-
-enum class ChunkInfoType : uint8_t;
-
-enum class ColumnDataAllocatorType : uint8_t;
-
-enum class ColumnDataScanProperties : uint8_t;
-
-enum class ColumnSegmentType : uint8_t;
-
-enum class CompressedMaterializationDirection : uint8_t;
-
-enum class CompressionType : uint8_t;
-
-enum class CompressionValidity : uint8_t;
-
-enum class ConflictManagerMode : uint8_t;
-
-enum class ConstraintType : uint8_t;
-
-enum class CopyFunctionReturnType : uint8_t;
-
-enum class CopyOverwriteMode : uint8_t;
-
-enum class CopyToType : uint8_t;
-
-enum class DataFileType : uint8_t;
-
-enum class DateCastResult : uint8_t;
-
-enum class DatePartSpecifier : uint8_t;
-
-enum class DebugInitialize : uint8_t;
-
-enum class DefaultOrderByNullType : uint8_t;
-
-enum class DependencyEntryType : uint8_t;
-
-enum class DeprecatedIndexType : uint8_t;
-
-enum class DestroyBufferUpon : uint8_t;
-
-enum class DistinctType : uint8_t;
-
-enum class ErrorType : uint16_t;
-
-enum class ExceptionFormatValueType : uint8_t;
-
-enum class ExceptionType : uint8_t;
-
-enum class ExplainFormat : uint8_t;
-
-enum class ExplainOutputType : uint8_t;
-
-enum class ExplainType : uint8_t;
-
-enum class ExponentType : uint8_t;
-
-enum class ExpressionClass : uint8_t;
-
-enum class ExpressionType : uint8_t;
-
-enum class ExtensionABIType : uint8_t;
-
-enum class ExtensionInstallMode : uint8_t;
-
-enum class ExtensionLoadResult : uint8_t;
-
-enum class ExtensionUpdateResultTag : uint8_t;
-
-enum class ExtraDropInfoType : uint8_t;
-
-enum class ExtraTypeInfoType : uint8_t;
-
-enum class FileBufferType : uint8_t;
-
-enum class FileCompressionType : uint8_t;
-
-enum class FileExpandResult : uint8_t;
-
-enum class FileGlobOptions : uint8_t;
-
-enum class FileLockType : uint8_t;
-
-enum class FilterPropagateResult : uint8_t;
-
-enum class ForeignKeyType : uint8_t;
-
-enum class FunctionCollationHandling : uint8_t;
-
-enum class FunctionErrors : uint8_t;
-
-enum class FunctionNullHandling : uint8_t;
-
-enum class FunctionStability : uint8_t;
-
-enum class GateStatus : uint8_t;
-
-enum class HLLStorageType : uint8_t;
-
-enum class IndexAppendMode : uint8_t;
-
-enum class IndexConstraintType : uint8_t;
-
-enum class InsertColumnOrder : uint8_t;
-
-enum class InterruptMode : uint8_t;
-
-enum class JoinRefType : uint8_t;
-
-enum class JoinType : uint8_t;
-
-enum class KeywordCategory : uint8_t;
-
-enum class LimitNodeType : uint8_t;
-
-enum class LoadType : uint8_t;
-
-enum class LogContextScope : uint8_t;
-
-enum class LogLevel : uint8_t;
-
-enum class LogMode : uint8_t;
-
-enum class LogicalOperatorType : uint8_t;
-
-enum class LogicalTypeId : uint8_t;
-
-enum class LookupResultType : uint8_t;
-
-enum class MacroType : uint8_t;
-
-enum class MapInvalidReason : uint8_t;
-
-enum class MemoryTag : uint8_t;
-
-enum class MetaPipelineType : uint8_t;
-
-enum class MetricsType : uint8_t;
-
-enum class MultiFileReaderColumnMappingMode : uint8_t;
-
-enum class NType : uint8_t;
-
-enum class NewLineIdentifier : uint8_t;
-
-enum class OnConflictAction : uint8_t;
-
-enum class OnCreateConflict : uint8_t;
-
-enum class OnEntryNotFound : uint8_t;
-
-enum class OperatorFinalizeResultType : uint8_t;
-
-enum class OperatorResultType : uint8_t;
-
-enum class OptimizerType : uint32_t;
-
-enum class OrderByNullType : uint8_t;
-
-enum class OrderPreservationType : uint8_t;
-
-enum class OrderType : uint8_t;
-
-enum class OutputStream : uint8_t;
-
-enum class ParseInfoType : uint8_t;
-
-enum class ParserExtensionResultType : uint8_t;
-
-enum class PartitionSortStage : uint8_t;
-
-enum class PartitionedColumnDataType : uint8_t;
-
-enum class PartitionedTupleDataType : uint8_t;
-
-enum class PendingExecutionResult : uint8_t;
-
-enum class PhysicalOperatorType : uint8_t;
-
-enum class PhysicalType : uint8_t;
-
-enum class PragmaType : uint8_t;
-
-enum class PreparedParamType : uint8_t;
-
-enum class PreparedStatementMode : uint8_t;
-
-enum class ProfilerPrintFormat : uint8_t;
-
-enum class QuantileSerializationType : uint8_t;
-
-enum class QueryNodeType : uint8_t;
-
-enum class QueryResultType : uint8_t;
-
-enum class QuoteRule : uint8_t;
-
-enum class RelationType : uint8_t;
-
-enum class RenderMode : uint8_t;
-
-enum class ResultModifierType : uint8_t;
-
-enum class SampleMethod : uint8_t;
-
-enum class SampleType : uint8_t;
-
-enum class SamplingState : uint8_t;
-
-enum class ScanType : uint8_t;
-
-enum class SecretDisplayType : uint8_t;
-
-enum class SecretPersistType : uint8_t;
-
-enum class SecretSerializationType : uint8_t;
-
-enum class SequenceInfo : uint8_t;
-
-enum class SetOperationType : uint8_t;
-
-enum class SetScope : uint8_t;
-
-enum class SetType : uint8_t;
-
-enum class SettingScope : uint8_t;
-
-enum class ShowType : uint8_t;
-
-enum class SimplifiedTokenType : uint8_t;
-
-enum class SinkCombineResultType : uint8_t;
-
-enum class SinkFinalizeType : uint8_t;
-
-enum class SinkNextBatchType : uint8_t;
-
-enum class SinkResultType : uint8_t;
-
-enum class SourceResultType : uint8_t;
-
-enum class StatementReturnType : uint8_t;
-
-enum class StatementType : uint8_t;
-
-enum class StatisticsType : uint8_t;
-
-enum class StatsInfo : uint8_t;
-
-enum class StrTimeSpecifier : uint8_t;
-
-enum class StreamExecutionResult : uint8_t;
-
-enum class SubqueryType : uint8_t;
-
-enum class TableColumnType : uint8_t;
-
-enum class TableFilterType : uint8_t;
-
-enum class TablePartitionInfo : uint8_t;
-
-enum class TableReferenceType : uint8_t;
-
-enum class TableScanType : uint8_t;
-
-enum class TaskExecutionMode : uint8_t;
-
-enum class TaskExecutionResult : uint8_t;
-
-enum class TemporaryBufferSize : uint64_t;
-
-enum class TemporaryCompressionLevel : int;
-
-enum class TimestampCastResult : uint8_t;
-
-enum class TransactionModifierType : uint8_t;
-
-enum class TransactionType : uint8_t;
-
-enum class TupleDataPinProperties : uint8_t;
-
-enum class UndoFlags : uint32_t;
-
-enum class UnionInvalidReason : uint8_t;
-
-enum class VectorAuxiliaryDataType : uint8_t;
-
-enum class VectorBufferType : uint8_t;
-
-enum class VectorType : uint8_t;
-
-enum class VerificationType : uint8_t;
-
-enum class VerifyExistenceType : uint8_t;
-
-enum class WALType : uint8_t;
-
-enum class WindowAggregationMode : uint32_t;
-
-enum class WindowBoundary : uint8_t;
-
-enum class WindowExcludeMode : uint8_t;
-
-
-template<>
-const char* EnumUtil::ToChars<ARTConflictType>(ARTConflictType value);
-
-template<>
-const char* EnumUtil::ToChars<AccessMode>(AccessMode value);
-
-template<>
-const char* EnumUtil::ToChars<AggregateCombineType>(AggregateCombineType value);
-
-template<>
-const char* EnumUtil::ToChars<AggregateDistinctDependent>(AggregateDistinctDependent value);
-
-template<>
-const char* EnumUtil::ToChars<AggregateHandling>(AggregateHandling value);
-
-template<>
-const char* EnumUtil::ToChars<AggregateOrderDependent>(AggregateOrderDependent value);
-
-template<>
-const char* EnumUtil::ToChars<AggregateType>(AggregateType value);
-
-template<>
-const char* EnumUtil::ToChars<AlterForeignKeyType>(AlterForeignKeyType value);
-
-template<>
-const char* EnumUtil::ToChars<AlterScalarFunctionType>(AlterScalarFunctionType value);
-
-template<>
-const char* EnumUtil::ToChars<AlterTableFunctionType>(AlterTableFunctionType value);
-
-template<>
-const char* EnumUtil::ToChars<AlterTableType>(AlterTableType value);
-
-template<>
-const char* EnumUtil::ToChars<AlterType>(AlterType value);
-
-template<>
-const char* EnumUtil::ToChars<AlterViewType>(AlterViewType value);
-
-template<>
-const char* EnumUtil::ToChars<AppenderType>(AppenderType value);
-
-template<>
-const char* EnumUtil::ToChars<ArrowDateTimeType>(ArrowDateTimeType value);
-
-template<>
-const char* EnumUtil::ToChars<ArrowOffsetSize>(ArrowOffsetSize value);
-
-template<>
-const char* EnumUtil::ToChars<ArrowTypeInfoType>(ArrowTypeInfoType value);
-
-template<>
-const char* EnumUtil::ToChars<ArrowVariableSizeType>(ArrowVariableSizeType value);
-
-template<>
-const char* EnumUtil::ToChars<BinderType>(BinderType value);
-
-template<>
-const char* EnumUtil::ToChars<BindingMode>(BindingMode value);
-
-template<>
-const char* EnumUtil::ToChars<BitpackingMode>(BitpackingMode value);
-
-template<>
-const char* EnumUtil::ToChars<BlockState>(BlockState value);
-
-template<>
-const char* EnumUtil::ToChars<CAPIResultSetType>(CAPIResultSetType value);
-
-template<>
-const char* EnumUtil::ToChars<CSVState>(CSVState value);
-
-template<>
-const char* EnumUtil::ToChars<CTEMaterialize>(CTEMaterialize value);
-
-template<>
-const char* EnumUtil::ToChars<CatalogLookupBehavior>(CatalogLookupBehavior value);
-
-template<>
-const char* EnumUtil::ToChars<CatalogType>(CatalogType value);
-
-template<>
-const char* EnumUtil::ToChars<CheckpointAbort>(CheckpointAbort value);
-
-template<>
-const char* EnumUtil::ToChars<ChunkInfoType>(ChunkInfoType value);
-
-template<>
-const char* EnumUtil::ToChars<ColumnDataAllocatorType>(ColumnDataAllocatorType value);
-
-template<>
-const char* EnumUtil::ToChars<ColumnDataScanProperties>(ColumnDataScanProperties value);
-
-template<>
-const char* EnumUtil::ToChars<ColumnSegmentType>(ColumnSegmentType value);
-
-template<>
-const char* EnumUtil::ToChars<CompressedMaterializationDirection>(CompressedMaterializationDirection value);
-
-template<>
-const char* EnumUtil::ToChars<CompressionType>(CompressionType value);
-
-template<>
-const char* EnumUtil::ToChars<CompressionValidity>(CompressionValidity value);
-
-template<>
-const char* EnumUtil::ToChars<ConflictManagerMode>(ConflictManagerMode value);
-
-template<>
-const char* EnumUtil::ToChars<ConstraintType>(ConstraintType value);
-
-template<>
-const char* EnumUtil::ToChars<CopyFunctionReturnType>(CopyFunctionReturnType value);
-
-template<>
-const char* EnumUtil::ToChars<CopyOverwriteMode>(CopyOverwriteMode value);
-
-template<>
-const char* EnumUtil::ToChars<CopyToType>(CopyToType value);
-
-template<>
-const char* EnumUtil::ToChars<DataFileType>(DataFileType value);
-
-template<>
-const char* EnumUtil::ToChars<DateCastResult>(DateCastResult value);
-
-template<>
-const char* EnumUtil::ToChars<DatePartSpecifier>(DatePartSpecifier value);
-
-template<>
-const char* EnumUtil::ToChars<DebugInitialize>(DebugInitialize value);
-
-template<>
-const char* EnumUtil::ToChars<DefaultOrderByNullType>(DefaultOrderByNullType value);
-
-template<>
-const char* EnumUtil::ToChars<DependencyEntryType>(DependencyEntryType value);
-
-template<>
-const char* EnumUtil::ToChars<DeprecatedIndexType>(DeprecatedIndexType value);
-
-template<>
-const char* EnumUtil::ToChars<DestroyBufferUpon>(DestroyBufferUpon value);
-
-template<>
-const char* EnumUtil::ToChars<DistinctType>(DistinctType value);
-
-template<>
-const char* EnumUtil::ToChars<ErrorType>(ErrorType value);
-
-template<>
-const char* EnumUtil::ToChars<ExceptionFormatValueType>(ExceptionFormatValueType value);
-
-template<>
-const char* EnumUtil::ToChars<ExceptionType>(ExceptionType value);
-
-template<>
-const char* EnumUtil::ToChars<ExplainFormat>(ExplainFormat value);
-
-template<>
-const char* EnumUtil::ToChars<ExplainOutputType>(ExplainOutputType value);
-
-template<>
-const char* EnumUtil::ToChars<ExplainType>(ExplainType value);
-
-template<>
-const char* EnumUtil::ToChars<ExponentType>(ExponentType value);
-
-template<>
-const char* EnumUtil::ToChars<ExpressionClass>(ExpressionClass value);
-
-template<>
-const char* EnumUtil::ToChars<ExpressionType>(ExpressionType value);
-
-template<>
-const char* EnumUtil::ToChars<ExtensionABIType>(ExtensionABIType value);
-
-template<>
-const char* EnumUtil::ToChars<ExtensionInstallMode>(ExtensionInstallMode value);
-
-template<>
-const char* EnumUtil::ToChars<ExtensionLoadResult>(ExtensionLoadResult value);
-
-template<>
-const char* EnumUtil::ToChars<ExtensionUpdateResultTag>(ExtensionUpdateResultTag value);
-
-template<>
-const char* EnumUtil::ToChars<ExtraDropInfoType>(ExtraDropInfoType value);
-
-template<>
-const char* EnumUtil::ToChars<ExtraTypeInfoType>(ExtraTypeInfoType value);
-
-template<>
-const char* EnumUtil::ToChars<FileBufferType>(FileBufferType value);
-
-template<>
-const char* EnumUtil::ToChars<FileCompressionType>(FileCompressionType value);
-
-template<>
-const char* EnumUtil::ToChars<FileExpandResult>(FileExpandResult value);
-
-template<>
-const char* EnumUtil::ToChars<FileGlobOptions>(FileGlobOptions value);
-
-template<>
-const char* EnumUtil::ToChars<FileLockType>(FileLockType value);
-
-template<>
-const char* EnumUtil::ToChars<FilterPropagateResult>(FilterPropagateResult value);
-
-template<>
-const char* EnumUtil::ToChars<ForeignKeyType>(ForeignKeyType value);
-
-template<>
-const char* EnumUtil::ToChars<FunctionCollationHandling>(FunctionCollationHandling value);
-
-template<>
-const char* EnumUtil::ToChars<FunctionErrors>(FunctionErrors value);
-
-template<>
-const char* EnumUtil::ToChars<FunctionNullHandling>(FunctionNullHandling value);
-
-template<>
-const char* EnumUtil::ToChars<FunctionStability>(FunctionStability value);
-
-template<>
-const char* EnumUtil::ToChars<GateStatus>(GateStatus value);
-
-template<>
-const char* EnumUtil::ToChars<HLLStorageType>(HLLStorageType value);
-
-template<>
-const char* EnumUtil::ToChars<IndexAppendMode>(IndexAppendMode value);
-
-template<>
-const char* EnumUtil::ToChars<IndexConstraintType>(IndexConstraintType value);
-
-template<>
-const char* EnumUtil::ToChars<InsertColumnOrder>(InsertColumnOrder value);
-
-template<>
-const char* EnumUtil::ToChars<InterruptMode>(InterruptMode value);
-
-template<>
-const char* EnumUtil::ToChars<JoinRefType>(JoinRefType value);
-
-template<>
-const char* EnumUtil::ToChars<JoinType>(JoinType value);
-
-template<>
-const char* EnumUtil::ToChars<KeywordCategory>(KeywordCategory value);
-
-template<>
-const char* EnumUtil::ToChars<LimitNodeType>(LimitNodeType value);
-
-template<>
-const char* EnumUtil::ToChars<LoadType>(LoadType value);
-
-template<>
-const char* EnumUtil::ToChars<LogContextScope>(LogContextScope value);
-
-template<>
-const char* EnumUtil::ToChars<LogLevel>(LogLevel value);
-
-template<>
-const char* EnumUtil::ToChars<LogMode>(LogMode value);
-
-template<>
-const char* EnumUtil::ToChars<LogicalOperatorType>(LogicalOperatorType value);
-
-template<>
-const char* EnumUtil::ToChars<LogicalTypeId>(LogicalTypeId value);
-
-template<>
-const char* EnumUtil::ToChars<LookupResultType>(LookupResultType value);
-
-template<>
-const char* EnumUtil::ToChars<MacroType>(MacroType value);
-
-template<>
-const char* EnumUtil::ToChars<MapInvalidReason>(MapInvalidReason value);
-
-template<>
-const char* EnumUtil::ToChars<MemoryTag>(MemoryTag value);
-
-template<>
-const char* EnumUtil::ToChars<MetaPipelineType>(MetaPipelineType value);
-
-template<>
-const char* EnumUtil::ToChars<MetricsType>(MetricsType value);
-
-template<>
-const char* EnumUtil::ToChars<MultiFileReaderColumnMappingMode>(MultiFileReaderColumnMappingMode value);
-
-template<>
-const char* EnumUtil::ToChars<NType>(NType value);
-
-template<>
-const char* EnumUtil::ToChars<NewLineIdentifier>(NewLineIdentifier value);
-
-template<>
-const char* EnumUtil::ToChars<OnConflictAction>(OnConflictAction value);
-
-template<>
-const char* EnumUtil::ToChars<OnCreateConflict>(OnCreateConflict value);
-
-template<>
-const char* EnumUtil::ToChars<OnEntryNotFound>(OnEntryNotFound value);
-
-template<>
-const char* EnumUtil::ToChars<OperatorFinalizeResultType>(OperatorFinalizeResultType value);
-
-template<>
-const char* EnumUtil::ToChars<OperatorResultType>(OperatorResultType value);
-
-template<>
-const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value);
-
-template<>
-const char* EnumUtil::ToChars<OrderByNullType>(OrderByNullType value);
-
-template<>
-const char* EnumUtil::ToChars<OrderPreservationType>(OrderPreservationType value);
-
-template<>
-const char* EnumUtil::ToChars<OrderType>(OrderType value);
-
-template<>
-const char* EnumUtil::ToChars<OutputStream>(OutputStream value);
-
-template<>
-const char* EnumUtil::ToChars<ParseInfoType>(ParseInfoType value);
-
-template<>
-const char* EnumUtil::ToChars<ParserExtensionResultType>(ParserExtensionResultType value);
-
-template<>
-const char* EnumUtil::ToChars<PartitionSortStage>(PartitionSortStage value);
-
-template<>
-const char* EnumUtil::ToChars<PartitionedColumnDataType>(PartitionedColumnDataType value);
-
-template<>
-const char* EnumUtil::ToChars<PartitionedTupleDataType>(PartitionedTupleDataType value);
-
-template<>
-const char* EnumUtil::ToChars<PendingExecutionResult>(PendingExecutionResult value);
-
-template<>
-const char* EnumUtil::ToChars<PhysicalOperatorType>(PhysicalOperatorType value);
-
-template<>
-const char* EnumUtil::ToChars<PhysicalType>(PhysicalType value);
-
-template<>
-const char* EnumUtil::ToChars<PragmaType>(PragmaType value);
-
-template<>
-const char* EnumUtil::ToChars<PreparedParamType>(PreparedParamType value);
-
-template<>
-const char* EnumUtil::ToChars<PreparedStatementMode>(PreparedStatementMode value);
-
-template<>
-const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value);
-
-template<>
-const char* EnumUtil::ToChars<QuantileSerializationType>(QuantileSerializationType value);
-
-template<>
-const char* EnumUtil::ToChars<QueryNodeType>(QueryNodeType value);
-
-template<>
-const char* EnumUtil::ToChars<QueryResultType>(QueryResultType value);
-
-template<>
-const char* EnumUtil::ToChars<QuoteRule>(QuoteRule value);
-
-template<>
-const char* EnumUtil::ToChars<RelationType>(RelationType value);
-
-template<>
-const char* EnumUtil::ToChars<RenderMode>(RenderMode value);
-
-template<>
-const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value);
-
-template<>
-const char* EnumUtil::ToChars<SampleMethod>(SampleMethod value);
-
-template<>
-const char* EnumUtil::ToChars<SampleType>(SampleType value);
-
-template<>
-const char* EnumUtil::ToChars<SamplingState>(SamplingState value);
-
-template<>
-const char* EnumUtil::ToChars<ScanType>(ScanType value);
-
-template<>
-const char* EnumUtil::ToChars<SecretDisplayType>(SecretDisplayType value);
-
-template<>
-const char* EnumUtil::ToChars<SecretPersistType>(SecretPersistType value);
-
-template<>
-const char* EnumUtil::ToChars<SecretSerializationType>(SecretSerializationType value);
-
-template<>
-const char* EnumUtil::ToChars<SequenceInfo>(SequenceInfo value);
-
-template<>
-const char* EnumUtil::ToChars<SetOperationType>(SetOperationType value);
-
-template<>
-const char* EnumUtil::ToChars<SetScope>(SetScope value);
-
-template<>
-const char* EnumUtil::ToChars<SetType>(SetType value);
-
-template<>
-const char* EnumUtil::ToChars<SettingScope>(SettingScope value);
-
-template<>
-const char* EnumUtil::ToChars<ShowType>(ShowType value);
-
-template<>
-const char* EnumUtil::ToChars<SimplifiedTokenType>(SimplifiedTokenType value);
-
-template<>
-const char* EnumUtil::ToChars<SinkCombineResultType>(SinkCombineResultType value);
-
-template<>
-const char* EnumUtil::ToChars<SinkFinalizeType>(SinkFinalizeType value);
-
-template<>
-const char* EnumUtil::ToChars<SinkNextBatchType>(SinkNextBatchType value);
-
-template<>
-const char* EnumUtil::ToChars<SinkResultType>(SinkResultType value);
-
-template<>
-const char* EnumUtil::ToChars<SourceResultType>(SourceResultType value);
-
-template<>
-const char* EnumUtil::ToChars<StatementReturnType>(StatementReturnType value);
-
-template<>
-const char* EnumUtil::ToChars<StatementType>(StatementType value);
-
-template<>
-const char* EnumUtil::ToChars<StatisticsType>(StatisticsType value);
-
-template<>
-const char* EnumUtil::ToChars<StatsInfo>(StatsInfo value);
-
-template<>
-const char* EnumUtil::ToChars<StrTimeSpecifier>(StrTimeSpecifier value);
-
-template<>
-const char* EnumUtil::ToChars<StreamExecutionResult>(StreamExecutionResult value);
-
-template<>
-const char* EnumUtil::ToChars<SubqueryType>(SubqueryType value);
-
-template<>
-const char* EnumUtil::ToChars<TableColumnType>(TableColumnType value);
-
-template<>
-const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value);
-
-template<>
-const char* EnumUtil::ToChars<TablePartitionInfo>(TablePartitionInfo value);
-
-template<>
-const char* EnumUtil::ToChars<TableReferenceType>(TableReferenceType value);
-
-template<>
-const char* EnumUtil::ToChars<TableScanType>(TableScanType value);
-
-template<>
-const char* EnumUtil::ToChars<TaskExecutionMode>(TaskExecutionMode value);
-
-template<>
-const char* EnumUtil::ToChars<TaskExecutionResult>(TaskExecutionResult value);
-
-template<>
-const char* EnumUtil::ToChars<TemporaryBufferSize>(TemporaryBufferSize value);
-
-template<>
-const char* EnumUtil::ToChars<TemporaryCompressionLevel>(TemporaryCompressionLevel value);
-
-template<>
-const char* EnumUtil::ToChars<TimestampCastResult>(TimestampCastResult value);
-
-template<>
-const char* EnumUtil::ToChars<TransactionModifierType>(TransactionModifierType value);
-
-template<>
-const char* EnumUtil::ToChars<TransactionType>(TransactionType value);
-
-template<>
-const char* EnumUtil::ToChars<TupleDataPinProperties>(TupleDataPinProperties value);
-
-template<>
-const char* EnumUtil::ToChars<UndoFlags>(UndoFlags value);
-
-template<>
-const char* EnumUtil::ToChars<UnionInvalidReason>(UnionInvalidReason value);
-
-template<>
-const char* EnumUtil::ToChars<VectorAuxiliaryDataType>(VectorAuxiliaryDataType value);
-
-template<>
-const char* EnumUtil::ToChars<VectorBufferType>(VectorBufferType value);
-
-template<>
-const char* EnumUtil::ToChars<VectorType>(VectorType value);
-
-template<>
-const char* EnumUtil::ToChars<VerificationType>(VerificationType value);
-
-template<>
-const char* EnumUtil::ToChars<VerifyExistenceType>(VerifyExistenceType value);
-
-template<>
-const char* EnumUtil::ToChars<WALType>(WALType value);
-
-template<>
-const char* EnumUtil::ToChars<WindowAggregationMode>(WindowAggregationMode value);
-
-template<>
-const char* EnumUtil::ToChars<WindowBoundary>(WindowBoundary value);
-
-template<>
-const char* EnumUtil::ToChars<WindowExcludeMode>(WindowExcludeMode value);
-
-
-template<>
-ARTConflictType EnumUtil::FromString<ARTConflictType>(const char *value);
-
-template<>
-AccessMode EnumUtil::FromString<AccessMode>(const char *value);
-
-template<>
-AggregateCombineType EnumUtil::FromString<AggregateCombineType>(const char *value);
-
-template<>
-AggregateDistinctDependent EnumUtil::FromString<AggregateDistinctDependent>(const char *value);
-
-template<>
-AggregateHandling EnumUtil::FromString<AggregateHandling>(const char *value);
-
-template<>
-AggregateOrderDependent EnumUtil::FromString<AggregateOrderDependent>(const char *value);
-
-template<>
-AggregateType EnumUtil::FromString<AggregateType>(const char *value);
-
-template<>
-AlterForeignKeyType EnumUtil::FromString<AlterForeignKeyType>(const char *value);
-
-template<>
-AlterScalarFunctionType EnumUtil::FromString<AlterScalarFunctionType>(const char *value);
-
-template<>
-AlterTableFunctionType EnumUtil::FromString<AlterTableFunctionType>(const char *value);
-
-template<>
-AlterTableType EnumUtil::FromString<AlterTableType>(const char *value);
-
-template<>
-AlterType EnumUtil::FromString<AlterType>(const char *value);
-
-template<>
-AlterViewType EnumUtil::FromString<AlterViewType>(const char *value);
-
-template<>
-AppenderType EnumUtil::FromString<AppenderType>(const char *value);
-
-template<>
-ArrowDateTimeType EnumUtil::FromString<ArrowDateTimeType>(const char *value);
-
-template<>
-ArrowOffsetSize EnumUtil::FromString<ArrowOffsetSize>(const char *value);
-
-template<>
-ArrowTypeInfoType EnumUtil::FromString<ArrowTypeInfoType>(const char *value);
-
-template<>
-ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *value);
-
-template<>
-BinderType EnumUtil::FromString<BinderType>(const char *value);
-
-template<>
-BindingMode EnumUtil::FromString<BindingMode>(const char *value);
-
-template<>
-BitpackingMode EnumUtil::FromString<BitpackingMode>(const char *value);
-
-template<>
-BlockState EnumUtil::FromString<BlockState>(const char *value);
-
-template<>
-CAPIResultSetType EnumUtil::FromString<CAPIResultSetType>(const char *value);
-
-template<>
-CSVState EnumUtil::FromString<CSVState>(const char *value);
-
-template<>
-CTEMaterialize EnumUtil::FromString<CTEMaterialize>(const char *value);
-
-template<>
-CatalogLookupBehavior EnumUtil::FromString<CatalogLookupBehavior>(const char *value);
-
-template<>
-CatalogType EnumUtil::FromString<CatalogType>(const char *value);
-
-template<>
-CheckpointAbort EnumUtil::FromString<CheckpointAbort>(const char *value);
-
-template<>
-ChunkInfoType EnumUtil::FromString<ChunkInfoType>(const char *value);
-
-template<>
-ColumnDataAllocatorType EnumUtil::FromString<ColumnDataAllocatorType>(const char *value);
-
-template<>
-ColumnDataScanProperties EnumUtil::FromString<ColumnDataScanProperties>(const char *value);
-
-template<>
-ColumnSegmentType EnumUtil::FromString<ColumnSegmentType>(const char *value);
-
-template<>
-CompressedMaterializationDirection EnumUtil::FromString<CompressedMaterializationDirection>(const char *value);
-
-template<>
-CompressionType EnumUtil::FromString<CompressionType>(const char *value);
-
-template<>
-CompressionValidity EnumUtil::FromString<CompressionValidity>(const char *value);
-
-template<>
-ConflictManagerMode EnumUtil::FromString<ConflictManagerMode>(const char *value);
-
-template<>
-ConstraintType EnumUtil::FromString<ConstraintType>(const char *value);
-
-template<>
-CopyFunctionReturnType EnumUtil::FromString<CopyFunctionReturnType>(const char *value);
-
-template<>
-CopyOverwriteMode EnumUtil::FromString<CopyOverwriteMode>(const char *value);
-
-template<>
-CopyToType EnumUtil::FromString<CopyToType>(const char *value);
-
-template<>
-DataFileType EnumUtil::FromString<DataFileType>(const char *value);
-
-template<>
-DateCastResult EnumUtil::FromString<DateCastResult>(const char *value);
-
-template<>
-DatePartSpecifier EnumUtil::FromString<DatePartSpecifier>(const char *value);
-
-template<>
-DebugInitialize EnumUtil::FromString<DebugInitialize>(const char *value);
-
-template<>
-DefaultOrderByNullType EnumUtil::FromString<DefaultOrderByNullType>(const char *value);
-
-template<>
-DependencyEntryType EnumUtil::FromString<DependencyEntryType>(const char *value);
-
-template<>
-DeprecatedIndexType EnumUtil::FromString<DeprecatedIndexType>(const char *value);
-
-template<>
-DestroyBufferUpon EnumUtil::FromString<DestroyBufferUpon>(const char *value);
-
-template<>
-DistinctType EnumUtil::FromString<DistinctType>(const char *value);
-
-template<>
-ErrorType EnumUtil::FromString<ErrorType>(const char *value);
-
-template<>
-ExceptionFormatValueType EnumUtil::FromString<ExceptionFormatValueType>(const char *value);
-
-template<>
-ExceptionType EnumUtil::FromString<ExceptionType>(const char *value);
-
-template<>
-ExplainFormat EnumUtil::FromString<ExplainFormat>(const char *value);
-
-template<>
-ExplainOutputType EnumUtil::FromString<ExplainOutputType>(const char *value);
-
-template<>
-ExplainType EnumUtil::FromString<ExplainType>(const char *value);
-
-template<>
-ExponentType EnumUtil::FromString<ExponentType>(const char *value);
-
-template<>
-ExpressionClass EnumUtil::FromString<ExpressionClass>(const char *value);
-
-template<>
-ExpressionType EnumUtil::FromString<ExpressionType>(const char *value);
-
-template<>
-ExtensionABIType EnumUtil::FromString<ExtensionABIType>(const char *value);
-
-template<>
-ExtensionInstallMode EnumUtil::FromString<ExtensionInstallMode>(const char *value);
-
-template<>
-ExtensionLoadResult EnumUtil::FromString<ExtensionLoadResult>(const char *value);
-
-template<>
-ExtensionUpdateResultTag EnumUtil::FromString<ExtensionUpdateResultTag>(const char *value);
-
-template<>
-ExtraDropInfoType EnumUtil::FromString<ExtraDropInfoType>(const char *value);
-
-template<>
-ExtraTypeInfoType EnumUtil::FromString<ExtraTypeInfoType>(const char *value);
-
-template<>
-FileBufferType EnumUtil::FromString<FileBufferType>(const char *value);
-
-template<>
-FileCompressionType EnumUtil::FromString<FileCompressionType>(const char *value);
-
-template<>
-FileExpandResult EnumUtil::FromString<FileExpandResult>(const char *value);
-
-template<>
-FileGlobOptions EnumUtil::FromString<FileGlobOptions>(const char *value);
-
-template<>
-FileLockType EnumUtil::FromString<FileLockType>(const char *value);
-
-template<>
-FilterPropagateResult EnumUtil::FromString<FilterPropagateResult>(const char *value);
-
-template<>
-ForeignKeyType EnumUtil::FromString<ForeignKeyType>(const char *value);
-
-template<>
-FunctionCollationHandling EnumUtil::FromString<FunctionCollationHandling>(const char *value);
-
-template<>
-FunctionErrors EnumUtil::FromString<FunctionErrors>(const char *value);
-
-template<>
-FunctionNullHandling EnumUtil::FromString<FunctionNullHandling>(const char *value);
-
-template<>
-FunctionStability EnumUtil::FromString<FunctionStability>(const char *value);
-
-template<>
-GateStatus EnumUtil::FromString<GateStatus>(const char *value);
-
-template<>
-HLLStorageType EnumUtil::FromString<HLLStorageType>(const char *value);
-
-template<>
-IndexAppendMode EnumUtil::FromString<IndexAppendMode>(const char *value);
-
-template<>
-IndexConstraintType EnumUtil::FromString<IndexConstraintType>(const char *value);
-
-template<>
-InsertColumnOrder EnumUtil::FromString<InsertColumnOrder>(const char *value);
-
-template<>
-InterruptMode EnumUtil::FromString<InterruptMode>(const char *value);
-
-template<>
-JoinRefType EnumUtil::FromString<JoinRefType>(const char *value);
-
-template<>
-JoinType EnumUtil::FromString<JoinType>(const char *value);
-
-template<>
-KeywordCategory EnumUtil::FromString<KeywordCategory>(const char *value);
-
-template<>
-LimitNodeType EnumUtil::FromString<LimitNodeType>(const char *value);
-
-template<>
-LoadType EnumUtil::FromString<LoadType>(const char *value);
-
-template<>
-LogContextScope EnumUtil::FromString<LogContextScope>(const char *value);
-
-template<>
-LogLevel EnumUtil::FromString<LogLevel>(const char *value);
-
-template<>
-LogMode EnumUtil::FromString<LogMode>(const char *value);
-
-template<>
-LogicalOperatorType EnumUtil::FromString<LogicalOperatorType>(const char *value);
-
-template<>
-LogicalTypeId EnumUtil::FromString<LogicalTypeId>(const char *value);
-
-template<>
-LookupResultType EnumUtil::FromString<LookupResultType>(const char *value);
-
-template<>
-MacroType EnumUtil::FromString<MacroType>(const char *value);
-
-template<>
-MapInvalidReason EnumUtil::FromString<MapInvalidReason>(const char *value);
-
-template<>
-MemoryTag EnumUtil::FromString<MemoryTag>(const char *value);
-
-template<>
-MetaPipelineType EnumUtil::FromString<MetaPipelineType>(const char *value);
-
-template<>
-MetricsType EnumUtil::FromString<MetricsType>(const char *value);
-
-template<>
-MultiFileReaderColumnMappingMode EnumUtil::FromString<MultiFileReaderColumnMappingMode>(const char *value);
-
-template<>
-NType EnumUtil::FromString<NType>(const char *value);
-
-template<>
-NewLineIdentifier EnumUtil::FromString<NewLineIdentifier>(const char *value);
-
-template<>
-OnConflictAction EnumUtil::FromString<OnConflictAction>(const char *value);
-
-template<>
-OnCreateConflict EnumUtil::FromString<OnCreateConflict>(const char *value);
-
-template<>
-OnEntryNotFound EnumUtil::FromString<OnEntryNotFound>(const char *value);
-
-template<>
-OperatorFinalizeResultType EnumUtil::FromString<OperatorFinalizeResultType>(const char *value);
-
-template<>
-OperatorResultType EnumUtil::FromString<OperatorResultType>(const char *value);
-
-template<>
-OptimizerType EnumUtil::FromString<OptimizerType>(const char *value);
-
-template<>
-OrderByNullType EnumUtil::FromString<OrderByNullType>(const char *value);
-
-template<>
-OrderPreservationType EnumUtil::FromString<OrderPreservationType>(const char *value);
-
-template<>
-OrderType EnumUtil::FromString<OrderType>(const char *value);
-
-template<>
-OutputStream EnumUtil::FromString<OutputStream>(const char *value);
-
-template<>
-ParseInfoType EnumUtil::FromString<ParseInfoType>(const char *value);
-
-template<>
-ParserExtensionResultType EnumUtil::FromString<ParserExtensionResultType>(const char *value);
-
-template<>
-PartitionSortStage EnumUtil::FromString<PartitionSortStage>(const char *value);
-
-template<>
-PartitionedColumnDataType EnumUtil::FromString<PartitionedColumnDataType>(const char *value);
-
-template<>
-PartitionedTupleDataType EnumUtil::FromString<PartitionedTupleDataType>(const char *value);
-
-template<>
-PendingExecutionResult EnumUtil::FromString<PendingExecutionResult>(const char *value);
-
-template<>
-PhysicalOperatorType EnumUtil::FromString<PhysicalOperatorType>(const char *value);
-
-template<>
-PhysicalType EnumUtil::FromString<PhysicalType>(const char *value);
-
-template<>
-PragmaType EnumUtil::FromString<PragmaType>(const char *value);
-
-template<>
-PreparedParamType EnumUtil::FromString<PreparedParamType>(const char *value);
-
-template<>
-PreparedStatementMode EnumUtil::FromString<PreparedStatementMode>(const char *value);
-
-template<>
-ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value);
-
-template<>
-QuantileSerializationType EnumUtil::FromString<QuantileSerializationType>(const char *value);
-
-template<>
-QueryNodeType EnumUtil::FromString<QueryNodeType>(const char *value);
-
-template<>
-QueryResultType EnumUtil::FromString<QueryResultType>(const char *value);
-
-template<>
-QuoteRule EnumUtil::FromString<QuoteRule>(const char *value);
-
-template<>
-RelationType EnumUtil::FromString<RelationType>(const char *value);
-
-template<>
-RenderMode EnumUtil::FromString<RenderMode>(const char *value);
-
-template<>
-ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value);
-
-template<>
-SampleMethod EnumUtil::FromString<SampleMethod>(const char *value);
-
-template<>
-SampleType EnumUtil::FromString<SampleType>(const char *value);
-
-template<>
-SamplingState EnumUtil::FromString<SamplingState>(const char *value);
-
-template<>
-ScanType EnumUtil::FromString<ScanType>(const char *value);
-
-template<>
-SecretDisplayType EnumUtil::FromString<SecretDisplayType>(const char *value);
-
-template<>
-SecretPersistType EnumUtil::FromString<SecretPersistType>(const char *value);
-
-template<>
-SecretSerializationType EnumUtil::FromString<SecretSerializationType>(const char *value);
-
-template<>
-SequenceInfo EnumUtil::FromString<SequenceInfo>(const char *value);
-
-template<>
-SetOperationType EnumUtil::FromString<SetOperationType>(const char *value);
-
-template<>
-SetScope EnumUtil::FromString<SetScope>(const char *value);
-
-template<>
-SetType EnumUtil::FromString<SetType>(const char *value);
-
-template<>
-SettingScope EnumUtil::FromString<SettingScope>(const char *value);
-
-template<>
-ShowType EnumUtil::FromString<ShowType>(const char *value);
-
-template<>
-SimplifiedTokenType EnumUtil::FromString<SimplifiedTokenType>(const char *value);
-
-template<>
-SinkCombineResultType EnumUtil::FromString<SinkCombineResultType>(const char *value);
-
-template<>
-SinkFinalizeType EnumUtil::FromString<SinkFinalizeType>(const char *value);
-
-template<>
-SinkNextBatchType EnumUtil::FromString<SinkNextBatchType>(const char *value);
-
-template<>
-SinkResultType EnumUtil::FromString<SinkResultType>(const char *value);
-
-template<>
-SourceResultType EnumUtil::FromString<SourceResultType>(const char *value);
-
-template<>
-StatementReturnType EnumUtil::FromString<StatementReturnType>(const char *value);
-
-template<>
-StatementType EnumUtil::FromString<StatementType>(const char *value);
-
-template<>
-StatisticsType EnumUtil::FromString<StatisticsType>(const char *value);
-
-template<>
-StatsInfo EnumUtil::FromString<StatsInfo>(const char *value);
-
-template<>
-StrTimeSpecifier EnumUtil::FromString<StrTimeSpecifier>(const char *value);
-
-template<>
-StreamExecutionResult EnumUtil::FromString<StreamExecutionResult>(const char *value);
-
-template<>
-SubqueryType EnumUtil::FromString<SubqueryType>(const char *value);
-
-template<>
-TableColumnType EnumUtil::FromString<TableColumnType>(const char *value);
-
-template<>
-TableFilterType EnumUtil::FromString<TableFilterType>(const char *value);
-
-template<>
-TablePartitionInfo EnumUtil::FromString<TablePartitionInfo>(const char *value);
-
-template<>
-TableReferenceType EnumUtil::FromString<TableReferenceType>(const char *value);
-
-template<>
-TableScanType EnumUtil::FromString<TableScanType>(const char *value);
-
-template<>
-TaskExecutionMode EnumUtil::FromString<TaskExecutionMode>(const char *value);
-
-template<>
-TaskExecutionResult EnumUtil::FromString<TaskExecutionResult>(const char *value);
-
-template<>
-TemporaryBufferSize EnumUtil::FromString<TemporaryBufferSize>(const char *value);
-
-template<>
-TemporaryCompressionLevel EnumUtil::FromString<TemporaryCompressionLevel>(const char *value);
-
-template<>
-TimestampCastResult EnumUtil::FromString<TimestampCastResult>(const char *value);
-
-template<>
-TransactionModifierType EnumUtil::FromString<TransactionModifierType>(const char *value);
-
-template<>
-TransactionType EnumUtil::FromString<TransactionType>(const char *value);
-
-template<>
-TupleDataPinProperties EnumUtil::FromString<TupleDataPinProperties>(const char *value);
-
-template<>
-UndoFlags EnumUtil::FromString<UndoFlags>(const char *value);
-
-template<>
-UnionInvalidReason EnumUtil::FromString<UnionInvalidReason>(const char *value);
-
-template<>
-VectorAuxiliaryDataType EnumUtil::FromString<VectorAuxiliaryDataType>(const char *value);
-
-template<>
-VectorBufferType EnumUtil::FromString<VectorBufferType>(const char *value);
-
-template<>
-VectorType EnumUtil::FromString<VectorType>(const char *value);
-
-template<>
-VerificationType EnumUtil::FromString<VerificationType>(const char *value);
-
-template<>
-VerifyExistenceType EnumUtil::FromString<VerifyExistenceType>(const char *value);
-
-template<>
-WALType EnumUtil::FromString<WALType>(const char *value);
-
-template<>
-WindowAggregationMode EnumUtil::FromString<WindowAggregationMode>(const char *value);
-
-template<>
-WindowBoundary EnumUtil::FromString<WindowBoundary>(const char *value);
-
-template<>
-WindowExcludeMode EnumUtil::FromString<WindowExcludeMode>(const char *value);
-
-
-}
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/enums/on_create_conflict.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-namespace duckdb {
-
-enum class OnCreateConflict : uint8_t {
-	// Standard: throw error
-	ERROR_ON_CONFLICT,
-	// CREATE IF NOT EXISTS, silently do nothing on conflict
-	IGNORE_ON_CONFLICT,
-	// CREATE OR REPLACE
-	REPLACE_ON_CONFLICT,
-	// Update on conflict - only support for functions. Add a function overload if the function already exists.
-	ALTER_ON_CONFLICT
-};
-
-} // namespace duckdb
-
-
-
-
-namespace duckdb {
-struct AlterInfo;
-
-struct CreateInfo : public ParseInfo {
-public:
-	static constexpr const ParseInfoType TYPE = ParseInfoType::CREATE_INFO;
-
-public:
-	explicit CreateInfo(CatalogType type, string schema = DEFAULT_SCHEMA, string catalog_p = INVALID_CATALOG)
-	    : ParseInfo(TYPE), type(type), catalog(std::move(catalog_p)), schema(std::move(schema)),
-	      on_conflict(OnCreateConflict::ERROR_ON_CONFLICT), temporary(false), internal(false) {
-	}
-	~CreateInfo() override {
-	}
-
-	//! The to-be-created catalog type
-	CatalogType type;
-	//! The catalog name of the entry
-	string catalog;
-	//! The schema name of the entry
-	string schema;
-	//! What to do on create conflict
-	OnCreateConflict on_conflict;
-	//! Whether or not the entry is temporary
-	bool temporary;
-	//! Whether or not the entry is an internal entry
-	bool internal;
-	//! The SQL string of the CREATE statement
-	string sql;
-	//! The inherent dependencies of the created entry
-	LogicalDependencyList dependencies;
-	//! User provided comment
-	Value comment;
-	//! Key-value tags with additional metadata
-	unordered_map<string, string> tags;
-
-public:
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<CreateInfo> Deserialize(Deserializer &deserializer);
-
-	virtual unique_ptr<CreateInfo> Copy() const = 0;
-
-	DUCKDB_API void CopyProperties(CreateInfo &other) const;
-	//! Generates an alter statement from the create statement - used for OnCreateConflict::ALTER_ON_CONFLICT
-	DUCKDB_API virtual unique_ptr<AlterInfo> GetAlterInfo() const;
-
-	virtual string ToString() const {
-		throw NotImplementedException("ToString not supported for this type of CreateInfo: '%s'",
-		                              EnumUtil::ToString(info_type));
-	}
-};
-
-} // namespace duckdb
-
-
-
-namespace duckdb {
-
-enum class SequenceInfo : uint8_t {
-	// Sequence start
-	SEQ_START,
-	// Sequence increment
-	SEQ_INC,
-	// Sequence minimum value
-	SEQ_MIN,
-	// Sequence maximum value
-	SEQ_MAX,
-	// Sequence cycle option
-	SEQ_CYCLE,
-	// Sequence owner table
-	SEQ_OWN
-};
-
-struct CreateSequenceInfo : public CreateInfo {
-	CreateSequenceInfo();
-
-	//! Sequence name to create
-	string name;
-	//! Usage count of the sequence
-	uint64_t usage_count;
-	//! The increment value
-	int64_t increment;
-	//! The minimum value of the sequence
-	int64_t min_value;
-	//! The maximum value of the sequence
-	int64_t max_value;
-	//! The start value of the sequence
-	int64_t start_value;
-	//! Whether or not the sequence cycles
-	bool cycle;
-
-public:
-	unique_ptr<CreateInfo> Copy() const override;
-
-public:
-	DUCKDB_API void Serialize(Serializer &serializer) const override;
-	DUCKDB_API static unique_ptr<CreateInfo> Deserialize(Deserializer &deserializer);
-
-	string ToString() const override;
-};
-
-} // namespace duckdb
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/parsed_data/alter_table_info.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/parsed_data/alter_info.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-
-namespace duckdb {
-
-enum class AlterType : uint8_t {
-	INVALID = 0,
-	ALTER_TABLE = 1,
-	ALTER_VIEW = 2,
-	ALTER_SEQUENCE = 3,
-	CHANGE_OWNERSHIP = 4,
-	ALTER_SCALAR_FUNCTION = 5,
-	ALTER_TABLE_FUNCTION = 6,
-	SET_COMMENT = 7,
-	SET_COLUMN_COMMENT = 8
-};
-
-struct AlterEntryData {
-	AlterEntryData() {
-	}
-	AlterEntryData(string catalog_p, string schema_p, string name_p, OnEntryNotFound if_not_found)
-	    : catalog(std::move(catalog_p)), schema(std::move(schema_p)), name(std::move(name_p)),
-	      if_not_found(if_not_found) {
-	}
-
-	string catalog;
-	string schema;
-	string name;
-	OnEntryNotFound if_not_found;
-};
-
-struct AlterInfo : public ParseInfo {
-public:
-	static constexpr const ParseInfoType TYPE = ParseInfoType::ALTER_INFO;
-
-public:
-	AlterInfo(AlterType type, string catalog, string schema, string name, OnEntryNotFound if_not_found);
-	~AlterInfo() override;
-
-	AlterType type;
-	//! if exists
-	OnEntryNotFound if_not_found;
-	//! Catalog name to alter
-	string catalog;
-	//! Schema name to alter
-	string schema;
-	//! Entry name to alter
-	string name;
-	//! Allow altering internal entries
-	bool allow_internal;
-
-public:
-	virtual CatalogType GetCatalogType() const = 0;
-	virtual unique_ptr<AlterInfo> Copy() const = 0;
-	virtual string ToString() const = 0;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<ParseInfo> Deserialize(Deserializer &deserializer);
-
-	virtual string GetColumnName() const {
-		return "";
-	};
-
-	AlterEntryData GetAlterEntryData() const;
-	bool IsAddPrimaryKey() const;
-
-protected:
-	explicit AlterInfo(AlterType type);
-};
-
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/constraint.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-namespace duckdb {
-
-class Serializer;
-class Deserializer;
-
-//===--------------------------------------------------------------------===//
-// Constraint Types
-//===--------------------------------------------------------------------===//
-enum class ConstraintType : uint8_t {
-	INVALID = 0,     // invalid constraint type
-	NOT_NULL = 1,    // NOT NULL constraint
-	CHECK = 2,       // CHECK constraint
-	UNIQUE = 3,      // UNIQUE constraint
-	FOREIGN_KEY = 4, // FOREIGN KEY constraint
-};
-
-enum class ForeignKeyType : uint8_t {
-	FK_TYPE_PRIMARY_KEY_TABLE = 0,   // main table
-	FK_TYPE_FOREIGN_KEY_TABLE = 1,   // referencing table
-	FK_TYPE_SELF_REFERENCE_TABLE = 2 // self refrencing table
-};
-
-struct ForeignKeyInfo {
-	ForeignKeyType type;
-	string schema;
-	//! if type is FK_TYPE_FOREIGN_KEY_TABLE, means main key table, if type is FK_TYPE_PRIMARY_KEY_TABLE, means foreign
-	//! key table
-	string table;
-	//! The set of main key table's column's index
-	vector<PhysicalIndex> pk_keys;
-	//! The set of foreign key table's column's index
-	vector<PhysicalIndex> fk_keys;
-
-	bool IsDeleteConstraint() const {
-		return type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ||
-		       type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
-	}
-	bool IsAppendConstraint() const {
-		return type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
-		       type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
-	}
-};
-
-//! Constraint is the base class of any type of table constraint.
-class Constraint {
-public:
-	DUCKDB_API explicit Constraint(ConstraintType type);
-	DUCKDB_API virtual ~Constraint();
-
-	ConstraintType type;
-
-public:
-	DUCKDB_API virtual string ToString() const = 0;
-	DUCKDB_API void Print() const;
-
-	DUCKDB_API virtual unique_ptr<Constraint> Copy() const = 0;
-
-	DUCKDB_API virtual void Serialize(Serializer &serializer) const;
-	DUCKDB_API static unique_ptr<Constraint> Deserialize(Deserializer &deserializer);
-
-public:
-	template <class TARGET>
-	TARGET &Cast() {
-		if (type != TARGET::TYPE) {
-			throw InternalException("Failed to cast constraint to type - constraint type mismatch");
-		}
-		return reinterpret_cast<TARGET &>(*this);
-	}
-
-	template <class TARGET>
-	const TARGET &Cast() const {
-		if (type != TARGET::TYPE) {
-			throw InternalException("Failed to cast constraint to type - constraint type mismatch");
-		}
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-};
-} // namespace duckdb
-
-
-
-namespace duckdb {
-
-enum class AlterForeignKeyType : uint8_t { AFT_ADD = 0, AFT_DELETE = 1 };
-
-//===--------------------------------------------------------------------===//
-// Change Ownership
-//===--------------------------------------------------------------------===//
-struct ChangeOwnershipInfo : public AlterInfo {
-	ChangeOwnershipInfo(CatalogType entry_catalog_type, string entry_catalog, string entry_schema, string entry_name,
-	                    string owner_schema, string owner_name, OnEntryNotFound if_not_found);
-
-	// Catalog type refers to the entry type, since this struct is usually built from an
-	// ALTER <TYPE> <schema>.<name> OWNED BY <owner_schema>.<owner_name> statement
-	// here it is only possible to know the type of who is to be owned
-	CatalogType entry_catalog_type;
-
-	string owner_schema;
-	string owner_name;
-
-public:
-	CatalogType GetCatalogType() const override;
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
-
-	explicit ChangeOwnershipInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// Set Comment
-//===--------------------------------------------------------------------===//
-struct SetCommentInfo : public AlterInfo {
-	SetCommentInfo(CatalogType entry_catalog_type, string entry_catalog, string entry_schema, string entry_name,
-	               Value new_comment_value_p, OnEntryNotFound if_not_found);
-
-	CatalogType entry_catalog_type;
-	Value comment_value;
-
-public:
-	CatalogType GetCatalogType() const override;
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
-
-	explicit SetCommentInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// Alter Table
-//===--------------------------------------------------------------------===//
-enum class AlterTableType : uint8_t {
-	INVALID = 0,
-	RENAME_COLUMN = 1,
-	RENAME_TABLE = 2,
-	ADD_COLUMN = 3,
-	REMOVE_COLUMN = 4,
-	ALTER_COLUMN_TYPE = 5,
-	SET_DEFAULT = 6,
-	FOREIGN_KEY_CONSTRAINT = 7,
-	SET_NOT_NULL = 8,
-	DROP_NOT_NULL = 9,
-	SET_COLUMN_COMMENT = 10,
-	ADD_CONSTRAINT = 11
-};
-
-struct AlterTableInfo : public AlterInfo {
-	AlterTableInfo(AlterTableType type, AlterEntryData data);
-	~AlterTableInfo() override;
-
-	AlterTableType alter_table_type;
-
-public:
-	CatalogType GetCatalogType() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
-
-protected:
-	explicit AlterTableInfo(AlterTableType type);
-};
-
-//===--------------------------------------------------------------------===//
-// RenameColumnInfo
-//===--------------------------------------------------------------------===//
-struct RenameColumnInfo : public AlterTableInfo {
-	RenameColumnInfo(AlterEntryData data, string old_name_p, string new_name_p);
-	~RenameColumnInfo() override;
-
-	//! Column old name
-	string old_name;
-	//! Column new name
-	string new_name;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	RenameColumnInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// RenameTableInfo
-//===--------------------------------------------------------------------===//
-struct RenameTableInfo : public AlterTableInfo {
-	RenameTableInfo(AlterEntryData data, string new_name);
-	~RenameTableInfo() override;
-
-	//! Relation new name
-	string new_table_name;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	RenameTableInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// AddColumnInfo
-//===--------------------------------------------------------------------===//
-struct AddColumnInfo : public AlterTableInfo {
-	AddColumnInfo(AlterEntryData data, ColumnDefinition new_column, bool if_column_not_exists);
-	~AddColumnInfo() override;
-
-	//! New column
-	ColumnDefinition new_column;
-	//! Whether or not an error should be thrown if the column exist
-	bool if_column_not_exists;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	explicit AddColumnInfo(ColumnDefinition new_column);
-};
-
-//===--------------------------------------------------------------------===//
-// RemoveColumnInfo
-//===--------------------------------------------------------------------===//
-struct RemoveColumnInfo : public AlterTableInfo {
-	RemoveColumnInfo(AlterEntryData data, string removed_column, bool if_column_exists, bool cascade);
-	~RemoveColumnInfo() override;
-
-	//! The column to remove
-	string removed_column;
-	//! Whether or not an error should be thrown if the column does not exist
-	bool if_column_exists;
-	//! Whether or not the column should be removed if a dependency conflict arises (used by GENERATED columns)
-	bool cascade;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-	string GetColumnName() const override {
-		return removed_column;
-	}
-
-private:
-	RemoveColumnInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// ChangeColumnTypeInfo
-//===--------------------------------------------------------------------===//
-struct ChangeColumnTypeInfo : public AlterTableInfo {
-	ChangeColumnTypeInfo(AlterEntryData data, string column_name, LogicalType target_type,
-	                     unique_ptr<ParsedExpression> expression);
-	~ChangeColumnTypeInfo() override;
-
-	//! The column name to alter
-	string column_name;
-	//! The target type of the column
-	LogicalType target_type;
-	//! The expression used for data conversion
-	unique_ptr<ParsedExpression> expression;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-	string GetColumnName() const override {
-		return column_name;
-	};
-
-private:
-	ChangeColumnTypeInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// SetDefaultInfo
-//===--------------------------------------------------------------------===//
-struct SetDefaultInfo : public AlterTableInfo {
-	SetDefaultInfo(AlterEntryData data, string column_name, unique_ptr<ParsedExpression> new_default);
-	~SetDefaultInfo() override;
-
-	//! The column name to alter
-	string column_name;
-	//! The expression used for data conversion
-	unique_ptr<ParsedExpression> expression;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	SetDefaultInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// AlterForeignKeyInfo
-//===--------------------------------------------------------------------===//
-struct AlterForeignKeyInfo : public AlterTableInfo {
-	AlterForeignKeyInfo(AlterEntryData data, string fk_table, vector<string> pk_columns, vector<string> fk_columns,
-	                    vector<PhysicalIndex> pk_keys, vector<PhysicalIndex> fk_keys, AlterForeignKeyType type);
-	~AlterForeignKeyInfo() override;
-
-	string fk_table;
-	vector<string> pk_columns;
-	vector<string> fk_columns;
-	vector<PhysicalIndex> pk_keys;
-	vector<PhysicalIndex> fk_keys;
-	AlterForeignKeyType type;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	AlterForeignKeyInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// SetNotNullInfo
-//===--------------------------------------------------------------------===//
-struct SetNotNullInfo : public AlterTableInfo {
-	SetNotNullInfo(AlterEntryData data, string column_name);
-	~SetNotNullInfo() override;
-
-	//! The column name to alter
-	string column_name;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	SetNotNullInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// DropNotNullInfo
-//===--------------------------------------------------------------------===//
-struct DropNotNullInfo : public AlterTableInfo {
-	DropNotNullInfo(AlterEntryData data, string column_name);
-	~DropNotNullInfo() override;
-
-	//! The column name to alter
-	string column_name;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	DropNotNullInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// Alter View
-//===--------------------------------------------------------------------===//
-enum class AlterViewType : uint8_t { INVALID = 0, RENAME_VIEW = 1 };
-
-struct AlterViewInfo : public AlterInfo {
-	AlterViewInfo(AlterViewType type, AlterEntryData data);
-	~AlterViewInfo() override;
-
-	AlterViewType alter_view_type;
-
-public:
-	CatalogType GetCatalogType() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
-
-protected:
-	explicit AlterViewInfo(AlterViewType type);
-};
-
-//===--------------------------------------------------------------------===//
-// RenameViewInfo
-//===--------------------------------------------------------------------===//
-struct RenameViewInfo : public AlterViewInfo {
-	RenameViewInfo(AlterEntryData data, string new_name);
-	~RenameViewInfo() override;
-
-	//! Relation new name
-	string new_view_name;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterViewInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	RenameViewInfo();
-};
-
-//===--------------------------------------------------------------------===//
-// AddConstraintInfo
-//===--------------------------------------------------------------------===//
-struct AddConstraintInfo : public AlterTableInfo {
-	AddConstraintInfo(AlterEntryData data, unique_ptr<Constraint> constraint);
-	~AddConstraintInfo() override;
-
-	//! The constraint to add.
-	unique_ptr<Constraint> constraint;
-
-public:
-	unique_ptr<AlterInfo> Copy() const override;
-	string ToString() const override;
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
-
-private:
-	AddConstraintInfo();
-};
-
-} // namespace duckdb
-
-
-namespace duckdb {
-class DuckTransaction;
-class SequenceCatalogEntry;
-
-struct SequenceValue {
-	SequenceCatalogEntry *entry;
-	uint64_t usage_count;
-	int64_t counter;
-};
-
-struct SequenceData {
-	explicit SequenceData(CreateSequenceInfo &info);
-
-	//! The amount of times the sequence has been used
-	uint64_t usage_count;
-	//! The sequence counter
-	int64_t counter;
-	//! The most recently returned value
-	int64_t last_value;
-	//! The increment value
-	int64_t increment;
-	//! The minimum value of the sequence
-	int64_t start_value;
-	//! The minimum value of the sequence
-	int64_t min_value;
-	//! The maximum value of the sequence
-	int64_t max_value;
-	//! Whether or not the sequence cycles
-	bool cycle;
-};
-
-//! A sequence catalog entry
-class SequenceCatalogEntry : public StandardEntry {
-public:
-	static constexpr const CatalogType Type = CatalogType::SEQUENCE_ENTRY;
-	static constexpr const char *Name = "sequence";
-
-public:
-	//! Create a real TableCatalogEntry and initialize storage for it
-	SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateSequenceInfo &info);
-
-public:
-	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
-	unique_ptr<CreateInfo> GetInfo() const override;
-
-	SequenceData GetData() const;
-	int64_t CurrentValue();
-	int64_t NextValue(DuckTransaction &transaction);
-	void ReplayValue(uint64_t usage_count, int64_t counter);
-
-	string ToSQL() const override;
-
-private:
-	//! Lock for getting a value on the sequence
-	mutable mutex lock;
-	//! Sequence data
-	SequenceData data;
-};
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/transaction/transaction_data.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-namespace duckdb {
-class DuckTransaction;
-class Transaction;
-
-struct TransactionData {
-	TransactionData(DuckTransaction &transaction_p); // NOLINT: allow implicit conversion
-	TransactionData(transaction_t transaction_id_p, transaction_t start_time_p);
-
-	optional_ptr<DuckTransaction> transaction;
-	transaction_t transaction_id;
-	transaction_t start_time;
-};
-
-} // namespace duckdb
-
-
-
-
-namespace duckdb {
-class SequenceCatalogEntry;
-class SchemaCatalogEntry;
-
-class AttachedDatabase;
-class ColumnData;
-class ClientContext;
-class CatalogEntry;
-class DataTable;
-class DatabaseInstance;
-class LocalStorage;
-class MetaTransaction;
-class TransactionManager;
-class WriteAheadLog;
-
-class ChunkVectorInfo;
-
-struct DeleteInfo;
-struct UpdateInfo;
-
-//! The transaction object holds information about a currently running or past
-//! transaction
-class Transaction {
-public:
-	DUCKDB_API Transaction(TransactionManager &manager, ClientContext &context);
-	DUCKDB_API virtual ~Transaction();
-
-	TransactionManager &manager;
-	weak_ptr<ClientContext> context;
-	//! The current active query for the transaction. Set to MAXIMUM_QUERY_ID if
-	//! no query is active.
-	atomic<transaction_t> active_query;
-
-public:
-	DUCKDB_API static Transaction &Get(ClientContext &context, AttachedDatabase &db);
-	DUCKDB_API static Transaction &Get(ClientContext &context, Catalog &catalog);
-	//! Returns the transaction for the given context if it has already been started
-	DUCKDB_API static optional_ptr<Transaction> TryGet(ClientContext &context, AttachedDatabase &db);
-
-	//! Whether or not the transaction has made any modifications to the database so far
-	DUCKDB_API bool IsReadOnly();
-	//! Promotes the transaction to a read-write transaction
-	DUCKDB_API virtual void SetReadWrite();
-
-	virtual bool IsDuckTransaction() const {
-		return false;
-	}
-
-public:
-	template <class TARGET>
-	TARGET &Cast() {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<TARGET &>(*this);
-	}
-	template <class TARGET>
-	const TARGET &Cast() const {
-		DynamicCastCheck<TARGET>(this);
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-
-private:
-	bool is_read_only;
-};
-
-} // namespace duckdb
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/similar_catalog_entry.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-namespace duckdb {
-class SchemaCatalogEntry;
-
-//! Return value of SimilarEntryInSchemas
-struct SimilarCatalogEntry {
-	//! The entry name. Empty if absent
-	string name;
-	//! The similarity score of the given name (between 0.0 and 1.0, higher is better)
-	double score = 0.0;
-	//! The schema of the entry.
-	optional_ptr<SchemaCatalogEntry> schema;
-
-	bool Found() const {
-		return !name.empty();
-	}
-
-	DUCKDB_API string GetQualifiedName(bool qualify_catalog, bool qualify_schema) const;
-};
-
-} // namespace duckdb
-
-#include <functional>
-#include <memory>
-
-namespace duckdb {
-struct AlterInfo;
-
-class ClientContext;
-class LogicalDependencyList;
-
-class DuckCatalog;
-class TableCatalogEntry;
-class SequenceCatalogEntry;
-
-class CatalogEntryMap {
-public:
-	CatalogEntryMap() {
-	}
-
-public:
-	void AddEntry(unique_ptr<CatalogEntry> entry);
-	void UpdateEntry(unique_ptr<CatalogEntry> entry);
-	void DropEntry(CatalogEntry &entry);
-	case_insensitive_tree_t<unique_ptr<CatalogEntry>> &Entries();
-	optional_ptr<CatalogEntry> GetEntry(const string &name);
-
-private:
-	//! Mapping of string to catalog entry
-	case_insensitive_tree_t<unique_ptr<CatalogEntry>> entries;
-};
-
-//! The Catalog Set stores (key, value) map of a set of CatalogEntries
-class CatalogSet {
-public:
-	struct EntryLookup {
-		enum class FailureReason { SUCCESS, DELETED, NOT_PRESENT, INVISIBLE };
-		optional_ptr<CatalogEntry> result;
-		FailureReason reason;
-	};
-
-public:
-	DUCKDB_API explicit CatalogSet(Catalog &catalog, unique_ptr<DefaultGenerator> defaults = nullptr);
-	~CatalogSet();
-
-	//! Create an entry in the catalog set. Returns whether or not it was
-	//! successful.
-	DUCKDB_API bool CreateEntry(CatalogTransaction transaction, const string &name, unique_ptr<CatalogEntry> value,
-	                            const LogicalDependencyList &dependencies);
-	DUCKDB_API bool CreateEntry(ClientContext &context, const string &name, unique_ptr<CatalogEntry> value,
-	                            const LogicalDependencyList &dependencies);
-
-	DUCKDB_API bool AlterEntry(CatalogTransaction transaction, const string &name, AlterInfo &alter_info);
-
-	DUCKDB_API bool DropEntry(CatalogTransaction transaction, const string &name, bool cascade,
-	                          bool allow_drop_internal = false);
-	DUCKDB_API bool DropEntry(ClientContext &context, const string &name, bool cascade,
-	                          bool allow_drop_internal = false);
-	//! Verify that the entry referenced by the dependency is still alive
-	DUCKDB_API void VerifyExistenceOfDependency(transaction_t commit_id, CatalogEntry &entry);
-	//! Verify we can still drop the entry while committing
-	DUCKDB_API void CommitDrop(transaction_t commit_id, transaction_t start_time, CatalogEntry &entry);
-
-	DUCKDB_API DuckCatalog &GetCatalog();
-
-	bool AlterOwnership(CatalogTransaction transaction, ChangeOwnershipInfo &info);
-
-	void CleanupEntry(CatalogEntry &catalog_entry);
-
-	//! Returns the entry with the specified name
-	DUCKDB_API EntryLookup GetEntryDetailed(CatalogTransaction transaction, const string &name);
-	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(CatalogTransaction transaction, const string &name);
-	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name);
-
-	//! Gets the entry that is most similar to the given name (i.e. smallest levenshtein distance), or empty string if
-	//! none is found. The returned pair consists of the entry name and the distance (smaller means closer).
-	SimilarCatalogEntry SimilarEntry(CatalogTransaction transaction, const string &name);
-
-	//! Rollback <entry> to be the currently valid entry for a certain catalog
-	//! entry
-	void Undo(CatalogEntry &entry);
-
-	//! Scan the catalog set, invoking the callback method for every committed entry
-	DUCKDB_API void Scan(const std::function<void(CatalogEntry &)> &callback);
-	//! Scan the catalog set, invoking the callback method for every entry
-	DUCKDB_API void ScanWithPrefix(CatalogTransaction transaction, const std::function<void(CatalogEntry &)> &callback,
-	                               const string &prefix);
-	DUCKDB_API void Scan(CatalogTransaction transaction, const std::function<void(CatalogEntry &)> &callback);
-	DUCKDB_API void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
-
-	template <class T>
-	vector<reference<T>> GetEntries(CatalogTransaction transaction) {
-		vector<reference<T>> result;
-		Scan(transaction, [&](CatalogEntry &entry) { result.push_back(entry.Cast<T>()); });
-		return result;
-	}
-
-	DUCKDB_API bool CreatedByOtherActiveTransaction(CatalogTransaction transaction, transaction_t timestamp);
-	DUCKDB_API bool CommittedAfterStarting(CatalogTransaction transaction, transaction_t timestamp);
-	DUCKDB_API bool HasConflict(CatalogTransaction transaction, transaction_t timestamp);
-	DUCKDB_API bool UseTimestamp(CatalogTransaction transaction, transaction_t timestamp);
-	static bool IsCommitted(transaction_t timestamp);
-
-	static void UpdateTimestamp(CatalogEntry &entry, transaction_t timestamp);
-
-	mutex &GetCatalogLock() {
-		return catalog_lock;
-	}
-
-	void Verify(Catalog &catalog);
-
-private:
-	bool DropDependencies(CatalogTransaction transaction, const string &name, bool cascade,
-	                      bool allow_drop_internal = false);
-	//! Given a root entry, gets the entry valid for this transaction, 'visible' is used to indicate whether the entry
-	//! is actually visible to the transaction
-	CatalogEntry &GetEntryForTransaction(CatalogTransaction transaction, CatalogEntry &current, bool &visible);
-	//! Given a root entry, gets the entry valid for this transaction
-	CatalogEntry &GetEntryForTransaction(CatalogTransaction transaction, CatalogEntry &current);
-	CatalogEntry &GetCommittedEntry(CatalogEntry &current);
-	optional_ptr<CatalogEntry> GetEntryInternal(CatalogTransaction transaction, const string &name);
-	optional_ptr<CatalogEntry> CreateCommittedEntry(unique_ptr<CatalogEntry> entry);
-
-	//! Create all default entries
-	void CreateDefaultEntries(CatalogTransaction transaction, unique_lock<mutex> &lock);
-	//! Attempt to create a default entry with the specified name. Returns the entry if successful, nullptr otherwise.
-	optional_ptr<CatalogEntry> CreateDefaultEntry(CatalogTransaction transaction, const string &name,
-	                                              unique_lock<mutex> &lock);
-
-	bool DropEntryInternal(CatalogTransaction transaction, const string &name, bool allow_drop_internal = false);
-
-	bool CreateEntryInternal(CatalogTransaction transaction, const string &name, unique_ptr<CatalogEntry> value,
-	                         unique_lock<mutex> &read_lock, bool should_be_empty = true);
-	void CheckCatalogEntryInvariants(CatalogEntry &value, const string &name);
-	//! Verify that the previous entry in the chain is dropped.
-	bool VerifyVacancy(CatalogTransaction transaction, CatalogEntry &entry);
-	//! Start the catalog entry chain with a dummy node
-	bool StartChain(CatalogTransaction transaction, const string &name, unique_lock<mutex> &read_lock);
-	bool RenameEntryInternal(CatalogTransaction transaction, CatalogEntry &old, const string &new_name,
-	                         AlterInfo &alter_info, unique_lock<mutex> &read_lock);
-
-private:
-	DuckCatalog &catalog;
-	//! The catalog lock is used to make changes to the data
-	mutex catalog_lock;
-	CatalogEntryMap map;
-	//! The generator used to generate default internal entries
-	unique_ptr<DefaultGenerator> defaults;
-};
-} // namespace duckdb
-
-
-
-namespace duckdb {
-class ClientContext;
-
-class StandardEntry;
-class TableCatalogEntry;
-class TableFunctionCatalogEntry;
-class SequenceCatalogEntry;
-
-enum class OnCreateConflict : uint8_t;
-
-struct AlterTableInfo;
-struct CreateIndexInfo;
-struct CreateFunctionInfo;
-struct CreateCollationInfo;
-struct CreateViewInfo;
-struct BoundCreateTableInfo;
-struct CreatePragmaFunctionInfo;
-struct CreateSequenceInfo;
-struct CreateSchemaInfo;
-struct CreateTableFunctionInfo;
-struct CreateCopyFunctionInfo;
-struct CreateTypeInfo;
-
-struct DropInfo;
-
-//! A schema in the catalog
-class SchemaCatalogEntry : public InCatalogEntry {
-public:
-	static constexpr const CatalogType Type = CatalogType::SCHEMA_ENTRY;
-	static constexpr const char *Name = "schema";
-
-public:
-	SchemaCatalogEntry(Catalog &catalog, CreateSchemaInfo &info);
-
-public:
-	unique_ptr<CreateInfo> GetInfo() const override;
-
-	//! Scan the specified catalog set, invoking the callback method for every entry
-	virtual void Scan(ClientContext &context, CatalogType type,
-	                  const std::function<void(CatalogEntry &)> &callback) = 0;
-	//! Scan the specified catalog set, invoking the callback method for every committed entry
-	virtual void Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) = 0;
-
-	string ToSQL() const override;
-
-	//! Creates an index with the given name in the schema
-	virtual optional_ptr<CatalogEntry> CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,
-	                                               TableCatalogEntry &table) = 0;
-	optional_ptr<CatalogEntry> CreateIndex(ClientContext &context, CreateIndexInfo &info, TableCatalogEntry &table);
-	//! Create a scalar or aggregate function within the given schema
-	virtual optional_ptr<CatalogEntry> CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) = 0;
-	//! Creates a table with the given name in the schema
-	virtual optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) = 0;
-	//! Creates a view with the given name in the schema
-	virtual optional_ptr<CatalogEntry> CreateView(CatalogTransaction transaction, CreateViewInfo &info) = 0;
-	//! Creates a sequence with the given name in the schema
-	virtual optional_ptr<CatalogEntry> CreateSequence(CatalogTransaction transaction, CreateSequenceInfo &info) = 0;
-	//! Create a table function within the given schema
-	virtual optional_ptr<CatalogEntry> CreateTableFunction(CatalogTransaction transaction,
-	                                                       CreateTableFunctionInfo &info) = 0;
-	//! Create a copy function within the given schema
-	virtual optional_ptr<CatalogEntry> CreateCopyFunction(CatalogTransaction transaction,
-	                                                      CreateCopyFunctionInfo &info) = 0;
-	//! Create a pragma function within the given schema
-	virtual optional_ptr<CatalogEntry> CreatePragmaFunction(CatalogTransaction transaction,
-	                                                        CreatePragmaFunctionInfo &info) = 0;
-	//! Create a collation within the given schema
-	virtual optional_ptr<CatalogEntry> CreateCollation(CatalogTransaction transaction, CreateCollationInfo &info) = 0;
-	//! Create a enum within the given schema
-	virtual optional_ptr<CatalogEntry> CreateType(CatalogTransaction transaction, CreateTypeInfo &info) = 0;
-
-	DUCKDB_API virtual optional_ptr<CatalogEntry> GetEntry(CatalogTransaction transaction, CatalogType type,
-	                                                       const string &name) = 0;
-	DUCKDB_API virtual CatalogSet::EntryLookup GetEntryDetailed(CatalogTransaction transaction, CatalogType type,
-	                                                            const string &name);
-	DUCKDB_API virtual SimilarCatalogEntry GetSimilarEntry(CatalogTransaction transaction, CatalogType type,
-	                                                       const string &name);
-
-	//! Drops an entry from the schema
-	virtual void DropEntry(ClientContext &context, DropInfo &info) = 0;
-
-	//! Alters a catalog entry
-	virtual void Alter(CatalogTransaction transaction, AlterInfo &info) = 0;
-
-	CatalogTransaction GetCatalogTransaction(ClientContext &context);
-};
-} // namespace duckdb
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/catalog/catalog_search_path.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-#include <functional>
-
-
-
-
-
-namespace duckdb {
-
-class ClientContext;
-
-struct CatalogSearchEntry {
-	CatalogSearchEntry(string catalog, string schema);
-
-	string catalog;
-	string schema;
-
-public:
-	string ToString() const;
-	static string ListToString(const vector<CatalogSearchEntry> &input);
-	static CatalogSearchEntry Parse(const string &input);
-	static vector<CatalogSearchEntry> ParseList(const string &input);
-
-private:
-	static CatalogSearchEntry ParseInternal(const string &input, idx_t &pos);
-	static string WriteOptionallyQuoted(const string &input);
-};
-
-enum class CatalogSetPathType { SET_SCHEMA, SET_SCHEMAS };
-
-//! The schema search path, in order by which entries are searched if no schema entry is provided
-class CatalogSearchPath {
-public:
-	DUCKDB_API explicit CatalogSearchPath(ClientContext &client_p);
-	DUCKDB_API CatalogSearchPath(ClientContext &client_p, vector<CatalogSearchEntry> entries);
-	CatalogSearchPath(const CatalogSearchPath &other) = delete;
-
-	DUCKDB_API void Set(CatalogSearchEntry new_value, CatalogSetPathType set_type);
-	DUCKDB_API void Set(vector<CatalogSearchEntry> new_paths, CatalogSetPathType set_type);
-	DUCKDB_API void Reset();
-
-	DUCKDB_API const vector<CatalogSearchEntry> &Get() const;
-	const vector<CatalogSearchEntry> &GetSetPaths() const {
-		return set_paths;
-	}
-	DUCKDB_API const CatalogSearchEntry &GetDefault() const;
-	//! FIXME: this method is deprecated
-	DUCKDB_API string GetDefaultSchema(const string &catalog) const;
-	DUCKDB_API string GetDefaultSchema(ClientContext &context, const string &catalog) const;
-	DUCKDB_API string GetDefaultCatalog(const string &schema) const;
-
-	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog) const;
-	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema) const;
-
-	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name,
-	                                   const string &schema_name) const;
-
-private:
-	//! Set paths without checking if they exist
-	void SetPathsInternal(vector<CatalogSearchEntry> new_paths);
-	string GetSetName(CatalogSetPathType set_type);
-
-private:
-	ClientContext &context;
-	vector<CatalogSearchEntry> paths;
-	//! Only the paths that were explicitly set (minus the always included paths)
-	vector<CatalogSearchEntry> set_paths;
-};
-
-} // namespace duckdb
-
-
-namespace duckdb {
-
-class ClientContext;
-class Catalog;
-class CatalogEntry;
-
-using catalog_entry_callback_t = std::function<void(CatalogEntry &)>;
-
-// Wraps the Catalog::GetEntry method
-class CatalogEntryRetriever {
-public:
-	explicit CatalogEntryRetriever(ClientContext &context) : context(context) {
-	}
-	CatalogEntryRetriever(const CatalogEntryRetriever &other) : callback(other.callback), context(other.context) {
-	}
-
-public:
-	void Inherit(const CatalogEntryRetriever &parent);
-	ClientContext &GetContext() {
-		return context;
-	}
-
-	optional_ptr<CatalogEntry> GetEntry(CatalogType type, const string &catalog, const string &schema,
-	                                    const string &name,
-	                                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::THROW_EXCEPTION,
-	                                    QueryErrorContext error_context = QueryErrorContext());
-
-	optional_ptr<CatalogEntry> GetEntry(CatalogType type, Catalog &catalog, const string &schema, const string &name,
-	                                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::THROW_EXCEPTION,
-	                                    QueryErrorContext error_context = QueryErrorContext());
-
-	LogicalType GetType(const string &catalog, const string &schema, const string &name,
-	                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::RETURN_NULL);
-	LogicalType GetType(Catalog &catalog, const string &schema, const string &name,
-	                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::RETURN_NULL);
-
-	optional_ptr<SchemaCatalogEntry> GetSchema(const string &catalog, const string &name,
-	                                           OnEntryNotFound on_entry_not_found = OnEntryNotFound::THROW_EXCEPTION,
-	                                           QueryErrorContext error_context = QueryErrorContext());
-
-	const CatalogSearchPath &GetSearchPath() const;
-	void SetSearchPath(vector<CatalogSearchEntry> entries);
-
-	void SetCallback(catalog_entry_callback_t callback);
-	catalog_entry_callback_t GetCallback();
-
-private:
-	optional_ptr<CatalogEntry> ReturnAndCallback(optional_ptr<CatalogEntry> result);
-
-private:
-	//! (optional) callback, called on every successful entry retrieval
-	catalog_entry_callback_t callback = nullptr;
-	ClientContext &context;
-	shared_ptr<CatalogSearchPath> search_path;
-};
-
-} // namespace duckdb
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/planner/expression/bound_lambda_expression.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/parser/expression/lambda_expression.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-namespace duckdb {
-
-//! LambdaExpression represents either:
-//! 	1. A lambda function that can be used for, e.g., mapping an expression to a list
-//! 	2. An OperatorExpression with the "->" operator (JSON)
-//! Lambda expressions are written in the form of "params -> expr", e.g., "x -> x + 1"
-class LambdaExpression : public ParsedExpression {
-public:
-	static constexpr const ExpressionClass TYPE = ExpressionClass::LAMBDA;
-
-public:
-	LambdaExpression(unique_ptr<ParsedExpression> lhs, unique_ptr<ParsedExpression> expr);
-
-	//! The LHS of a lambda expression or the JSON "->"-operator. We need the context
-	//! to determine if the LHS is a list of column references (lambda parameters) or an expression (JSON)
-	unique_ptr<ParsedExpression> lhs;
-	//! The lambda or JSON expression (RHS)
-	unique_ptr<ParsedExpression> expr;
-
-public:
-	//! Returns a vector to the column references in the LHS expression, and fills the error message,
-	//! if the LHS is not a valid lambda parameter list
-	vector<reference<ParsedExpression>> ExtractColumnRefExpressions(string &error_message);
-	//! Returns the error message for an invalid lambda parameter list
-	static string InvalidParametersErrorMessage();
-	//! Returns true, if the column_name is a lambda parameter name
-	static bool IsLambdaParameter(const vector<unordered_set<string>> &lambda_params, const string &column_name);
-
-	string ToString() const override;
-	static bool Equal(const LambdaExpression &a, const LambdaExpression &b);
-	hash_t Hash() const override;
-	unique_ptr<ParsedExpression> Copy() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<ParsedExpression> Deserialize(Deserializer &deserializer);
-
-private:
-	LambdaExpression();
-};
-
-} // namespace duckdb
-
-
-namespace duckdb {
-
-class BoundLambdaExpression : public Expression {
-public:
-	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_LAMBDA;
-
-public:
-	BoundLambdaExpression(ExpressionType type_p, LogicalType return_type_p, unique_ptr<Expression> lambda_expr_p,
-	                      idx_t parameter_count_p);
-
-	//! The lambda expression that we'll use in the expression executor during execution
-	unique_ptr<Expression> lambda_expr;
-	//! Non-lambda constants, column references, and outer lambda parameters that we need to pass
-	//! into the execution chunk
-	vector<unique_ptr<Expression>> captures;
-	//! The number of lhs parameters of the lambda function
-	idx_t parameter_count;
-
-public:
-	string ToString() const override;
-	bool Equals(const BaseExpression &other) const override;
-	unique_ptr<Expression> Copy() const override;
-
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<Expression> Deserialize(Deserializer &deserializer);
-};
-} // namespace duckdb
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/common/enums/collation_type.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-namespace duckdb {
-
-enum class CollationType { ALL_COLLATIONS, COMBINABLE_COLLATIONS };
-
-} // namespace duckdb
-
-
-namespace duckdb {
-
-class Binder;
-class ClientContext;
-class QueryNode;
-
-class ScalarFunctionCatalogEntry;
-class AggregateFunctionCatalogEntry;
-class ScalarMacroCatalogEntry;
-class CatalogEntry;
-class SimpleFunction;
-
-struct DummyBinding;
-struct SelectBindState;
-
-struct BoundColumnReferenceInfo {
-	string name;
-	optional_idx query_location;
-};
-
-struct BindResult {
-	BindResult() {
-	}
-	explicit BindResult(const Exception &ex) : error(ex) {
-	}
-	explicit BindResult(const string &error_msg) : error(ExceptionType::BINDER, error_msg) {
-	}
-	explicit BindResult(ErrorData error) : error(std::move(error)) {
-	}
-	explicit BindResult(unique_ptr<Expression> expr) : expression(std::move(expr)) {
-	}
-
-	bool HasError() const {
-		return error.HasError();
-	}
-	void SetError(const string &error_message) {
-		error = ErrorData(ExceptionType::BINDER, error_message);
-	}
-
-	unique_ptr<Expression> expression;
-	ErrorData error;
-};
-
-class ExpressionBinder {
-	friend class StackChecker<ExpressionBinder>;
-
-public:
-	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
-	virtual ~ExpressionBinder();
-
-	//! The target type that should result from the binder. If the result is not of this type, a cast to this type will
-	//! be added. Defaults to INVALID.
-	LogicalType target_type;
-
-	optional_ptr<DummyBinding> macro_binding;
-	optional_ptr<vector<DummyBinding>> lambda_bindings;
-
-public:
-	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> &expr, optional_ptr<LogicalType> result_type = nullptr,
-	                            bool root_expression = true);
-
-	//! Returns whether or not any columns have been bound by the expression binder
-	bool HasBoundColumns() {
-		return !bound_columns.empty();
-	}
-	const vector<BoundColumnReferenceInfo> &GetBoundColumns() {
-		return bound_columns;
-	}
-
-	void SetCatalogLookupCallback(catalog_entry_callback_t callback);
-	ErrorData Bind(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression = false);
-
-	//! Returns the STRUCT_EXTRACT operator expression
-	unique_ptr<ParsedExpression> CreateStructExtract(unique_ptr<ParsedExpression> base, const string &field_name);
-	//! Returns a STRUCT_PACK function expression
-	unique_ptr<ParsedExpression> CreateStructPack(ColumnRefExpression &col_ref);
-
-	BindResult BindQualifiedColumnName(ColumnRefExpression &colref, const string &table_name);
-
-	//! Returns a qualified column reference from a column name
-	unique_ptr<ParsedExpression> QualifyColumnName(const string &column_name, ErrorData &error);
-	//! Returns a qualified column reference from a column reference with column_names.size() > 2
-	unique_ptr<ParsedExpression> QualifyColumnNameWithManyDots(ColumnRefExpression &col_ref, ErrorData &error);
-	//! Returns a qualified column reference from a column reference
-	virtual unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &col_ref, ErrorData &error);
-	//! Enables special-handling of lambda parameters by tracking them in the lambda_params vector
-	void QualifyColumnNamesInLambda(FunctionExpression &function, vector<unordered_set<string>> &lambda_params);
-	//! Recursively qualifies the column references in the (children) of the expression. Passes on the
-	//! within_function_expression state from outer expressions, or sets it
-	void QualifyColumnNames(unique_ptr<ParsedExpression> &expr, vector<unordered_set<string>> &lambda_params,
-	                        const bool within_function_expression = false);
-	//! Entry point for qualifying the column references of the expression
-	static void QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpression> &expr);
-	static void QualifyColumnNames(ExpressionBinder &binder, unique_ptr<ParsedExpression> &expr);
-
-	static bool PushCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
-	                          CollationType type = CollationType::ALL_COLLATIONS);
-	static void TestCollation(ClientContext &context, const string &collation);
-
-	BindResult BindCorrelatedColumns(unique_ptr<ParsedExpression> &expr, ErrorData error_message);
-
-	void BindChild(unique_ptr<ParsedExpression> &expr, idx_t depth, ErrorData &error);
-	static void ExtractCorrelatedExpressions(Binder &binder, Expression &expr);
-
-	static bool ContainsNullType(const LogicalType &type);
-	static LogicalType ExchangeNullType(const LogicalType &type);
-	static bool ContainsType(const LogicalType &type, LogicalTypeId target);
-	static LogicalType ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type);
-
-	virtual bool TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result);
-	virtual bool QualifyColumnAlias(const ColumnRefExpression &colref);
-
-	//! Bind the given expression. Unlike Bind(), this does *not* mute the given ParsedExpression.
-	//! Exposed to be used from sub-binders that aren't subclasses of ExpressionBinder.
-	virtual BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
-	                                  bool root_expression = false);
-
-	//! FIXME: Generalise this for extensibility.
-	//! Recursively replaces macro parameters with the provided input parameters.
-	void ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr, vector<unordered_set<string>> &lambda_params);
-	//! Enables special-handling of lambda parameters during macro replacement by tracking them in the lambda_params
-	//! vector.
-	void ReplaceMacroParametersInLambda(FunctionExpression &function, vector<unordered_set<string>> &lambda_params);
-	//! Recursively qualifies column references in ON CONFLICT DO UPDATE SET expressions.
-	void DoUpdateSetQualify(unique_ptr<ParsedExpression> &expr, const string &table_name,
-	                        vector<unordered_set<string>> &lambda_params);
-	//! Enables special-handling of lambda parameters during ON CONFLICT TO UPDATE SET qualification by tracking them in
-	//! the lambda_params vector.
-	void DoUpdateSetQualifyInLambda(FunctionExpression &function, const string &table_name,
-	                                vector<unordered_set<string>> &lambda_params);
-
-	static LogicalType GetExpressionReturnType(const Expression &expr);
-
-private:
-	//! Current stack depth
-	idx_t stack_depth = DConstants::INVALID_INDEX;
-
-	void InitializeStackCheck();
-	StackChecker<ExpressionBinder> StackCheck(const ParsedExpression &expr, idx_t extra_stack = 1);
-
-protected:
-	BindResult BindExpression(BetweenExpression &expr, idx_t depth);
-	BindResult BindExpression(CaseExpression &expr, idx_t depth);
-	BindResult BindExpression(CollateExpression &expr, idx_t depth);
-	BindResult BindExpression(CastExpression &expr, idx_t depth);
-	BindResult BindExpression(ColumnRefExpression &expr, idx_t depth, bool root_expression);
-	BindResult BindExpression(LambdaRefExpression &expr, idx_t depth);
-	BindResult BindExpression(ComparisonExpression &expr, idx_t depth);
-	BindResult BindExpression(ConjunctionExpression &expr, idx_t depth);
-	BindResult BindExpression(ConstantExpression &expr, idx_t depth);
-	BindResult BindExpression(FunctionExpression &expr, idx_t depth, unique_ptr<ParsedExpression> &expr_ptr);
-	BindResult BindExpression(LambdaExpression &expr, idx_t depth, const LogicalType &list_child_type,
-	                          optional_ptr<bind_lambda_function_t> bind_lambda_function);
-	BindResult BindExpression(OperatorExpression &expr, idx_t depth);
-	BindResult BindExpression(ParameterExpression &expr, idx_t depth);
-	BindResult BindExpression(SubqueryExpression &expr, idx_t depth);
-	BindResult BindPositionalReference(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression);
-
-	void TransformCapturedLambdaColumn(unique_ptr<Expression> &original, unique_ptr<Expression> &replacement,
-	                                   BoundLambdaExpression &bound_lambda_expr,
-	                                   const optional_ptr<bind_lambda_function_t> bind_lambda_function,
-	                                   const LogicalType &list_child_type);
-	void CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_expr, unique_ptr<Expression> &expr,
-	                          const optional_ptr<bind_lambda_function_t> bind_lambda_function,
-	                          const LogicalType &list_child_type);
-
-	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
-
-	LogicalType ResolveOperatorType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
-	LogicalType ResolveCoalesceType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
-	LogicalType ResolveNotType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
-
-	BindResult BindUnsupportedExpression(ParsedExpression &expr, idx_t depth, const string &message);
-
-protected:
-	virtual BindResult BindGroupingFunction(OperatorExpression &op, idx_t depth);
-	virtual BindResult BindFunction(FunctionExpression &expr, ScalarFunctionCatalogEntry &function, idx_t depth);
-	virtual BindResult BindLambdaFunction(FunctionExpression &expr, ScalarFunctionCatalogEntry &function, idx_t depth);
-	virtual BindResult BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry &function, idx_t depth);
-	virtual BindResult BindUnnest(FunctionExpression &expr, idx_t depth, bool root_expression);
-	virtual BindResult BindMacro(FunctionExpression &expr, ScalarMacroCatalogEntry &macro, idx_t depth,
-	                             unique_ptr<ParsedExpression> &expr_ptr);
-	void UnfoldMacroExpression(FunctionExpression &function, ScalarMacroCatalogEntry &macro_func,
-	                           unique_ptr<ParsedExpression> &expr);
-
-	virtual string UnsupportedAggregateMessage();
-	virtual string UnsupportedUnnestMessage();
-	optional_ptr<CatalogEntry> GetCatalogEntry(CatalogType type, const string &catalog, const string &schema,
-	                                           const string &name, OnEntryNotFound on_entry_not_found,
-	                                           QueryErrorContext &error_context);
-
-	Binder &binder;
-	ClientContext &context;
-	optional_ptr<ExpressionBinder> stored_binder;
-	vector<BoundColumnReferenceInfo> bound_columns;
-
-	//! Returns true if the function name is an alias for the UNNEST function
-	static bool IsUnnestFunction(const string &function_name);
-	BindResult TryBindLambdaOrJson(FunctionExpression &function, idx_t depth, CatalogEntry &func);
-
-	unique_ptr<ParsedExpression> QualifyColumnNameWithManyDotsInternal(ColumnRefExpression &col_ref, ErrorData &error,
-	                                                                   idx_t &struct_extract_start);
-	virtual void ThrowIfUnnestInLambda(const ColumnBinding &column_binding);
-};
-
-} // namespace duckdb
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/planner/table_binding.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-
-
-
-
-
-namespace duckdb {
-class BindContext;
-class BoundQueryNode;
-class ColumnRefExpression;
-class SubqueryRef;
-class LogicalGet;
-class TableCatalogEntry;
-class TableFunctionCatalogEntry;
-class BoundTableFunction;
-class StandardEntry;
-struct ColumnBinding;
-
-enum class BindingType { BASE, TABLE, DUMMY, CATALOG_ENTRY };
-
-//! A Binding represents a binding to a table, table-producing function or subquery with a specified table index.
-struct Binding {
-	Binding(BindingType binding_type, BindingAlias alias, vector<LogicalType> types, vector<string> names, idx_t index,
-	        LogicalType rowid_type = LogicalType(LogicalType::ROW_TYPE));
-	virtual ~Binding() = default;
-
-	//! The type of Binding
-	BindingType binding_type;
-	//! The alias of the binding
-	BindingAlias alias;
-	//! The table index of the binding
-	idx_t index;
-	//! The types of the bound columns
-	vector<LogicalType> types;
-	//! Column names of the subquery
-	vector<string> names;
-	//! Name -> index for the names
-	case_insensitive_map_t<column_t> name_map;
-
-	LogicalType rowid_type;
-
-public:
-	bool TryGetBindingIndex(const string &column_name, column_t &column_index);
-	column_t GetBindingIndex(const string &column_name);
-	bool HasMatchingBinding(const string &column_name);
-	virtual ErrorData ColumnNotFoundError(const string &column_name) const;
-	virtual BindResult Bind(ColumnRefExpression &colref, idx_t depth);
-	virtual optional_ptr<StandardEntry> GetStandardEntry();
-	string GetAlias() const;
-
-	static BindingAlias GetAlias(const string &explicit_alias, const StandardEntry &entry);
-	static BindingAlias GetAlias(const string &explicit_alias, optional_ptr<StandardEntry> entry);
-
-public:
-	template <class TARGET>
-	TARGET &Cast() {
-		if (binding_type != TARGET::TYPE) {
-			throw InternalException("Failed to cast binding to type - binding type mismatch");
-		}
-		return reinterpret_cast<TARGET &>(*this);
-	}
-
-	template <class TARGET>
-	const TARGET &Cast() const {
-		if (binding_type != TARGET::TYPE) {
-			throw InternalException("Failed to cast binding to type - binding type mismatch");
-		}
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-};
-
-struct EntryBinding : public Binding {
-public:
-	static constexpr const BindingType TYPE = BindingType::CATALOG_ENTRY;
-
-public:
-	EntryBinding(const string &alias, vector<LogicalType> types, vector<string> names, idx_t index,
-	             StandardEntry &entry);
-	StandardEntry &entry;
-
-public:
-	optional_ptr<StandardEntry> GetStandardEntry() override;
-};
-
-//! TableBinding is exactly like the Binding, except it keeps track of which columns were bound in the linked LogicalGet
-//! node for projection pushdown purposes.
-struct TableBinding : public Binding {
-public:
-	static constexpr const BindingType TYPE = BindingType::TABLE;
-
-public:
-	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names,
-	             vector<ColumnIndex> &bound_column_ids, optional_ptr<StandardEntry> entry, idx_t index,
-	             bool add_row_id = false);
-
-	//! A reference to the set of bound column ids
-	vector<ColumnIndex> &bound_column_ids;
-	//! The underlying catalog entry (if any)
-	optional_ptr<StandardEntry> entry;
-
-public:
-	unique_ptr<ParsedExpression> ExpandGeneratedColumn(const string &column_name);
-	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override;
-	optional_ptr<StandardEntry> GetStandardEntry() override;
-	ErrorData ColumnNotFoundError(const string &column_name) const override;
-	// These are columns that are present in the name_map, appearing in the order that they're bound
-	const vector<ColumnIndex> &GetBoundColumnIds() const;
-
-protected:
-	ColumnBinding GetColumnBinding(column_t column_index);
-};
-
-//! DummyBinding is like the Binding, except the alias and index are set by default.
-//! Used for binding lambdas and macro parameters.
-struct DummyBinding : public Binding {
-public:
-	static constexpr const BindingType TYPE = BindingType::DUMMY;
-	// NOTE: changing this string conflicts with the storage version
-	static constexpr const char *DUMMY_NAME = "0_macro_parameters";
-
-public:
-	DummyBinding(vector<LogicalType> types, vector<string> names, string dummy_name);
-
-	//! Arguments (for macros)
-	vector<unique_ptr<ParsedExpression>> *arguments;
-	//! The name of the dummy binding
-	string dummy_name;
-
-public:
-	//! Binding macros
-	BindResult Bind(ColumnRefExpression &col_ref, idx_t depth) override;
-	//! Binding lambdas
-	BindResult Bind(LambdaRefExpression &lambda_ref, idx_t depth);
-
-	//! Returns a copy of the col_ref parameter as a parsed expression
-	unique_ptr<ParsedExpression> ParamToArg(ColumnRefExpression &col_ref);
-};
-
-} // namespace duckdb
-
-
-namespace duckdb {
-class Binder;
-class LogicalGet;
-class BoundQueryNode;
-
-class StarExpression;
-
-class TableCatalogEntry;
-class TableFunctionCatalogEntry;
-
-struct UsingColumnSet {
-	BindingAlias primary_binding;
-	vector<BindingAlias> bindings;
-};
-
-enum class ColumnBindType { EXPAND_GENERATED_COLUMNS, DO_NOT_EXPAND_GENERATED_COLUMNS };
-
-//! The BindContext object keeps track of all the tables and columns that are
-//! encountered during the binding process.
-class BindContext {
-public:
-	explicit BindContext(Binder &binder);
-
-	//! Keep track of recursive CTE references
-	case_insensitive_map_t<shared_ptr<idx_t>> cte_references;
-
-public:
-	//! Given a column name, find the matching table it belongs to. Throws an
-	//! exception if no table has a column of the given name.
-	optional_ptr<Binding> GetMatchingBinding(const string &column_name);
-	//! Like GetMatchingBinding, but instead of throwing an error if multiple tables have the same binding it will
-	//! return a list of all the matching ones
-	vector<reference<Binding>> GetMatchingBindings(const string &column_name);
-	//! Like GetMatchingBindings, but returns the top 3 most similar bindings (in levenshtein distance) instead of the
-	//! matching ones
-	vector<string> GetSimilarBindings(const string &column_name);
-
-	optional_ptr<Binding> GetCTEBinding(const string &ctename);
-	//! Binds a column expression to the base table. Returns the bound expression
-	//! or throws an exception if the column could not be bound.
-	BindResult BindColumn(ColumnRefExpression &colref, idx_t depth);
-	string BindColumn(PositionalReferenceExpression &ref, string &table_name, string &column_name);
-	unique_ptr<ColumnRefExpression> PositionToColumn(PositionalReferenceExpression &ref);
-
-	unique_ptr<ParsedExpression> ExpandGeneratedColumn(TableBinding &table_binding, const string &column_name);
-
-	unique_ptr<ParsedExpression>
-	CreateColumnReference(const string &table_name, const string &column_name,
-	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
-	unique_ptr<ParsedExpression>
-	CreateColumnReference(const string &schema_name, const string &table_name, const string &column_name,
-	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
-	unique_ptr<ParsedExpression>
-	CreateColumnReference(const string &catalog_name, const string &schema_name, const string &table_name,
-	                      const string &column_name,
-	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
-	unique_ptr<ParsedExpression>
-	CreateColumnReference(const BindingAlias &table_alias, const string &column_name,
-	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
-
-	//! Generate column expressions for all columns that are present in the
-	//! referenced tables. This is used to resolve the * expression in a
-	//! selection list.
-	void GenerateAllColumnExpressions(StarExpression &expr, vector<unique_ptr<ParsedExpression>> &new_select_list);
-
-	const vector<unique_ptr<Binding>> &GetBindingsList() {
-		return bindings_list;
-	}
-	vector<BindingAlias> GetBindingAliases();
-
-	void GetTypesAndNames(vector<string> &result_names, vector<LogicalType> &result_types);
-
-	//! Adds a base table with the given alias to the BindContext.
-	void AddBaseTable(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
-	                  vector<ColumnIndex> &bound_column_ids, StandardEntry &entry, bool add_row_id = true);
-	void AddBaseTable(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
-	                  vector<ColumnIndex> &bound_column_ids, const string &table_name);
-	//! Adds a call to a table function with the given alias to the BindContext.
-	void AddTableFunction(idx_t index, const string &alias, const vector<string> &names,
-	                      const vector<LogicalType> &types, vector<ColumnIndex> &bound_column_ids,
-	                      optional_ptr<StandardEntry> entry);
-	//! Adds a table view with a given alias to the BindContext.
-	void AddView(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery, ViewCatalogEntry &view);
-	//! Adds a subquery with a given alias to the BindContext.
-	void AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery);
-	//! Adds a subquery with a given alias to the BindContext.
-	void AddSubquery(idx_t index, const string &alias, TableFunctionRef &ref, BoundQueryNode &subquery);
-	//! Adds a binding to a catalog entry with a given alias to the BindContext.
-	void AddEntryBinding(idx_t index, const string &alias, const vector<string> &names,
-	                     const vector<LogicalType> &types, StandardEntry &entry);
-	//! Adds a base table with the given alias to the BindContext.
-	void AddGenericBinding(idx_t index, const string &alias, const vector<string> &names,
-	                       const vector<LogicalType> &types);
-
-	//! Adds a base table with the given alias to the CTE BindContext.
-	//! We need this to correctly bind recursive CTEs with multiple references.
-	void AddCTEBinding(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types);
-
-	//! Add an implicit join condition (e.g. USING (x))
-	void AddUsingBinding(const string &column_name, UsingColumnSet &set);
-
-	void AddUsingBindingSet(unique_ptr<UsingColumnSet> set);
-
-	//! Returns any using column set for the given column name, or nullptr if there is none. On conflict (multiple using
-	//! column sets with the same name) throw an exception.
-	optional_ptr<UsingColumnSet> GetUsingBinding(const string &column_name);
-	//! Returns any using column set for the given column name, or nullptr if there is none
-	optional_ptr<UsingColumnSet> GetUsingBinding(const string &column_name, const BindingAlias &binding);
-	//! Erase a using binding from the set of using bindings
-	void RemoveUsingBinding(const string &column_name, UsingColumnSet &set);
-	//! Transfer a using binding from one bind context to this bind context
-	void TransferUsingBinding(BindContext &current_context, optional_ptr<UsingColumnSet> current_set,
-	                          UsingColumnSet &new_set, const string &using_column);
-
-	//! Fetch the actual column name from the given binding, or throws if none exists
-	//! This can be different from "column_name" because of case insensitivity
-	//! (e.g. "column_name" might return "COLUMN_NAME")
-	string GetActualColumnName(const BindingAlias &binding_alias, const string &column_name);
-	string GetActualColumnName(Binding &binding, const string &column_name);
-
-	case_insensitive_map_t<shared_ptr<Binding>> GetCTEBindings() {
-		return cte_bindings;
-	}
-	void SetCTEBindings(case_insensitive_map_t<shared_ptr<Binding>> bindings) {
-		cte_bindings = std::move(bindings);
-	}
-
-	//! Alias a set of column names for the specified table, using the original names if there are not enough aliases
-	//! specified.
-	static vector<string> AliasColumnNames(const string &table_name, const vector<string> &names,
-	                                       const vector<string> &column_aliases);
-
-	//! Add all the bindings from a BindContext to this BindContext. The other BindContext is destroyed in the process.
-	void AddContext(BindContext other);
-	//! For semi and anti joins we remove the binding context of the right table after binding the condition.
-	void RemoveContext(const vector<BindingAlias> &aliases);
-
-	//! Gets a binding of the specified name. Returns a nullptr and sets the out_error if the binding could not be
-	//! found.
-	optional_ptr<Binding> GetBinding(const string &name, ErrorData &out_error);
-
-	optional_ptr<Binding> GetBinding(const BindingAlias &alias, ErrorData &out_error);
-
-	optional_ptr<Binding> GetBinding(const BindingAlias &alias, const string &column_name, ErrorData &out_error);
-
-	//! Get all bindings that match a specific binding alias - returns an error if none match
-	vector<reference<Binding>> GetBindings(const BindingAlias &alias, ErrorData &out_error);
-
-private:
-	void AddBinding(unique_ptr<Binding> binding);
-	static string AmbiguityException(const BindingAlias &alias, const vector<reference<Binding>> &bindings);
-
-private:
-	Binder &binder;
-	//! The list of bindings in insertion order
-	vector<unique_ptr<Binding>> bindings_list;
-	//! The set of columns used in USING join conditions
-	case_insensitive_map_t<reference_set_t<UsingColumnSet>> using_columns;
-	//! Using column sets
-	vector<unique_ptr<UsingColumnSet>> using_column_sets;
-
-	//! The set of CTE bindings
-	case_insensitive_map_t<shared_ptr<Binding>> cte_bindings;
-};
-} // namespace duckdb
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/function/partition_stats.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-namespace duckdb {
-
-//! How a table is partitioned by a given set of columns
-enum class TablePartitionInfo : uint8_t {
-	NOT_PARTITIONED,         // the table is not partitioned by the given set of columns
-	SINGLE_VALUE_PARTITIONS, // each partition has exactly one unique value (e.g. bounds = [1,1][2,2][3,3])
-	OVERLAPPING_PARTITIONS,  // the partitions overlap **only** at the boundaries (e.g. bounds = [1,2][2,3][3,4]
-	DISJOINT_PARTITIONS      // the partitions are disjoint (e.g. bounds = [1,2][3,4][5,6])
-};
-
-enum class CountType { COUNT_EXACT, COUNT_APPROXIMATE };
-
-struct PartitionStatistics {
-	PartitionStatistics();
-
-	//! The row id start
-	idx_t row_start;
-	//! The amount of rows in the partition
-	idx_t count;
-	//! Whether or not the count is exact or approximate
-	CountType count_type;
 };
 
 } // namespace duckdb
@@ -22969,7 +19238,9 @@ class LogicalDependencyList;
 class LogicalGet;
 class TableFunction;
 class TableFilterSet;
+class TableFunctionRef;
 class TableCatalogEntry;
+class SampleOptions;
 struct MultiFileReader;
 struct OperatorPartitionData;
 struct OperatorPartitionInfo;
@@ -23120,6 +19391,20 @@ struct TableFunctionToStringInput {
 	optional_ptr<const FunctionData> bind_data;
 };
 
+struct TableFunctionDynamicToStringInput {
+	TableFunctionDynamicToStringInput(const TableFunction &table_function_p,
+	                                  optional_ptr<const FunctionData> bind_data_p,
+	                                  optional_ptr<LocalTableFunctionState> local_state_p,
+	                                  optional_ptr<GlobalTableFunctionState> global_state_p)
+	    : table_function(table_function_p), bind_data(bind_data_p), local_state(local_state_p),
+	      global_state(global_state_p) {
+	}
+	const TableFunction &table_function;
+	optional_ptr<const FunctionData> bind_data;
+	optional_ptr<LocalTableFunctionState> local_state;
+	optional_ptr<GlobalTableFunctionState> global_state;
+};
+
 struct TableFunctionGetPartitionInput {
 public:
 	TableFunctionGetPartitionInput(optional_ptr<const FunctionData> bind_data_p,
@@ -23191,6 +19476,9 @@ public:
 typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, TableFunctionBindInput &input,
                                                           vector<LogicalType> &return_types, vector<string> &names);
 typedef unique_ptr<TableRef> (*table_function_bind_replace_t)(ClientContext &context, TableFunctionBindInput &input);
+typedef unique_ptr<LogicalOperator> (*table_function_bind_operator_t)(ClientContext &context,
+                                                                      TableFunctionBindInput &input, idx_t bind_index,
+                                                                      vector<string> &return_names);
 typedef unique_ptr<GlobalTableFunctionState> (*table_function_init_global_t)(ClientContext &context,
                                                                              TableFunctionInitInput &input);
 typedef unique_ptr<LocalTableFunctionState> (*table_function_init_local_t)(ExecutionContext &context,
@@ -23220,7 +19508,10 @@ typedef unique_ptr<NodeStatistics> (*table_function_cardinality_t)(ClientContext
 typedef void (*table_function_pushdown_complex_filter_t)(ClientContext &context, LogicalGet &get,
                                                          FunctionData *bind_data,
                                                          vector<unique_ptr<Expression>> &filters);
+typedef bool (*table_function_pushdown_expression_t)(ClientContext &context, const LogicalGet &get, Expression &expr);
 typedef InsertionOrderPreservingMap<string> (*table_function_to_string_t)(TableFunctionToStringInput &input);
+typedef InsertionOrderPreservingMap<string> (*table_function_dynamic_to_string_t)(
+    TableFunctionDynamicToStringInput &input);
 
 typedef void (*table_function_serialize_t)(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
                                            const TableFunction &function);
@@ -23233,6 +19524,12 @@ typedef TablePartitionInfo (*table_function_get_partition_info_t)(ClientContext 
 
 typedef vector<PartitionStatistics> (*table_function_get_partition_stats_t)(ClientContext &context,
                                                                             GetPartitionStatsInput &input);
+
+typedef virtual_column_map_t (*table_function_get_virtual_columns_t)(ClientContext &context,
+                                                                     optional_ptr<FunctionData> bind_data);
+
+typedef vector<column_t> (*table_function_get_row_id_columns)(ClientContext &context,
+                                                              optional_ptr<FunctionData> bind_data);
 
 //! When to call init_global to initialize the table function
 enum class TableFunctionInitialization { INITIALIZE_ON_EXECUTE, INITIALIZE_ON_SCHEDULE };
@@ -23257,6 +19554,10 @@ public:
 	//! to generate a logical plan that replaces the LogicalGet of a regularly bound TableFunction. The BindReplace can
 	//! also return a nullptr to indicate a regular bind needs to be performed instead.
 	table_function_bind_replace_t bind_replace;
+	//! (Optional) Bind operator function
+	//! This function is called before the regular bind function - similar to bind_replace - but allows returning a
+	//! custom LogicalOperator instead.
+	table_function_bind_operator_t bind_operator;
 	//! (Optional) global init function
 	//! Initialize the global operator state of the function.
 	//! The global operator state is used to keep track of the progress in the table function and is shared between
@@ -23284,8 +19585,12 @@ public:
 	//! (Optional) pushdown a set of arbitrary filter expressions, rather than only simple comparisons with a constant
 	//! Any functions remaining in the expression list will be pushed as a regular filter after the scan
 	table_function_pushdown_complex_filter_t pushdown_complex_filter;
-	//! (Optional) function for rendering the operator to a string in profiling output
+	//! (Optional) whether or not this table function supports pushing down an expression into a TableFilter
+	table_function_pushdown_expression_t pushdown_expression;
+	//! (Optional) function for rendering the operator to a string in explain/profiling output (invoked pre-execution)
 	table_function_to_string_t to_string;
+	//! (Optional) function for rendering the operator to a string in profiling output (invoked post-execution)
+	table_function_dynamic_to_string_t dynamic_to_string;
 	//! (Optional) return how much of the table we have scanned up to this point (% of the data)
 	table_function_progress_t table_scan_progress;
 	//! (Optional) returns the partition info of the current scan operator
@@ -23302,6 +19607,10 @@ public:
 	table_function_get_partition_info_t get_partition_info;
 	//! (Optional) get a list of all the partition stats of the table
 	table_function_get_partition_stats_t get_partition_stats;
+	//! (Optional) returns a list of virtual columns emitted by the table function
+	table_function_get_virtual_columns_t get_virtual_columns;
+	//! (Optional) returns a list of row id columns
+	table_function_get_row_id_columns get_row_id_columns;
 
 	table_function_serialize_t serialize;
 	table_function_deserialize_t deserialize;
@@ -23319,6 +19628,8 @@ public:
 	//! Whether or not the table function supports sampling pushdown. If not supported a sample will be taken after the
 	//! table function.
 	bool sampling_pushdown;
+	//! Whether or not the table function supports late materialization
+	bool late_materialization;
 	//! Additional function info, passed to the bind
 	shared_ptr<TableFunctionInfo> function_info;
 
@@ -23511,6 +19822,10 @@ public:
 	Pipeline &pipeline;
 	unique_ptr<PipelineExecutor> pipeline_executor;
 
+	string TaskType() const override {
+		return "PipelineTask";
+	}
+
 public:
 	const PipelineExecutor &GetPipelineExecutor() const;
 	bool TaskBlockedOnResult() const override;
@@ -23579,6 +19894,7 @@ public:
 	//! Returns a list of all operators (including source and sink) involved in this pipeline
 	vector<reference<PhysicalOperator>> GetOperators();
 	vector<const_reference<PhysicalOperator>> GetOperators() const;
+	const vector<reference<PhysicalOperator>> &GetIntermediateOperators() const;
 
 	optional_ptr<PhysicalOperator> GetSink() {
 		return sink;
@@ -24265,6 +20581,3318 @@ const char *ToString(JoinRefType value);
 
 
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/catalog_entry/schema_catalog_entry.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/catalog_set.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/default/default_generator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+class ClientContext;
+
+class DefaultGenerator {
+public:
+	explicit DefaultGenerator(Catalog &catalog);
+	virtual ~DefaultGenerator();
+
+	Catalog &catalog;
+	atomic<bool> created_all_entries;
+
+public:
+	//! Creates a default entry with the specified name, or returns nullptr if no such entry can be generated
+	virtual unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name);
+	virtual unique_ptr<CatalogEntry> CreateDefaultEntry(CatalogTransaction transaction, const string &entry_name);
+	//! Get a list of all default entries in the generator
+	virtual vector<string> GetDefaultEntries() = 0;
+};
+
+} // namespace duckdb
+
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/transaction/transaction.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/standard_entry.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/dependency_list.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/catalog_entry_map.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+class CatalogEntry;
+
+struct CatalogEntryHashFunction {
+	uint64_t operator()(const reference<CatalogEntry> &a) const {
+		std::hash<void *> hash_func;
+		return hash_func((void *)&a.get());
+	}
+};
+
+struct CatalogEntryEquality {
+	bool operator()(const reference<CatalogEntry> &a, const reference<CatalogEntry> &b) const {
+		return RefersToSameObject(a, b);
+	}
+};
+
+using catalog_entry_set_t = unordered_set<reference<CatalogEntry>, CatalogEntryHashFunction, CatalogEntryEquality>;
+
+template <typename T>
+using catalog_entry_map_t = unordered_map<reference<CatalogEntry>, T, CatalogEntryHashFunction, CatalogEntryEquality>;
+
+using catalog_entry_vector_t = vector<reference<CatalogEntry>>;
+
+} // namespace duckdb
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/dependency.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+class CatalogEntry;
+
+struct DependencyFlags {
+public:
+	DependencyFlags() : value(0) {
+	}
+	DependencyFlags(const DependencyFlags &other) : value(other.value) {
+	}
+	virtual ~DependencyFlags() = default;
+	DependencyFlags &operator=(const DependencyFlags &other) {
+		value = other.value;
+		return *this;
+	}
+	bool operator==(const DependencyFlags &other) const {
+		return other.value == value;
+	}
+	bool operator!=(const DependencyFlags &other) const {
+		return !(*this == other);
+	}
+
+public:
+	virtual string ToString() const = 0;
+
+protected:
+	template <uint8_t BIT>
+	bool IsSet() const {
+		static const uint8_t FLAG = (1 << BIT);
+		return (value & FLAG) == FLAG;
+	}
+	template <uint8_t BIT>
+	void Set() {
+		static const uint8_t FLAG = (1 << BIT);
+		value |= FLAG;
+	}
+	void Merge(uint8_t other) {
+		value |= other;
+	}
+	uint8_t Value() {
+		return value;
+	}
+
+private:
+	uint8_t value;
+};
+
+struct DependencySubjectFlags : public DependencyFlags {
+private:
+	static constexpr uint8_t OWNERSHIP = 0;
+
+public:
+	DependencySubjectFlags &Apply(DependencySubjectFlags other) {
+		Merge(other.Value());
+		return *this;
+	}
+
+public:
+	bool IsOwnership() const {
+		return IsSet<OWNERSHIP>();
+	}
+
+public:
+	DependencySubjectFlags &SetOwnership() {
+		Set<OWNERSHIP>();
+		return *this;
+	}
+
+public:
+	string ToString() const override {
+		string result;
+		if (IsOwnership()) {
+			result += "OWNS";
+		}
+		return result;
+	}
+};
+
+struct DependencyDependentFlags : public DependencyFlags {
+private:
+	static constexpr uint8_t BLOCKING = 0;
+	static constexpr uint8_t OWNED_BY = 1;
+
+public:
+	DependencyDependentFlags &Apply(DependencyDependentFlags other) {
+		Merge(other.Value());
+		return *this;
+	}
+
+public:
+	bool IsBlocking() const {
+		return IsSet<BLOCKING>();
+	}
+	bool IsOwnedBy() const {
+		return IsSet<OWNED_BY>();
+	}
+
+public:
+	DependencyDependentFlags &SetBlocking() {
+		Set<BLOCKING>();
+		return *this;
+	}
+	DependencyDependentFlags &SetOwnedBy() {
+		Set<OWNED_BY>();
+		return *this;
+	}
+
+public:
+	string ToString() const override {
+		string result;
+		if (IsBlocking()) {
+			result += "REGULAR";
+		} else {
+			result += "AUTOMATIC";
+		}
+		result += " | ";
+		if (IsOwnedBy()) {
+			result += "OWNED BY";
+		}
+		return result;
+	}
+};
+
+struct CatalogEntryInfo {
+public:
+	CatalogType type;
+	string schema;
+	string name;
+
+public:
+	bool operator==(const CatalogEntryInfo &other) const {
+		if (other.type != type) {
+			return false;
+		}
+		if (!StringUtil::CIEquals(other.schema, schema)) {
+			return false;
+		}
+		if (!StringUtil::CIEquals(other.name, name)) {
+			return false;
+		}
+		return true;
+	}
+
+public:
+	void Serialize(Serializer &serializer) const;
+	static CatalogEntryInfo Deserialize(Deserializer &deserializer);
+};
+
+struct Dependency {
+	Dependency(CatalogEntry &entry, // NOLINT: Allow implicit conversion from `CatalogEntry`
+	           DependencyDependentFlags flags = DependencyDependentFlags().SetBlocking())
+	    : entry(entry), flags(std::move(flags)) {
+	}
+
+	//! The catalog entry this depends on
+	reference<CatalogEntry> entry;
+	//! The type of dependency
+	DependencyDependentFlags flags;
+};
+
+struct DependencyHashFunction {
+	uint64_t operator()(const Dependency &a) const {
+		std::hash<void *> hash_func;
+		return hash_func((void *)&a.entry.get());
+	}
+};
+
+struct DependencyEquality {
+	bool operator()(const Dependency &a, const Dependency &b) const {
+		return RefersToSameObject(a.entry, b.entry);
+	}
+};
+using dependency_set_t = unordered_set<Dependency, DependencyHashFunction, DependencyEquality>;
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class Catalog;
+class CatalogEntry;
+struct CreateInfo;
+class SchemaCatalogEntry;
+struct CatalogTransaction;
+class LogicalDependencyList;
+
+//! A minimal representation of a CreateInfo / CatalogEntry
+//! enough to look up the entry inside SchemaCatalogEntry::GetEntry
+struct LogicalDependency {
+public:
+	CatalogEntryInfo entry;
+	string catalog;
+
+public:
+	explicit LogicalDependency(CatalogEntry &entry);
+	LogicalDependency();
+	LogicalDependency(optional_ptr<Catalog> catalog, CatalogEntryInfo entry, string catalog_str);
+	bool operator==(const LogicalDependency &other) const;
+
+public:
+	void Serialize(Serializer &serializer) const;
+	static LogicalDependency Deserialize(Deserializer &deserializer);
+};
+
+struct LogicalDependencyHashFunction {
+	uint64_t operator()(const LogicalDependency &a) const;
+};
+
+struct LogicalDependencyEquality {
+	bool operator()(const LogicalDependency &a, const LogicalDependency &b) const;
+};
+
+//! The LogicalDependencyList containing LogicalDependency objects, not looked up in the catalog yet
+class LogicalDependencyList {
+	using create_info_set_t =
+	    unordered_set<LogicalDependency, LogicalDependencyHashFunction, LogicalDependencyEquality>;
+
+public:
+	DUCKDB_API void AddDependency(CatalogEntry &entry);
+	DUCKDB_API void AddDependency(const LogicalDependency &entry);
+	DUCKDB_API bool Contains(CatalogEntry &entry);
+
+public:
+	DUCKDB_API void VerifyDependencies(Catalog &catalog, const string &name);
+	void Serialize(Serializer &serializer) const;
+	static LogicalDependencyList Deserialize(Deserializer &deserializer);
+	bool operator==(const LogicalDependencyList &other) const;
+	const create_info_set_t &Set() const;
+
+private:
+	create_info_set_t set;
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class SchemaCatalogEntry;
+
+//! A StandardEntry is a catalog entry that is a member of a schema
+class StandardEntry : public InCatalogEntry {
+public:
+	StandardEntry(CatalogType type, SchemaCatalogEntry &schema, Catalog &catalog, string name)
+	    : InCatalogEntry(type, catalog, std::move(name)), schema(schema) {
+	}
+	~StandardEntry() override {
+	}
+
+	//! The schema the entry belongs to
+	SchemaCatalogEntry &schema;
+	//! The dependencies of the entry, can be empty
+	LogicalDependencyList dependencies;
+
+public:
+	SchemaCatalogEntry &ParentSchema() override {
+		return schema;
+	}
+	const SchemaCatalogEntry &ParentSchema() const override {
+		return schema;
+	}
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/create_sequence_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/create_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/parse_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+enum class CatalogType : uint8_t;
+
+enum class ParseInfoType : uint8_t {
+	ALTER_INFO,
+	ATTACH_INFO,
+	COPY_INFO,
+	CREATE_INFO,
+	CREATE_SECRET_INFO,
+	DETACH_INFO,
+	DROP_INFO,
+	BOUND_EXPORT_DATA,
+	LOAD_INFO,
+	PRAGMA_INFO,
+	SHOW_SELECT_INFO,
+	TRANSACTION_INFO,
+	VACUUM_INFO,
+	COMMENT_ON_INFO,
+	COMMENT_ON_COLUMN_INFO,
+	COPY_DATABASE_INFO,
+	UPDATE_EXTENSIONS_INFO
+};
+
+struct ParseInfo {
+	explicit ParseInfo(ParseInfoType info_type) : info_type(info_type) {
+	}
+	virtual ~ParseInfo() {
+	}
+
+	ParseInfoType info_type;
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+	virtual void Serialize(Serializer &serializer) const;
+	static unique_ptr<ParseInfo> Deserialize(Deserializer &deserializer);
+	static string QualifierToString(const string &catalog, const string &schema, const string &name);
+	static string TypeToString(CatalogType type);
+};
+
+} // namespace duckdb
+
+//-------------------------------------------------------------------------
+// This file is automatically generated by scripts/generate_enum_util.py
+// Do not edit this file manually, your changes will be overwritten
+// If you want to exclude an enum from serialization, add it to the blacklist in the script
+//
+// Note: The generated code will only work properly if the enum is a top level item in the duckdb namespace
+// If the enum is nested in a class, or in another namespace, the generated code will not compile.
+// You should move the enum to the duckdb namespace, manually write a specialization or add it to the blacklist
+//-------------------------------------------------------------------------
+
+
+
+
+#include <stdint.h>
+
+
+namespace duckdb {
+
+struct EnumUtil {
+    // String -> Enum
+    template <class T>
+    static T FromString(const char *value) = delete;
+
+    template <class T>
+    static T FromString(const string &value) { return FromString<T>(value.c_str()); }
+
+    // Enum -> String
+    template <class T>
+    static const char *ToChars(T value) = delete;
+
+    template <class T>
+    static string ToString(T value) { return string(ToChars<T>(value)); }
+};
+
+enum class ARTConflictType : uint8_t;
+
+enum class ARTHandlingResult : uint8_t;
+
+enum class ARTScanHandling : uint8_t;
+
+enum class AccessMode : uint8_t;
+
+enum class AggregateCombineType : uint8_t;
+
+enum class AggregateDistinctDependent : uint8_t;
+
+enum class AggregateHandling : uint8_t;
+
+enum class AggregateOrderDependent : uint8_t;
+
+enum class AggregateType : uint8_t;
+
+enum class AlterForeignKeyType : uint8_t;
+
+enum class AlterScalarFunctionType : uint8_t;
+
+enum class AlterTableFunctionType : uint8_t;
+
+enum class AlterTableType : uint8_t;
+
+enum class AlterType : uint8_t;
+
+enum class AlterViewType : uint8_t;
+
+enum class AppenderType : uint8_t;
+
+enum class ArrowDateTimeType : uint8_t;
+
+enum class ArrowOffsetSize : uint8_t;
+
+enum class ArrowTypeInfoType : uint8_t;
+
+enum class ArrowVariableSizeType : uint8_t;
+
+enum class BinderType : uint8_t;
+
+enum class BindingMode : uint8_t;
+
+enum class BitpackingMode : uint8_t;
+
+enum class BlockState : uint8_t;
+
+enum class CAPIResultSetType : uint8_t;
+
+enum class CSVState : uint8_t;
+
+enum class CTEMaterialize : uint8_t;
+
+enum class CatalogLookupBehavior : uint8_t;
+
+enum class CatalogType : uint8_t;
+
+enum class CheckpointAbort : uint8_t;
+
+enum class ChunkInfoType : uint8_t;
+
+enum class ColumnDataAllocatorType : uint8_t;
+
+enum class ColumnDataScanProperties : uint8_t;
+
+enum class ColumnSegmentType : uint8_t;
+
+enum class CompressedMaterializationDirection : uint8_t;
+
+enum class CompressionType : uint8_t;
+
+enum class CompressionValidity : uint8_t;
+
+enum class ConflictManagerMode : uint8_t;
+
+enum class ConstraintType : uint8_t;
+
+enum class CopyFunctionReturnType : uint8_t;
+
+enum class CopyOverwriteMode : uint8_t;
+
+enum class CopyToType : uint8_t;
+
+enum class DataFileType : uint8_t;
+
+enum class DateCastResult : uint8_t;
+
+enum class DatePartSpecifier : uint8_t;
+
+enum class DebugInitialize : uint8_t;
+
+enum class DebugVectorVerification : uint8_t;
+
+enum class DecimalBitWidth : uint8_t;
+
+enum class DefaultOrderByNullType : uint8_t;
+
+enum class DependencyEntryType : uint8_t;
+
+enum class DeprecatedIndexType : uint8_t;
+
+enum class DestroyBufferUpon : uint8_t;
+
+enum class DistinctType : uint8_t;
+
+enum class ErrorType : uint16_t;
+
+enum class ExceptionFormatValueType : uint8_t;
+
+enum class ExceptionType : uint8_t;
+
+enum class ExplainFormat : uint8_t;
+
+enum class ExplainOutputType : uint8_t;
+
+enum class ExplainType : uint8_t;
+
+enum class ExponentType : uint8_t;
+
+enum class ExpressionClass : uint8_t;
+
+enum class ExpressionType : uint8_t;
+
+enum class ExtensionABIType : uint8_t;
+
+enum class ExtensionInstallMode : uint8_t;
+
+enum class ExtensionLoadResult : uint8_t;
+
+enum class ExtensionUpdateResultTag : uint8_t;
+
+enum class ExtraDropInfoType : uint8_t;
+
+enum class ExtraTypeInfoType : uint8_t;
+
+enum class FileBufferType : uint8_t;
+
+enum class FileCompressionType : uint8_t;
+
+enum class FileExpandResult : uint8_t;
+
+enum class FileGlobOptions : uint8_t;
+
+enum class FileLockType : uint8_t;
+
+enum class FileNameSegmentType : uint8_t;
+
+enum class FilterPropagateResult : uint8_t;
+
+enum class ForeignKeyType : uint8_t;
+
+enum class FunctionCollationHandling : uint8_t;
+
+enum class FunctionErrors : uint8_t;
+
+enum class FunctionNullHandling : uint8_t;
+
+enum class FunctionStability : uint8_t;
+
+enum class GateStatus : uint8_t;
+
+enum class HLLStorageType : uint8_t;
+
+enum class HTTPStatusCode : uint16_t;
+
+enum class IndexAppendMode : uint8_t;
+
+enum class IndexConstraintType : uint8_t;
+
+enum class InsertColumnOrder : uint8_t;
+
+enum class InterruptMode : uint8_t;
+
+enum class JoinRefType : uint8_t;
+
+enum class JoinType : uint8_t;
+
+enum class KeywordCategory : uint8_t;
+
+enum class LambdaSyntax : uint8_t;
+
+enum class LambdaSyntaxType : uint8_t;
+
+enum class LimitNodeType : uint8_t;
+
+enum class LoadType : uint8_t;
+
+enum class LogContextScope : uint8_t;
+
+enum class LogLevel : uint8_t;
+
+enum class LogMode : uint8_t;
+
+enum class LogicalOperatorType : uint8_t;
+
+enum class LogicalTypeId : uint8_t;
+
+enum class LookupResultType : uint8_t;
+
+enum class MacroType : uint8_t;
+
+enum class MapInvalidReason : uint8_t;
+
+enum class MemoryTag : uint8_t;
+
+enum class MetaPipelineType : uint8_t;
+
+enum class MetricsType : uint8_t;
+
+enum class MultiFileColumnMappingMode : uint8_t;
+
+enum class MultiFileFileState : uint8_t;
+
+enum class NType : uint8_t;
+
+enum class NewLineIdentifier : uint8_t;
+
+enum class OnConflictAction : uint8_t;
+
+enum class OnCreateConflict : uint8_t;
+
+enum class OnEntryNotFound : uint8_t;
+
+enum class OperatorFinalResultType : uint8_t;
+
+enum class OperatorFinalizeResultType : uint8_t;
+
+enum class OperatorResultType : uint8_t;
+
+enum class OptimizerType : uint32_t;
+
+enum class OrderByNullType : uint8_t;
+
+enum class OrderPreservationType : uint8_t;
+
+enum class OrderType : uint8_t;
+
+enum class OutputStream : uint8_t;
+
+enum class ParseInfoType : uint8_t;
+
+enum class ParserExtensionResultType : uint8_t;
+
+enum class PartitionSortStage : uint8_t;
+
+enum class PartitionedColumnDataType : uint8_t;
+
+enum class PartitionedTupleDataType : uint8_t;
+
+enum class PendingExecutionResult : uint8_t;
+
+enum class PhysicalOperatorType : uint8_t;
+
+enum class PhysicalType : uint8_t;
+
+enum class PragmaType : uint8_t;
+
+enum class PreparedParamType : uint8_t;
+
+enum class PreparedStatementMode : uint8_t;
+
+enum class PreserveOrderType : uint8_t;
+
+enum class ProfilerPrintFormat : uint8_t;
+
+enum class QuantileSerializationType : uint8_t;
+
+enum class QueryNodeType : uint8_t;
+
+enum class QueryResultType : uint8_t;
+
+enum class RelationType : uint8_t;
+
+enum class RenderMode : uint8_t;
+
+enum class RequestType : uint8_t;
+
+enum class ResultModifierType : uint8_t;
+
+enum class SampleMethod : uint8_t;
+
+enum class SampleType : uint8_t;
+
+enum class SamplingState : uint8_t;
+
+enum class ScanType : uint8_t;
+
+enum class SecretDisplayType : uint8_t;
+
+enum class SecretPersistType : uint8_t;
+
+enum class SecretSerializationType : uint8_t;
+
+enum class SequenceInfo : uint8_t;
+
+enum class SetOperationType : uint8_t;
+
+enum class SetScope : uint8_t;
+
+enum class SetType : uint8_t;
+
+enum class SettingScope : uint8_t;
+
+enum class ShowType : uint8_t;
+
+enum class SimplifiedTokenType : uint8_t;
+
+enum class SinkCombineResultType : uint8_t;
+
+enum class SinkFinalizeType : uint8_t;
+
+enum class SinkNextBatchType : uint8_t;
+
+enum class SinkResultType : uint8_t;
+
+enum class SourceResultType : uint8_t;
+
+enum class StarExpressionType : uint8_t;
+
+enum class StatementReturnType : uint8_t;
+
+enum class StatementType : uint8_t;
+
+enum class StatisticsType : uint8_t;
+
+enum class StatsInfo : uint8_t;
+
+enum class StrTimeSpecifier : uint8_t;
+
+enum class StreamExecutionResult : uint8_t;
+
+enum class SubqueryType : uint8_t;
+
+enum class TableColumnType : uint8_t;
+
+enum class TableFilterType : uint8_t;
+
+enum class TablePartitionInfo : uint8_t;
+
+enum class TableReferenceType : uint8_t;
+
+enum class TableScanType : uint8_t;
+
+enum class TaskExecutionMode : uint8_t;
+
+enum class TaskExecutionResult : uint8_t;
+
+enum class TemporaryBufferSize : uint64_t;
+
+enum class TemporaryCompressionLevel : int;
+
+enum class TimestampCastResult : uint8_t;
+
+enum class TransactionModifierType : uint8_t;
+
+enum class TransactionType : uint8_t;
+
+enum class TupleDataPinProperties : uint8_t;
+
+enum class UndoFlags : uint32_t;
+
+enum class UnionInvalidReason : uint8_t;
+
+enum class VectorAuxiliaryDataType : uint8_t;
+
+enum class VectorBufferType : uint8_t;
+
+enum class VectorType : uint8_t;
+
+enum class VerificationType : uint8_t;
+
+enum class VerifyExistenceType : uint8_t;
+
+enum class WALType : uint8_t;
+
+enum class WindowAggregationMode : uint32_t;
+
+enum class WindowBoundary : uint8_t;
+
+enum class WindowExcludeMode : uint8_t;
+
+
+template<>
+const char* EnumUtil::ToChars<ARTConflictType>(ARTConflictType value);
+
+template<>
+const char* EnumUtil::ToChars<ARTHandlingResult>(ARTHandlingResult value);
+
+template<>
+const char* EnumUtil::ToChars<ARTScanHandling>(ARTScanHandling value);
+
+template<>
+const char* EnumUtil::ToChars<AccessMode>(AccessMode value);
+
+template<>
+const char* EnumUtil::ToChars<AggregateCombineType>(AggregateCombineType value);
+
+template<>
+const char* EnumUtil::ToChars<AggregateDistinctDependent>(AggregateDistinctDependent value);
+
+template<>
+const char* EnumUtil::ToChars<AggregateHandling>(AggregateHandling value);
+
+template<>
+const char* EnumUtil::ToChars<AggregateOrderDependent>(AggregateOrderDependent value);
+
+template<>
+const char* EnumUtil::ToChars<AggregateType>(AggregateType value);
+
+template<>
+const char* EnumUtil::ToChars<AlterForeignKeyType>(AlterForeignKeyType value);
+
+template<>
+const char* EnumUtil::ToChars<AlterScalarFunctionType>(AlterScalarFunctionType value);
+
+template<>
+const char* EnumUtil::ToChars<AlterTableFunctionType>(AlterTableFunctionType value);
+
+template<>
+const char* EnumUtil::ToChars<AlterTableType>(AlterTableType value);
+
+template<>
+const char* EnumUtil::ToChars<AlterType>(AlterType value);
+
+template<>
+const char* EnumUtil::ToChars<AlterViewType>(AlterViewType value);
+
+template<>
+const char* EnumUtil::ToChars<AppenderType>(AppenderType value);
+
+template<>
+const char* EnumUtil::ToChars<ArrowDateTimeType>(ArrowDateTimeType value);
+
+template<>
+const char* EnumUtil::ToChars<ArrowOffsetSize>(ArrowOffsetSize value);
+
+template<>
+const char* EnumUtil::ToChars<ArrowTypeInfoType>(ArrowTypeInfoType value);
+
+template<>
+const char* EnumUtil::ToChars<ArrowVariableSizeType>(ArrowVariableSizeType value);
+
+template<>
+const char* EnumUtil::ToChars<BinderType>(BinderType value);
+
+template<>
+const char* EnumUtil::ToChars<BindingMode>(BindingMode value);
+
+template<>
+const char* EnumUtil::ToChars<BitpackingMode>(BitpackingMode value);
+
+template<>
+const char* EnumUtil::ToChars<BlockState>(BlockState value);
+
+template<>
+const char* EnumUtil::ToChars<CAPIResultSetType>(CAPIResultSetType value);
+
+template<>
+const char* EnumUtil::ToChars<CSVState>(CSVState value);
+
+template<>
+const char* EnumUtil::ToChars<CTEMaterialize>(CTEMaterialize value);
+
+template<>
+const char* EnumUtil::ToChars<CatalogLookupBehavior>(CatalogLookupBehavior value);
+
+template<>
+const char* EnumUtil::ToChars<CatalogType>(CatalogType value);
+
+template<>
+const char* EnumUtil::ToChars<CheckpointAbort>(CheckpointAbort value);
+
+template<>
+const char* EnumUtil::ToChars<ChunkInfoType>(ChunkInfoType value);
+
+template<>
+const char* EnumUtil::ToChars<ColumnDataAllocatorType>(ColumnDataAllocatorType value);
+
+template<>
+const char* EnumUtil::ToChars<ColumnDataScanProperties>(ColumnDataScanProperties value);
+
+template<>
+const char* EnumUtil::ToChars<ColumnSegmentType>(ColumnSegmentType value);
+
+template<>
+const char* EnumUtil::ToChars<CompressedMaterializationDirection>(CompressedMaterializationDirection value);
+
+template<>
+const char* EnumUtil::ToChars<CompressionType>(CompressionType value);
+
+template<>
+const char* EnumUtil::ToChars<CompressionValidity>(CompressionValidity value);
+
+template<>
+const char* EnumUtil::ToChars<ConflictManagerMode>(ConflictManagerMode value);
+
+template<>
+const char* EnumUtil::ToChars<ConstraintType>(ConstraintType value);
+
+template<>
+const char* EnumUtil::ToChars<CopyFunctionReturnType>(CopyFunctionReturnType value);
+
+template<>
+const char* EnumUtil::ToChars<CopyOverwriteMode>(CopyOverwriteMode value);
+
+template<>
+const char* EnumUtil::ToChars<CopyToType>(CopyToType value);
+
+template<>
+const char* EnumUtil::ToChars<DataFileType>(DataFileType value);
+
+template<>
+const char* EnumUtil::ToChars<DateCastResult>(DateCastResult value);
+
+template<>
+const char* EnumUtil::ToChars<DatePartSpecifier>(DatePartSpecifier value);
+
+template<>
+const char* EnumUtil::ToChars<DebugInitialize>(DebugInitialize value);
+
+template<>
+const char* EnumUtil::ToChars<DebugVectorVerification>(DebugVectorVerification value);
+
+template<>
+const char* EnumUtil::ToChars<DecimalBitWidth>(DecimalBitWidth value);
+
+template<>
+const char* EnumUtil::ToChars<DefaultOrderByNullType>(DefaultOrderByNullType value);
+
+template<>
+const char* EnumUtil::ToChars<DependencyEntryType>(DependencyEntryType value);
+
+template<>
+const char* EnumUtil::ToChars<DeprecatedIndexType>(DeprecatedIndexType value);
+
+template<>
+const char* EnumUtil::ToChars<DestroyBufferUpon>(DestroyBufferUpon value);
+
+template<>
+const char* EnumUtil::ToChars<DistinctType>(DistinctType value);
+
+template<>
+const char* EnumUtil::ToChars<ErrorType>(ErrorType value);
+
+template<>
+const char* EnumUtil::ToChars<ExceptionFormatValueType>(ExceptionFormatValueType value);
+
+template<>
+const char* EnumUtil::ToChars<ExceptionType>(ExceptionType value);
+
+template<>
+const char* EnumUtil::ToChars<ExplainFormat>(ExplainFormat value);
+
+template<>
+const char* EnumUtil::ToChars<ExplainOutputType>(ExplainOutputType value);
+
+template<>
+const char* EnumUtil::ToChars<ExplainType>(ExplainType value);
+
+template<>
+const char* EnumUtil::ToChars<ExponentType>(ExponentType value);
+
+template<>
+const char* EnumUtil::ToChars<ExpressionClass>(ExpressionClass value);
+
+template<>
+const char* EnumUtil::ToChars<ExpressionType>(ExpressionType value);
+
+template<>
+const char* EnumUtil::ToChars<ExtensionABIType>(ExtensionABIType value);
+
+template<>
+const char* EnumUtil::ToChars<ExtensionInstallMode>(ExtensionInstallMode value);
+
+template<>
+const char* EnumUtil::ToChars<ExtensionLoadResult>(ExtensionLoadResult value);
+
+template<>
+const char* EnumUtil::ToChars<ExtensionUpdateResultTag>(ExtensionUpdateResultTag value);
+
+template<>
+const char* EnumUtil::ToChars<ExtraDropInfoType>(ExtraDropInfoType value);
+
+template<>
+const char* EnumUtil::ToChars<ExtraTypeInfoType>(ExtraTypeInfoType value);
+
+template<>
+const char* EnumUtil::ToChars<FileBufferType>(FileBufferType value);
+
+template<>
+const char* EnumUtil::ToChars<FileCompressionType>(FileCompressionType value);
+
+template<>
+const char* EnumUtil::ToChars<FileExpandResult>(FileExpandResult value);
+
+template<>
+const char* EnumUtil::ToChars<FileGlobOptions>(FileGlobOptions value);
+
+template<>
+const char* EnumUtil::ToChars<FileLockType>(FileLockType value);
+
+template<>
+const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value);
+
+template<>
+const char* EnumUtil::ToChars<FilterPropagateResult>(FilterPropagateResult value);
+
+template<>
+const char* EnumUtil::ToChars<ForeignKeyType>(ForeignKeyType value);
+
+template<>
+const char* EnumUtil::ToChars<FunctionCollationHandling>(FunctionCollationHandling value);
+
+template<>
+const char* EnumUtil::ToChars<FunctionErrors>(FunctionErrors value);
+
+template<>
+const char* EnumUtil::ToChars<FunctionNullHandling>(FunctionNullHandling value);
+
+template<>
+const char* EnumUtil::ToChars<FunctionStability>(FunctionStability value);
+
+template<>
+const char* EnumUtil::ToChars<GateStatus>(GateStatus value);
+
+template<>
+const char* EnumUtil::ToChars<HLLStorageType>(HLLStorageType value);
+
+template<>
+const char* EnumUtil::ToChars<HTTPStatusCode>(HTTPStatusCode value);
+
+template<>
+const char* EnumUtil::ToChars<IndexAppendMode>(IndexAppendMode value);
+
+template<>
+const char* EnumUtil::ToChars<IndexConstraintType>(IndexConstraintType value);
+
+template<>
+const char* EnumUtil::ToChars<InsertColumnOrder>(InsertColumnOrder value);
+
+template<>
+const char* EnumUtil::ToChars<InterruptMode>(InterruptMode value);
+
+template<>
+const char* EnumUtil::ToChars<JoinRefType>(JoinRefType value);
+
+template<>
+const char* EnumUtil::ToChars<JoinType>(JoinType value);
+
+template<>
+const char* EnumUtil::ToChars<KeywordCategory>(KeywordCategory value);
+
+template<>
+const char* EnumUtil::ToChars<LambdaSyntax>(LambdaSyntax value);
+
+template<>
+const char* EnumUtil::ToChars<LambdaSyntaxType>(LambdaSyntaxType value);
+
+template<>
+const char* EnumUtil::ToChars<LimitNodeType>(LimitNodeType value);
+
+template<>
+const char* EnumUtil::ToChars<LoadType>(LoadType value);
+
+template<>
+const char* EnumUtil::ToChars<LogContextScope>(LogContextScope value);
+
+template<>
+const char* EnumUtil::ToChars<LogLevel>(LogLevel value);
+
+template<>
+const char* EnumUtil::ToChars<LogMode>(LogMode value);
+
+template<>
+const char* EnumUtil::ToChars<LogicalOperatorType>(LogicalOperatorType value);
+
+template<>
+const char* EnumUtil::ToChars<LogicalTypeId>(LogicalTypeId value);
+
+template<>
+const char* EnumUtil::ToChars<LookupResultType>(LookupResultType value);
+
+template<>
+const char* EnumUtil::ToChars<MacroType>(MacroType value);
+
+template<>
+const char* EnumUtil::ToChars<MapInvalidReason>(MapInvalidReason value);
+
+template<>
+const char* EnumUtil::ToChars<MemoryTag>(MemoryTag value);
+
+template<>
+const char* EnumUtil::ToChars<MetaPipelineType>(MetaPipelineType value);
+
+template<>
+const char* EnumUtil::ToChars<MetricsType>(MetricsType value);
+
+template<>
+const char* EnumUtil::ToChars<MultiFileColumnMappingMode>(MultiFileColumnMappingMode value);
+
+template<>
+const char* EnumUtil::ToChars<MultiFileFileState>(MultiFileFileState value);
+
+template<>
+const char* EnumUtil::ToChars<NType>(NType value);
+
+template<>
+const char* EnumUtil::ToChars<NewLineIdentifier>(NewLineIdentifier value);
+
+template<>
+const char* EnumUtil::ToChars<OnConflictAction>(OnConflictAction value);
+
+template<>
+const char* EnumUtil::ToChars<OnCreateConflict>(OnCreateConflict value);
+
+template<>
+const char* EnumUtil::ToChars<OnEntryNotFound>(OnEntryNotFound value);
+
+template<>
+const char* EnumUtil::ToChars<OperatorFinalResultType>(OperatorFinalResultType value);
+
+template<>
+const char* EnumUtil::ToChars<OperatorFinalizeResultType>(OperatorFinalizeResultType value);
+
+template<>
+const char* EnumUtil::ToChars<OperatorResultType>(OperatorResultType value);
+
+template<>
+const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value);
+
+template<>
+const char* EnumUtil::ToChars<OrderByNullType>(OrderByNullType value);
+
+template<>
+const char* EnumUtil::ToChars<OrderPreservationType>(OrderPreservationType value);
+
+template<>
+const char* EnumUtil::ToChars<OrderType>(OrderType value);
+
+template<>
+const char* EnumUtil::ToChars<OutputStream>(OutputStream value);
+
+template<>
+const char* EnumUtil::ToChars<ParseInfoType>(ParseInfoType value);
+
+template<>
+const char* EnumUtil::ToChars<ParserExtensionResultType>(ParserExtensionResultType value);
+
+template<>
+const char* EnumUtil::ToChars<PartitionSortStage>(PartitionSortStage value);
+
+template<>
+const char* EnumUtil::ToChars<PartitionedColumnDataType>(PartitionedColumnDataType value);
+
+template<>
+const char* EnumUtil::ToChars<PartitionedTupleDataType>(PartitionedTupleDataType value);
+
+template<>
+const char* EnumUtil::ToChars<PendingExecutionResult>(PendingExecutionResult value);
+
+template<>
+const char* EnumUtil::ToChars<PhysicalOperatorType>(PhysicalOperatorType value);
+
+template<>
+const char* EnumUtil::ToChars<PhysicalType>(PhysicalType value);
+
+template<>
+const char* EnumUtil::ToChars<PragmaType>(PragmaType value);
+
+template<>
+const char* EnumUtil::ToChars<PreparedParamType>(PreparedParamType value);
+
+template<>
+const char* EnumUtil::ToChars<PreparedStatementMode>(PreparedStatementMode value);
+
+template<>
+const char* EnumUtil::ToChars<PreserveOrderType>(PreserveOrderType value);
+
+template<>
+const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value);
+
+template<>
+const char* EnumUtil::ToChars<QuantileSerializationType>(QuantileSerializationType value);
+
+template<>
+const char* EnumUtil::ToChars<QueryNodeType>(QueryNodeType value);
+
+template<>
+const char* EnumUtil::ToChars<QueryResultType>(QueryResultType value);
+
+template<>
+const char* EnumUtil::ToChars<RelationType>(RelationType value);
+
+template<>
+const char* EnumUtil::ToChars<RenderMode>(RenderMode value);
+
+template<>
+const char* EnumUtil::ToChars<RequestType>(RequestType value);
+
+template<>
+const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value);
+
+template<>
+const char* EnumUtil::ToChars<SampleMethod>(SampleMethod value);
+
+template<>
+const char* EnumUtil::ToChars<SampleType>(SampleType value);
+
+template<>
+const char* EnumUtil::ToChars<SamplingState>(SamplingState value);
+
+template<>
+const char* EnumUtil::ToChars<ScanType>(ScanType value);
+
+template<>
+const char* EnumUtil::ToChars<SecretDisplayType>(SecretDisplayType value);
+
+template<>
+const char* EnumUtil::ToChars<SecretPersistType>(SecretPersistType value);
+
+template<>
+const char* EnumUtil::ToChars<SecretSerializationType>(SecretSerializationType value);
+
+template<>
+const char* EnumUtil::ToChars<SequenceInfo>(SequenceInfo value);
+
+template<>
+const char* EnumUtil::ToChars<SetOperationType>(SetOperationType value);
+
+template<>
+const char* EnumUtil::ToChars<SetScope>(SetScope value);
+
+template<>
+const char* EnumUtil::ToChars<SetType>(SetType value);
+
+template<>
+const char* EnumUtil::ToChars<SettingScope>(SettingScope value);
+
+template<>
+const char* EnumUtil::ToChars<ShowType>(ShowType value);
+
+template<>
+const char* EnumUtil::ToChars<SimplifiedTokenType>(SimplifiedTokenType value);
+
+template<>
+const char* EnumUtil::ToChars<SinkCombineResultType>(SinkCombineResultType value);
+
+template<>
+const char* EnumUtil::ToChars<SinkFinalizeType>(SinkFinalizeType value);
+
+template<>
+const char* EnumUtil::ToChars<SinkNextBatchType>(SinkNextBatchType value);
+
+template<>
+const char* EnumUtil::ToChars<SinkResultType>(SinkResultType value);
+
+template<>
+const char* EnumUtil::ToChars<SourceResultType>(SourceResultType value);
+
+template<>
+const char* EnumUtil::ToChars<StarExpressionType>(StarExpressionType value);
+
+template<>
+const char* EnumUtil::ToChars<StatementReturnType>(StatementReturnType value);
+
+template<>
+const char* EnumUtil::ToChars<StatementType>(StatementType value);
+
+template<>
+const char* EnumUtil::ToChars<StatisticsType>(StatisticsType value);
+
+template<>
+const char* EnumUtil::ToChars<StatsInfo>(StatsInfo value);
+
+template<>
+const char* EnumUtil::ToChars<StrTimeSpecifier>(StrTimeSpecifier value);
+
+template<>
+const char* EnumUtil::ToChars<StreamExecutionResult>(StreamExecutionResult value);
+
+template<>
+const char* EnumUtil::ToChars<SubqueryType>(SubqueryType value);
+
+template<>
+const char* EnumUtil::ToChars<TableColumnType>(TableColumnType value);
+
+template<>
+const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value);
+
+template<>
+const char* EnumUtil::ToChars<TablePartitionInfo>(TablePartitionInfo value);
+
+template<>
+const char* EnumUtil::ToChars<TableReferenceType>(TableReferenceType value);
+
+template<>
+const char* EnumUtil::ToChars<TableScanType>(TableScanType value);
+
+template<>
+const char* EnumUtil::ToChars<TaskExecutionMode>(TaskExecutionMode value);
+
+template<>
+const char* EnumUtil::ToChars<TaskExecutionResult>(TaskExecutionResult value);
+
+template<>
+const char* EnumUtil::ToChars<TemporaryBufferSize>(TemporaryBufferSize value);
+
+template<>
+const char* EnumUtil::ToChars<TemporaryCompressionLevel>(TemporaryCompressionLevel value);
+
+template<>
+const char* EnumUtil::ToChars<TimestampCastResult>(TimestampCastResult value);
+
+template<>
+const char* EnumUtil::ToChars<TransactionModifierType>(TransactionModifierType value);
+
+template<>
+const char* EnumUtil::ToChars<TransactionType>(TransactionType value);
+
+template<>
+const char* EnumUtil::ToChars<TupleDataPinProperties>(TupleDataPinProperties value);
+
+template<>
+const char* EnumUtil::ToChars<UndoFlags>(UndoFlags value);
+
+template<>
+const char* EnumUtil::ToChars<UnionInvalidReason>(UnionInvalidReason value);
+
+template<>
+const char* EnumUtil::ToChars<VectorAuxiliaryDataType>(VectorAuxiliaryDataType value);
+
+template<>
+const char* EnumUtil::ToChars<VectorBufferType>(VectorBufferType value);
+
+template<>
+const char* EnumUtil::ToChars<VectorType>(VectorType value);
+
+template<>
+const char* EnumUtil::ToChars<VerificationType>(VerificationType value);
+
+template<>
+const char* EnumUtil::ToChars<VerifyExistenceType>(VerifyExistenceType value);
+
+template<>
+const char* EnumUtil::ToChars<WALType>(WALType value);
+
+template<>
+const char* EnumUtil::ToChars<WindowAggregationMode>(WindowAggregationMode value);
+
+template<>
+const char* EnumUtil::ToChars<WindowBoundary>(WindowBoundary value);
+
+template<>
+const char* EnumUtil::ToChars<WindowExcludeMode>(WindowExcludeMode value);
+
+
+template<>
+ARTConflictType EnumUtil::FromString<ARTConflictType>(const char *value);
+
+template<>
+ARTHandlingResult EnumUtil::FromString<ARTHandlingResult>(const char *value);
+
+template<>
+ARTScanHandling EnumUtil::FromString<ARTScanHandling>(const char *value);
+
+template<>
+AccessMode EnumUtil::FromString<AccessMode>(const char *value);
+
+template<>
+AggregateCombineType EnumUtil::FromString<AggregateCombineType>(const char *value);
+
+template<>
+AggregateDistinctDependent EnumUtil::FromString<AggregateDistinctDependent>(const char *value);
+
+template<>
+AggregateHandling EnumUtil::FromString<AggregateHandling>(const char *value);
+
+template<>
+AggregateOrderDependent EnumUtil::FromString<AggregateOrderDependent>(const char *value);
+
+template<>
+AggregateType EnumUtil::FromString<AggregateType>(const char *value);
+
+template<>
+AlterForeignKeyType EnumUtil::FromString<AlterForeignKeyType>(const char *value);
+
+template<>
+AlterScalarFunctionType EnumUtil::FromString<AlterScalarFunctionType>(const char *value);
+
+template<>
+AlterTableFunctionType EnumUtil::FromString<AlterTableFunctionType>(const char *value);
+
+template<>
+AlterTableType EnumUtil::FromString<AlterTableType>(const char *value);
+
+template<>
+AlterType EnumUtil::FromString<AlterType>(const char *value);
+
+template<>
+AlterViewType EnumUtil::FromString<AlterViewType>(const char *value);
+
+template<>
+AppenderType EnumUtil::FromString<AppenderType>(const char *value);
+
+template<>
+ArrowDateTimeType EnumUtil::FromString<ArrowDateTimeType>(const char *value);
+
+template<>
+ArrowOffsetSize EnumUtil::FromString<ArrowOffsetSize>(const char *value);
+
+template<>
+ArrowTypeInfoType EnumUtil::FromString<ArrowTypeInfoType>(const char *value);
+
+template<>
+ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *value);
+
+template<>
+BinderType EnumUtil::FromString<BinderType>(const char *value);
+
+template<>
+BindingMode EnumUtil::FromString<BindingMode>(const char *value);
+
+template<>
+BitpackingMode EnumUtil::FromString<BitpackingMode>(const char *value);
+
+template<>
+BlockState EnumUtil::FromString<BlockState>(const char *value);
+
+template<>
+CAPIResultSetType EnumUtil::FromString<CAPIResultSetType>(const char *value);
+
+template<>
+CSVState EnumUtil::FromString<CSVState>(const char *value);
+
+template<>
+CTEMaterialize EnumUtil::FromString<CTEMaterialize>(const char *value);
+
+template<>
+CatalogLookupBehavior EnumUtil::FromString<CatalogLookupBehavior>(const char *value);
+
+template<>
+CatalogType EnumUtil::FromString<CatalogType>(const char *value);
+
+template<>
+CheckpointAbort EnumUtil::FromString<CheckpointAbort>(const char *value);
+
+template<>
+ChunkInfoType EnumUtil::FromString<ChunkInfoType>(const char *value);
+
+template<>
+ColumnDataAllocatorType EnumUtil::FromString<ColumnDataAllocatorType>(const char *value);
+
+template<>
+ColumnDataScanProperties EnumUtil::FromString<ColumnDataScanProperties>(const char *value);
+
+template<>
+ColumnSegmentType EnumUtil::FromString<ColumnSegmentType>(const char *value);
+
+template<>
+CompressedMaterializationDirection EnumUtil::FromString<CompressedMaterializationDirection>(const char *value);
+
+template<>
+CompressionType EnumUtil::FromString<CompressionType>(const char *value);
+
+template<>
+CompressionValidity EnumUtil::FromString<CompressionValidity>(const char *value);
+
+template<>
+ConflictManagerMode EnumUtil::FromString<ConflictManagerMode>(const char *value);
+
+template<>
+ConstraintType EnumUtil::FromString<ConstraintType>(const char *value);
+
+template<>
+CopyFunctionReturnType EnumUtil::FromString<CopyFunctionReturnType>(const char *value);
+
+template<>
+CopyOverwriteMode EnumUtil::FromString<CopyOverwriteMode>(const char *value);
+
+template<>
+CopyToType EnumUtil::FromString<CopyToType>(const char *value);
+
+template<>
+DataFileType EnumUtil::FromString<DataFileType>(const char *value);
+
+template<>
+DateCastResult EnumUtil::FromString<DateCastResult>(const char *value);
+
+template<>
+DatePartSpecifier EnumUtil::FromString<DatePartSpecifier>(const char *value);
+
+template<>
+DebugInitialize EnumUtil::FromString<DebugInitialize>(const char *value);
+
+template<>
+DebugVectorVerification EnumUtil::FromString<DebugVectorVerification>(const char *value);
+
+template<>
+DecimalBitWidth EnumUtil::FromString<DecimalBitWidth>(const char *value);
+
+template<>
+DefaultOrderByNullType EnumUtil::FromString<DefaultOrderByNullType>(const char *value);
+
+template<>
+DependencyEntryType EnumUtil::FromString<DependencyEntryType>(const char *value);
+
+template<>
+DeprecatedIndexType EnumUtil::FromString<DeprecatedIndexType>(const char *value);
+
+template<>
+DestroyBufferUpon EnumUtil::FromString<DestroyBufferUpon>(const char *value);
+
+template<>
+DistinctType EnumUtil::FromString<DistinctType>(const char *value);
+
+template<>
+ErrorType EnumUtil::FromString<ErrorType>(const char *value);
+
+template<>
+ExceptionFormatValueType EnumUtil::FromString<ExceptionFormatValueType>(const char *value);
+
+template<>
+ExceptionType EnumUtil::FromString<ExceptionType>(const char *value);
+
+template<>
+ExplainFormat EnumUtil::FromString<ExplainFormat>(const char *value);
+
+template<>
+ExplainOutputType EnumUtil::FromString<ExplainOutputType>(const char *value);
+
+template<>
+ExplainType EnumUtil::FromString<ExplainType>(const char *value);
+
+template<>
+ExponentType EnumUtil::FromString<ExponentType>(const char *value);
+
+template<>
+ExpressionClass EnumUtil::FromString<ExpressionClass>(const char *value);
+
+template<>
+ExpressionType EnumUtil::FromString<ExpressionType>(const char *value);
+
+template<>
+ExtensionABIType EnumUtil::FromString<ExtensionABIType>(const char *value);
+
+template<>
+ExtensionInstallMode EnumUtil::FromString<ExtensionInstallMode>(const char *value);
+
+template<>
+ExtensionLoadResult EnumUtil::FromString<ExtensionLoadResult>(const char *value);
+
+template<>
+ExtensionUpdateResultTag EnumUtil::FromString<ExtensionUpdateResultTag>(const char *value);
+
+template<>
+ExtraDropInfoType EnumUtil::FromString<ExtraDropInfoType>(const char *value);
+
+template<>
+ExtraTypeInfoType EnumUtil::FromString<ExtraTypeInfoType>(const char *value);
+
+template<>
+FileBufferType EnumUtil::FromString<FileBufferType>(const char *value);
+
+template<>
+FileCompressionType EnumUtil::FromString<FileCompressionType>(const char *value);
+
+template<>
+FileExpandResult EnumUtil::FromString<FileExpandResult>(const char *value);
+
+template<>
+FileGlobOptions EnumUtil::FromString<FileGlobOptions>(const char *value);
+
+template<>
+FileLockType EnumUtil::FromString<FileLockType>(const char *value);
+
+template<>
+FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value);
+
+template<>
+FilterPropagateResult EnumUtil::FromString<FilterPropagateResult>(const char *value);
+
+template<>
+ForeignKeyType EnumUtil::FromString<ForeignKeyType>(const char *value);
+
+template<>
+FunctionCollationHandling EnumUtil::FromString<FunctionCollationHandling>(const char *value);
+
+template<>
+FunctionErrors EnumUtil::FromString<FunctionErrors>(const char *value);
+
+template<>
+FunctionNullHandling EnumUtil::FromString<FunctionNullHandling>(const char *value);
+
+template<>
+FunctionStability EnumUtil::FromString<FunctionStability>(const char *value);
+
+template<>
+GateStatus EnumUtil::FromString<GateStatus>(const char *value);
+
+template<>
+HLLStorageType EnumUtil::FromString<HLLStorageType>(const char *value);
+
+template<>
+HTTPStatusCode EnumUtil::FromString<HTTPStatusCode>(const char *value);
+
+template<>
+IndexAppendMode EnumUtil::FromString<IndexAppendMode>(const char *value);
+
+template<>
+IndexConstraintType EnumUtil::FromString<IndexConstraintType>(const char *value);
+
+template<>
+InsertColumnOrder EnumUtil::FromString<InsertColumnOrder>(const char *value);
+
+template<>
+InterruptMode EnumUtil::FromString<InterruptMode>(const char *value);
+
+template<>
+JoinRefType EnumUtil::FromString<JoinRefType>(const char *value);
+
+template<>
+JoinType EnumUtil::FromString<JoinType>(const char *value);
+
+template<>
+KeywordCategory EnumUtil::FromString<KeywordCategory>(const char *value);
+
+template<>
+LambdaSyntax EnumUtil::FromString<LambdaSyntax>(const char *value);
+
+template<>
+LambdaSyntaxType EnumUtil::FromString<LambdaSyntaxType>(const char *value);
+
+template<>
+LimitNodeType EnumUtil::FromString<LimitNodeType>(const char *value);
+
+template<>
+LoadType EnumUtil::FromString<LoadType>(const char *value);
+
+template<>
+LogContextScope EnumUtil::FromString<LogContextScope>(const char *value);
+
+template<>
+LogLevel EnumUtil::FromString<LogLevel>(const char *value);
+
+template<>
+LogMode EnumUtil::FromString<LogMode>(const char *value);
+
+template<>
+LogicalOperatorType EnumUtil::FromString<LogicalOperatorType>(const char *value);
+
+template<>
+LogicalTypeId EnumUtil::FromString<LogicalTypeId>(const char *value);
+
+template<>
+LookupResultType EnumUtil::FromString<LookupResultType>(const char *value);
+
+template<>
+MacroType EnumUtil::FromString<MacroType>(const char *value);
+
+template<>
+MapInvalidReason EnumUtil::FromString<MapInvalidReason>(const char *value);
+
+template<>
+MemoryTag EnumUtil::FromString<MemoryTag>(const char *value);
+
+template<>
+MetaPipelineType EnumUtil::FromString<MetaPipelineType>(const char *value);
+
+template<>
+MetricsType EnumUtil::FromString<MetricsType>(const char *value);
+
+template<>
+MultiFileColumnMappingMode EnumUtil::FromString<MultiFileColumnMappingMode>(const char *value);
+
+template<>
+MultiFileFileState EnumUtil::FromString<MultiFileFileState>(const char *value);
+
+template<>
+NType EnumUtil::FromString<NType>(const char *value);
+
+template<>
+NewLineIdentifier EnumUtil::FromString<NewLineIdentifier>(const char *value);
+
+template<>
+OnConflictAction EnumUtil::FromString<OnConflictAction>(const char *value);
+
+template<>
+OnCreateConflict EnumUtil::FromString<OnCreateConflict>(const char *value);
+
+template<>
+OnEntryNotFound EnumUtil::FromString<OnEntryNotFound>(const char *value);
+
+template<>
+OperatorFinalResultType EnumUtil::FromString<OperatorFinalResultType>(const char *value);
+
+template<>
+OperatorFinalizeResultType EnumUtil::FromString<OperatorFinalizeResultType>(const char *value);
+
+template<>
+OperatorResultType EnumUtil::FromString<OperatorResultType>(const char *value);
+
+template<>
+OptimizerType EnumUtil::FromString<OptimizerType>(const char *value);
+
+template<>
+OrderByNullType EnumUtil::FromString<OrderByNullType>(const char *value);
+
+template<>
+OrderPreservationType EnumUtil::FromString<OrderPreservationType>(const char *value);
+
+template<>
+OrderType EnumUtil::FromString<OrderType>(const char *value);
+
+template<>
+OutputStream EnumUtil::FromString<OutputStream>(const char *value);
+
+template<>
+ParseInfoType EnumUtil::FromString<ParseInfoType>(const char *value);
+
+template<>
+ParserExtensionResultType EnumUtil::FromString<ParserExtensionResultType>(const char *value);
+
+template<>
+PartitionSortStage EnumUtil::FromString<PartitionSortStage>(const char *value);
+
+template<>
+PartitionedColumnDataType EnumUtil::FromString<PartitionedColumnDataType>(const char *value);
+
+template<>
+PartitionedTupleDataType EnumUtil::FromString<PartitionedTupleDataType>(const char *value);
+
+template<>
+PendingExecutionResult EnumUtil::FromString<PendingExecutionResult>(const char *value);
+
+template<>
+PhysicalOperatorType EnumUtil::FromString<PhysicalOperatorType>(const char *value);
+
+template<>
+PhysicalType EnumUtil::FromString<PhysicalType>(const char *value);
+
+template<>
+PragmaType EnumUtil::FromString<PragmaType>(const char *value);
+
+template<>
+PreparedParamType EnumUtil::FromString<PreparedParamType>(const char *value);
+
+template<>
+PreparedStatementMode EnumUtil::FromString<PreparedStatementMode>(const char *value);
+
+template<>
+PreserveOrderType EnumUtil::FromString<PreserveOrderType>(const char *value);
+
+template<>
+ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value);
+
+template<>
+QuantileSerializationType EnumUtil::FromString<QuantileSerializationType>(const char *value);
+
+template<>
+QueryNodeType EnumUtil::FromString<QueryNodeType>(const char *value);
+
+template<>
+QueryResultType EnumUtil::FromString<QueryResultType>(const char *value);
+
+template<>
+RelationType EnumUtil::FromString<RelationType>(const char *value);
+
+template<>
+RenderMode EnumUtil::FromString<RenderMode>(const char *value);
+
+template<>
+RequestType EnumUtil::FromString<RequestType>(const char *value);
+
+template<>
+ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value);
+
+template<>
+SampleMethod EnumUtil::FromString<SampleMethod>(const char *value);
+
+template<>
+SampleType EnumUtil::FromString<SampleType>(const char *value);
+
+template<>
+SamplingState EnumUtil::FromString<SamplingState>(const char *value);
+
+template<>
+ScanType EnumUtil::FromString<ScanType>(const char *value);
+
+template<>
+SecretDisplayType EnumUtil::FromString<SecretDisplayType>(const char *value);
+
+template<>
+SecretPersistType EnumUtil::FromString<SecretPersistType>(const char *value);
+
+template<>
+SecretSerializationType EnumUtil::FromString<SecretSerializationType>(const char *value);
+
+template<>
+SequenceInfo EnumUtil::FromString<SequenceInfo>(const char *value);
+
+template<>
+SetOperationType EnumUtil::FromString<SetOperationType>(const char *value);
+
+template<>
+SetScope EnumUtil::FromString<SetScope>(const char *value);
+
+template<>
+SetType EnumUtil::FromString<SetType>(const char *value);
+
+template<>
+SettingScope EnumUtil::FromString<SettingScope>(const char *value);
+
+template<>
+ShowType EnumUtil::FromString<ShowType>(const char *value);
+
+template<>
+SimplifiedTokenType EnumUtil::FromString<SimplifiedTokenType>(const char *value);
+
+template<>
+SinkCombineResultType EnumUtil::FromString<SinkCombineResultType>(const char *value);
+
+template<>
+SinkFinalizeType EnumUtil::FromString<SinkFinalizeType>(const char *value);
+
+template<>
+SinkNextBatchType EnumUtil::FromString<SinkNextBatchType>(const char *value);
+
+template<>
+SinkResultType EnumUtil::FromString<SinkResultType>(const char *value);
+
+template<>
+SourceResultType EnumUtil::FromString<SourceResultType>(const char *value);
+
+template<>
+StarExpressionType EnumUtil::FromString<StarExpressionType>(const char *value);
+
+template<>
+StatementReturnType EnumUtil::FromString<StatementReturnType>(const char *value);
+
+template<>
+StatementType EnumUtil::FromString<StatementType>(const char *value);
+
+template<>
+StatisticsType EnumUtil::FromString<StatisticsType>(const char *value);
+
+template<>
+StatsInfo EnumUtil::FromString<StatsInfo>(const char *value);
+
+template<>
+StrTimeSpecifier EnumUtil::FromString<StrTimeSpecifier>(const char *value);
+
+template<>
+StreamExecutionResult EnumUtil::FromString<StreamExecutionResult>(const char *value);
+
+template<>
+SubqueryType EnumUtil::FromString<SubqueryType>(const char *value);
+
+template<>
+TableColumnType EnumUtil::FromString<TableColumnType>(const char *value);
+
+template<>
+TableFilterType EnumUtil::FromString<TableFilterType>(const char *value);
+
+template<>
+TablePartitionInfo EnumUtil::FromString<TablePartitionInfo>(const char *value);
+
+template<>
+TableReferenceType EnumUtil::FromString<TableReferenceType>(const char *value);
+
+template<>
+TableScanType EnumUtil::FromString<TableScanType>(const char *value);
+
+template<>
+TaskExecutionMode EnumUtil::FromString<TaskExecutionMode>(const char *value);
+
+template<>
+TaskExecutionResult EnumUtil::FromString<TaskExecutionResult>(const char *value);
+
+template<>
+TemporaryBufferSize EnumUtil::FromString<TemporaryBufferSize>(const char *value);
+
+template<>
+TemporaryCompressionLevel EnumUtil::FromString<TemporaryCompressionLevel>(const char *value);
+
+template<>
+TimestampCastResult EnumUtil::FromString<TimestampCastResult>(const char *value);
+
+template<>
+TransactionModifierType EnumUtil::FromString<TransactionModifierType>(const char *value);
+
+template<>
+TransactionType EnumUtil::FromString<TransactionType>(const char *value);
+
+template<>
+TupleDataPinProperties EnumUtil::FromString<TupleDataPinProperties>(const char *value);
+
+template<>
+UndoFlags EnumUtil::FromString<UndoFlags>(const char *value);
+
+template<>
+UnionInvalidReason EnumUtil::FromString<UnionInvalidReason>(const char *value);
+
+template<>
+VectorAuxiliaryDataType EnumUtil::FromString<VectorAuxiliaryDataType>(const char *value);
+
+template<>
+VectorBufferType EnumUtil::FromString<VectorBufferType>(const char *value);
+
+template<>
+VectorType EnumUtil::FromString<VectorType>(const char *value);
+
+template<>
+VerificationType EnumUtil::FromString<VerificationType>(const char *value);
+
+template<>
+VerifyExistenceType EnumUtil::FromString<VerifyExistenceType>(const char *value);
+
+template<>
+WALType EnumUtil::FromString<WALType>(const char *value);
+
+template<>
+WindowAggregationMode EnumUtil::FromString<WindowAggregationMode>(const char *value);
+
+template<>
+WindowBoundary EnumUtil::FromString<WindowBoundary>(const char *value);
+
+template<>
+WindowExcludeMode EnumUtil::FromString<WindowExcludeMode>(const char *value);
+
+
+}
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/on_create_conflict.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+enum class OnCreateConflict : uint8_t {
+	// Standard: throw error
+	ERROR_ON_CONFLICT,
+	// CREATE IF NOT EXISTS, silently do nothing on conflict
+	IGNORE_ON_CONFLICT,
+	// CREATE OR REPLACE
+	REPLACE_ON_CONFLICT,
+	// Update on conflict - only support for functions. Add a function overload if the function already exists.
+	ALTER_ON_CONFLICT
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+struct AlterInfo;
+
+struct CreateInfo : public ParseInfo {
+public:
+	static constexpr const ParseInfoType TYPE = ParseInfoType::CREATE_INFO;
+
+public:
+	explicit CreateInfo(CatalogType type, string schema = DEFAULT_SCHEMA, string catalog_p = INVALID_CATALOG)
+	    : ParseInfo(TYPE), type(type), catalog(std::move(catalog_p)), schema(std::move(schema)),
+	      on_conflict(OnCreateConflict::ERROR_ON_CONFLICT), temporary(false), internal(false) {
+	}
+	~CreateInfo() override {
+	}
+
+	//! The to-be-created catalog type
+	CatalogType type;
+	//! The catalog name of the entry
+	string catalog;
+	//! The schema name of the entry
+	string schema;
+	//! What to do on create conflict
+	OnCreateConflict on_conflict;
+	//! Whether or not the entry is temporary
+	bool temporary;
+	//! Whether or not the entry is an internal entry
+	bool internal;
+	//! The SQL string of the CREATE statement
+	string sql;
+	//! The inherent dependencies of the created entry
+	LogicalDependencyList dependencies;
+	//! User provided comment
+	Value comment;
+	//! Key-value tags with additional metadata
+	InsertionOrderPreservingMap<string> tags;
+
+public:
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<CreateInfo> Deserialize(Deserializer &deserializer);
+
+	virtual unique_ptr<CreateInfo> Copy() const = 0;
+
+	DUCKDB_API void CopyProperties(CreateInfo &other) const;
+	//! Generates an alter statement from the create statement - used for OnCreateConflict::ALTER_ON_CONFLICT
+	DUCKDB_API virtual unique_ptr<AlterInfo> GetAlterInfo() const;
+
+	virtual string ToString() const {
+		throw NotImplementedException("ToString not supported for this type of CreateInfo: '%s'",
+		                              EnumUtil::ToString(info_type));
+	}
+};
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+enum class SequenceInfo : uint8_t {
+	// Sequence start
+	SEQ_START,
+	// Sequence increment
+	SEQ_INC,
+	// Sequence minimum value
+	SEQ_MIN,
+	// Sequence maximum value
+	SEQ_MAX,
+	// Sequence cycle option
+	SEQ_CYCLE,
+	// Sequence owner table
+	SEQ_OWN
+};
+
+struct CreateSequenceInfo : public CreateInfo {
+	CreateSequenceInfo();
+
+	//! Sequence name to create
+	string name;
+	//! Usage count of the sequence
+	uint64_t usage_count;
+	//! The increment value
+	int64_t increment;
+	//! The minimum value of the sequence
+	int64_t min_value;
+	//! The maximum value of the sequence
+	int64_t max_value;
+	//! The start value of the sequence
+	int64_t start_value;
+	//! Whether or not the sequence cycles
+	bool cycle;
+
+public:
+	unique_ptr<CreateInfo> Copy() const override;
+
+public:
+	DUCKDB_API void Serialize(Serializer &serializer) const override;
+	DUCKDB_API static unique_ptr<CreateInfo> Deserialize(Deserializer &deserializer);
+
+	string ToString() const override;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/alter_table_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/alter_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+enum class AlterType : uint8_t {
+	INVALID = 0,
+	ALTER_TABLE = 1,
+	ALTER_VIEW = 2,
+	ALTER_SEQUENCE = 3,
+	CHANGE_OWNERSHIP = 4,
+	ALTER_SCALAR_FUNCTION = 5,
+	ALTER_TABLE_FUNCTION = 6,
+	SET_COMMENT = 7,
+	SET_COLUMN_COMMENT = 8
+};
+
+struct AlterEntryData {
+	AlterEntryData() {
+	}
+	AlterEntryData(string catalog_p, string schema_p, string name_p, OnEntryNotFound if_not_found)
+	    : catalog(std::move(catalog_p)), schema(std::move(schema_p)), name(std::move(name_p)),
+	      if_not_found(if_not_found) {
+	}
+
+	string catalog;
+	string schema;
+	string name;
+	OnEntryNotFound if_not_found;
+};
+
+struct AlterInfo : public ParseInfo {
+public:
+	static constexpr const ParseInfoType TYPE = ParseInfoType::ALTER_INFO;
+
+public:
+	AlterInfo(AlterType type, string catalog, string schema, string name, OnEntryNotFound if_not_found);
+	~AlterInfo() override;
+
+	AlterType type;
+	//! if exists
+	OnEntryNotFound if_not_found;
+	//! Catalog name to alter
+	string catalog;
+	//! Schema name to alter
+	string schema;
+	//! Entry name to alter
+	string name;
+	//! Allow altering internal entries
+	bool allow_internal;
+
+public:
+	virtual CatalogType GetCatalogType() const = 0;
+	virtual unique_ptr<AlterInfo> Copy() const = 0;
+	virtual string ToString() const = 0;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<ParseInfo> Deserialize(Deserializer &deserializer);
+
+	virtual string GetColumnName() const {
+		return "";
+	};
+
+	AlterEntryData GetAlterEntryData() const;
+	bool IsAddPrimaryKey() const;
+
+protected:
+	explicit AlterInfo(AlterType type);
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/constraint.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+class Serializer;
+class Deserializer;
+
+//===--------------------------------------------------------------------===//
+// Constraint Types
+//===--------------------------------------------------------------------===//
+enum class ConstraintType : uint8_t {
+	INVALID = 0,     // invalid constraint type
+	NOT_NULL = 1,    // NOT NULL constraint
+	CHECK = 2,       // CHECK constraint
+	UNIQUE = 3,      // UNIQUE constraint
+	FOREIGN_KEY = 4, // FOREIGN KEY constraint
+};
+
+enum class ForeignKeyType : uint8_t {
+	FK_TYPE_PRIMARY_KEY_TABLE = 0,   // main table
+	FK_TYPE_FOREIGN_KEY_TABLE = 1,   // referencing table
+	FK_TYPE_SELF_REFERENCE_TABLE = 2 // self refrencing table
+};
+
+struct ForeignKeyInfo {
+	ForeignKeyType type;
+	string schema;
+	//! if type is FK_TYPE_FOREIGN_KEY_TABLE, means main key table, if type is FK_TYPE_PRIMARY_KEY_TABLE, means foreign
+	//! key table
+	string table;
+	//! The set of main key table's column's index
+	vector<PhysicalIndex> pk_keys;
+	//! The set of foreign key table's column's index
+	vector<PhysicalIndex> fk_keys;
+
+	bool IsDeleteConstraint() const {
+		return type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ||
+		       type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
+	}
+	bool IsAppendConstraint() const {
+		return type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
+		       type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
+	}
+};
+
+//! Constraint is the base class of any type of table constraint.
+class Constraint {
+public:
+	DUCKDB_API explicit Constraint(ConstraintType type);
+	DUCKDB_API virtual ~Constraint();
+
+	ConstraintType type;
+
+public:
+	DUCKDB_API virtual string ToString() const = 0;
+	DUCKDB_API void Print() const;
+
+	DUCKDB_API virtual unique_ptr<Constraint> Copy() const = 0;
+
+	DUCKDB_API virtual void Serialize(Serializer &serializer) const;
+	DUCKDB_API static unique_ptr<Constraint> Deserialize(Deserializer &deserializer);
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		if (type != TARGET::TYPE) {
+			throw InternalException("Failed to cast constraint to type - constraint type mismatch");
+		}
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		if (type != TARGET::TYPE) {
+			throw InternalException("Failed to cast constraint to type - constraint type mismatch");
+		}
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+enum class AlterForeignKeyType : uint8_t { AFT_ADD = 0, AFT_DELETE = 1 };
+
+//===--------------------------------------------------------------------===//
+// Change Ownership
+//===--------------------------------------------------------------------===//
+struct ChangeOwnershipInfo : public AlterInfo {
+	ChangeOwnershipInfo(CatalogType entry_catalog_type, string entry_catalog, string entry_schema, string entry_name,
+	                    string owner_schema, string owner_name, OnEntryNotFound if_not_found);
+
+	// Catalog type refers to the entry type, since this struct is usually built from an
+	// ALTER <TYPE> <schema>.<name> OWNED BY <owner_schema>.<owner_name> statement
+	// here it is only possible to know the type of who is to be owned
+	CatalogType entry_catalog_type;
+
+	string owner_schema;
+	string owner_name;
+
+public:
+	CatalogType GetCatalogType() const override;
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
+
+	explicit ChangeOwnershipInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// Set Comment
+//===--------------------------------------------------------------------===//
+struct SetCommentInfo : public AlterInfo {
+	SetCommentInfo(CatalogType entry_catalog_type, string entry_catalog, string entry_schema, string entry_name,
+	               Value new_comment_value_p, OnEntryNotFound if_not_found);
+
+	CatalogType entry_catalog_type;
+	Value comment_value;
+
+public:
+	CatalogType GetCatalogType() const override;
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
+
+	explicit SetCommentInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// Alter Table
+//===--------------------------------------------------------------------===//
+enum class AlterTableType : uint8_t {
+	INVALID = 0,
+	RENAME_COLUMN = 1,
+	RENAME_TABLE = 2,
+	ADD_COLUMN = 3,
+	REMOVE_COLUMN = 4,
+	ALTER_COLUMN_TYPE = 5,
+	SET_DEFAULT = 6,
+	FOREIGN_KEY_CONSTRAINT = 7,
+	SET_NOT_NULL = 8,
+	DROP_NOT_NULL = 9,
+	SET_COLUMN_COMMENT = 10,
+	ADD_CONSTRAINT = 11,
+	SET_PARTITIONED_BY = 12,
+	SET_SORTED_BY = 13,
+	ADD_FIELD = 14,
+	REMOVE_FIELD = 15,
+	RENAME_FIELD = 16
+};
+
+struct AlterTableInfo : public AlterInfo {
+	AlterTableInfo(AlterTableType type, AlterEntryData data);
+	~AlterTableInfo() override;
+
+	AlterTableType alter_table_type;
+
+public:
+	CatalogType GetCatalogType() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
+
+protected:
+	explicit AlterTableInfo(AlterTableType type);
+};
+
+//===--------------------------------------------------------------------===//
+// RenameColumnInfo
+//===--------------------------------------------------------------------===//
+struct RenameColumnInfo : public AlterTableInfo {
+	RenameColumnInfo(AlterEntryData data, string old_name_p, string new_name_p);
+	~RenameColumnInfo() override;
+
+	//! Column old name
+	string old_name;
+	//! Column new name
+	string new_name;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	RenameColumnInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// RenameFieldInfo
+//===--------------------------------------------------------------------===//
+struct RenameFieldInfo : public AlterTableInfo {
+	RenameFieldInfo(AlterEntryData data, vector<string> column_path, string new_name_p);
+	~RenameFieldInfo() override;
+
+	//! Path to source field
+	vector<string> column_path;
+	//! Column new name
+	string new_name;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	RenameFieldInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// RenameTableInfo
+//===--------------------------------------------------------------------===//
+struct RenameTableInfo : public AlterTableInfo {
+	RenameTableInfo(AlterEntryData data, string new_name);
+	~RenameTableInfo() override;
+
+	//! Relation new name
+	string new_table_name;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	RenameTableInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// AddColumnInfo
+//===--------------------------------------------------------------------===//
+struct AddColumnInfo : public AlterTableInfo {
+	AddColumnInfo(AlterEntryData data, ColumnDefinition new_column, bool if_column_not_exists);
+	~AddColumnInfo() override;
+
+	//! New column
+	ColumnDefinition new_column;
+	//! Whether or not an error should be thrown if the column exist
+	bool if_column_not_exists;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	explicit AddColumnInfo(ColumnDefinition new_column);
+};
+
+//===--------------------------------------------------------------------===//
+// AddFieldInfo
+//===--------------------------------------------------------------------===//
+struct AddFieldInfo : public AlterTableInfo {
+	AddFieldInfo(AlterEntryData data, vector<string> column_path, ColumnDefinition new_field, bool if_field_not_exists);
+	~AddFieldInfo() override;
+
+	//! The path to the struct
+	vector<string> column_path;
+	//! New field to add to the struct
+	ColumnDefinition new_field;
+	//! Whether or not an error should be thrown if the field exist
+	bool if_field_not_exists;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	explicit AddFieldInfo(ColumnDefinition new_column);
+};
+
+//===--------------------------------------------------------------------===//
+// RemoveColumnInfo
+//===--------------------------------------------------------------------===//
+struct RemoveColumnInfo : public AlterTableInfo {
+	RemoveColumnInfo(AlterEntryData data, string removed_column, bool if_column_exists, bool cascade);
+	~RemoveColumnInfo() override;
+
+	//! The column to remove
+	string removed_column;
+	//! Whether or not an error should be thrown if the column does not exist
+	bool if_column_exists;
+	//! Whether or not the column should be removed if a dependency conflict arises (used by GENERATED columns)
+	bool cascade;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+	string GetColumnName() const override {
+		return removed_column;
+	}
+
+private:
+	RemoveColumnInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// RemoveFieldInfo
+//===--------------------------------------------------------------------===//
+struct RemoveFieldInfo : public AlterTableInfo {
+	RemoveFieldInfo(AlterEntryData data, vector<string> column_path, bool if_column_exists, bool cascade);
+	~RemoveFieldInfo() override;
+
+	//! The path to the field to remove
+	vector<string> column_path;
+	//! Whether or not an error should be thrown if the column does not exist
+	bool if_column_exists;
+	//! Whether or not the column should be removed if a dependency conflict arises (used by GENERATED columns)
+	bool cascade;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	RemoveFieldInfo();
+};
+//===--------------------------------------------------------------------===//
+// ChangeColumnTypeInfo
+//===--------------------------------------------------------------------===//
+struct ChangeColumnTypeInfo : public AlterTableInfo {
+	ChangeColumnTypeInfo(AlterEntryData data, string column_name, LogicalType target_type,
+	                     unique_ptr<ParsedExpression> expression);
+	~ChangeColumnTypeInfo() override;
+
+	//! The column name to alter
+	string column_name;
+	//! The target type of the column
+	LogicalType target_type;
+	//! The expression used for data conversion
+	unique_ptr<ParsedExpression> expression;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+	string GetColumnName() const override {
+		return column_name;
+	};
+
+private:
+	ChangeColumnTypeInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// SetDefaultInfo
+//===--------------------------------------------------------------------===//
+struct SetDefaultInfo : public AlterTableInfo {
+	SetDefaultInfo(AlterEntryData data, string column_name, unique_ptr<ParsedExpression> new_default);
+	~SetDefaultInfo() override;
+
+	//! The column name to alter
+	string column_name;
+	//! The expression used for data conversion
+	unique_ptr<ParsedExpression> expression;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	SetDefaultInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// AlterForeignKeyInfo
+//===--------------------------------------------------------------------===//
+struct AlterForeignKeyInfo : public AlterTableInfo {
+	AlterForeignKeyInfo(AlterEntryData data, string fk_table, vector<string> pk_columns, vector<string> fk_columns,
+	                    vector<PhysicalIndex> pk_keys, vector<PhysicalIndex> fk_keys, AlterForeignKeyType type);
+	~AlterForeignKeyInfo() override;
+
+	string fk_table;
+	vector<string> pk_columns;
+	vector<string> fk_columns;
+	vector<PhysicalIndex> pk_keys;
+	vector<PhysicalIndex> fk_keys;
+	AlterForeignKeyType type;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	AlterForeignKeyInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// SetNotNullInfo
+//===--------------------------------------------------------------------===//
+struct SetNotNullInfo : public AlterTableInfo {
+	SetNotNullInfo(AlterEntryData data, string column_name);
+	~SetNotNullInfo() override;
+
+	//! The column name to alter
+	string column_name;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	SetNotNullInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// DropNotNullInfo
+//===--------------------------------------------------------------------===//
+struct DropNotNullInfo : public AlterTableInfo {
+	DropNotNullInfo(AlterEntryData data, string column_name);
+	~DropNotNullInfo() override;
+
+	//! The column name to alter
+	string column_name;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	DropNotNullInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// Alter View
+//===--------------------------------------------------------------------===//
+enum class AlterViewType : uint8_t { INVALID = 0, RENAME_VIEW = 1 };
+
+struct AlterViewInfo : public AlterInfo {
+	AlterViewInfo(AlterViewType type, AlterEntryData data);
+	~AlterViewInfo() override;
+
+	AlterViewType alter_view_type;
+
+public:
+	CatalogType GetCatalogType() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
+
+protected:
+	explicit AlterViewInfo(AlterViewType type);
+};
+
+//===--------------------------------------------------------------------===//
+// RenameViewInfo
+//===--------------------------------------------------------------------===//
+struct RenameViewInfo : public AlterViewInfo {
+	RenameViewInfo(AlterEntryData data, string new_name);
+	~RenameViewInfo() override;
+
+	//! Relation new name
+	string new_view_name;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterViewInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	RenameViewInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// AddConstraintInfo
+//===--------------------------------------------------------------------===//
+struct AddConstraintInfo : public AlterTableInfo {
+	AddConstraintInfo(AlterEntryData data, unique_ptr<Constraint> constraint);
+	~AddConstraintInfo() override;
+
+	//! The constraint to add.
+	unique_ptr<Constraint> constraint;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	AddConstraintInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// SetPartitionedByInfo
+//===--------------------------------------------------------------------===//
+struct SetPartitionedByInfo : public AlterTableInfo {
+	SetPartitionedByInfo(AlterEntryData data, vector<unique_ptr<ParsedExpression>> partition_keys);
+	~SetPartitionedByInfo() override;
+
+	//! The partition keys
+	vector<unique_ptr<ParsedExpression>> partition_keys;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	SetPartitionedByInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// SetSortedByInfo
+//===--------------------------------------------------------------------===//
+struct SetSortedByInfo : public AlterTableInfo {
+	SetSortedByInfo(AlterEntryData data, vector<OrderByNode> orders);
+	~SetSortedByInfo() override;
+
+	//! The sort keys
+	vector<OrderByNode> orders;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	SetSortedByInfo();
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class DuckTransaction;
+class SequenceCatalogEntry;
+
+struct SequenceValue {
+	SequenceCatalogEntry *entry;
+	uint64_t usage_count;
+	int64_t counter;
+};
+
+struct SequenceData {
+	explicit SequenceData(CreateSequenceInfo &info);
+
+	//! The amount of times the sequence has been used
+	uint64_t usage_count;
+	//! The sequence counter
+	int64_t counter;
+	//! The most recently returned value
+	int64_t last_value;
+	//! The increment value
+	int64_t increment;
+	//! The minimum value of the sequence
+	int64_t start_value;
+	//! The minimum value of the sequence
+	int64_t min_value;
+	//! The maximum value of the sequence
+	int64_t max_value;
+	//! Whether or not the sequence cycles
+	bool cycle;
+};
+
+//! A sequence catalog entry
+class SequenceCatalogEntry : public StandardEntry {
+public:
+	static constexpr const CatalogType Type = CatalogType::SEQUENCE_ENTRY;
+	static constexpr const char *Name = "sequence";
+
+public:
+	//! Create a real TableCatalogEntry and initialize storage for it
+	SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateSequenceInfo &info);
+
+public:
+	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
+	unique_ptr<CreateInfo> GetInfo() const override;
+
+	SequenceData GetData() const;
+	int64_t CurrentValue();
+	int64_t NextValue(DuckTransaction &transaction);
+	void ReplayValue(uint64_t usage_count, int64_t counter);
+
+	string ToSQL() const override;
+
+private:
+	//! Lock for getting a value on the sequence
+	mutable mutex lock;
+	//! Sequence data
+	SequenceData data;
+};
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/transaction/transaction_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+class DuckTransaction;
+class Transaction;
+
+struct TransactionData {
+	TransactionData(DuckTransaction &transaction_p); // NOLINT: allow implicit conversion
+	TransactionData(transaction_t transaction_id_p, transaction_t start_time_p);
+
+	optional_ptr<DuckTransaction> transaction;
+	transaction_t transaction_id;
+	transaction_t start_time;
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+class SequenceCatalogEntry;
+class SchemaCatalogEntry;
+
+class AttachedDatabase;
+class ColumnData;
+class ClientContext;
+class CatalogEntry;
+class DataTable;
+class DatabaseInstance;
+class LocalStorage;
+class MetaTransaction;
+class TransactionManager;
+class WriteAheadLog;
+
+class ChunkVectorInfo;
+
+struct DeleteInfo;
+struct UpdateInfo;
+
+//! The transaction object holds information about a currently running or past
+//! transaction
+class Transaction {
+public:
+	DUCKDB_API Transaction(TransactionManager &manager, ClientContext &context);
+	DUCKDB_API virtual ~Transaction();
+
+	TransactionManager &manager;
+	weak_ptr<ClientContext> context;
+	//! The current active query for the transaction. Set to MAXIMUM_QUERY_ID if
+	//! no query is active.
+	atomic<transaction_t> active_query;
+
+public:
+	DUCKDB_API static Transaction &Get(ClientContext &context, AttachedDatabase &db);
+	DUCKDB_API static Transaction &Get(ClientContext &context, Catalog &catalog);
+	//! Returns the transaction for the given context if it has already been started
+	DUCKDB_API static optional_ptr<Transaction> TryGet(ClientContext &context, AttachedDatabase &db);
+
+	//! Whether or not the transaction has made any modifications to the database so far
+	DUCKDB_API bool IsReadOnly();
+	//! Promotes the transaction to a read-write transaction
+	DUCKDB_API virtual void SetReadWrite();
+
+	virtual bool IsDuckTransaction() const {
+		return false;
+	}
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+private:
+	bool is_read_only;
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/similar_catalog_entry.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+class SchemaCatalogEntry;
+
+//! Return value of SimilarEntryInSchemas
+struct SimilarCatalogEntry {
+	//! The entry name. Empty if absent
+	string name;
+	//! The similarity score of the given name (between 0.0 and 1.0, higher is better)
+	double score = 0.0;
+	//! The schema of the entry.
+	optional_ptr<SchemaCatalogEntry> schema;
+
+	bool Found() const {
+		return !name.empty();
+	}
+
+	DUCKDB_API string GetQualifiedName(bool qualify_catalog, bool qualify_schema) const;
+};
+
+} // namespace duckdb
+
+#include <functional>
+#include <memory>
+
+namespace duckdb {
+struct AlterInfo;
+
+class ClientContext;
+class LogicalDependencyList;
+
+class DuckCatalog;
+class TableCatalogEntry;
+class SequenceCatalogEntry;
+
+class CatalogEntryMap {
+public:
+	CatalogEntryMap() {
+	}
+
+public:
+	void AddEntry(unique_ptr<CatalogEntry> entry);
+	void UpdateEntry(unique_ptr<CatalogEntry> entry);
+	void DropEntry(CatalogEntry &entry);
+	case_insensitive_tree_t<unique_ptr<CatalogEntry>> &Entries();
+	optional_ptr<CatalogEntry> GetEntry(const string &name);
+
+private:
+	//! Mapping of string to catalog entry
+	case_insensitive_tree_t<unique_ptr<CatalogEntry>> entries;
+};
+
+//! The Catalog Set stores (key, value) map of a set of CatalogEntries
+class CatalogSet {
+public:
+	struct EntryLookup {
+		enum class FailureReason { SUCCESS, DELETED, NOT_PRESENT, INVISIBLE };
+		optional_ptr<CatalogEntry> result;
+		FailureReason reason;
+	};
+
+public:
+	DUCKDB_API explicit CatalogSet(Catalog &catalog, unique_ptr<DefaultGenerator> defaults = nullptr);
+	~CatalogSet();
+
+	//! Create an entry in the catalog set. Returns whether or not it was
+	//! successful.
+	DUCKDB_API bool CreateEntry(CatalogTransaction transaction, const string &name, unique_ptr<CatalogEntry> value,
+	                            const LogicalDependencyList &dependencies);
+	DUCKDB_API bool CreateEntry(ClientContext &context, const string &name, unique_ptr<CatalogEntry> value,
+	                            const LogicalDependencyList &dependencies);
+
+	DUCKDB_API bool AlterEntry(CatalogTransaction transaction, const string &name, AlterInfo &alter_info);
+
+	DUCKDB_API bool DropEntry(CatalogTransaction transaction, const string &name, bool cascade,
+	                          bool allow_drop_internal = false);
+	DUCKDB_API bool DropEntry(ClientContext &context, const string &name, bool cascade,
+	                          bool allow_drop_internal = false);
+	//! Verify that the entry referenced by the dependency is still alive
+	DUCKDB_API void VerifyExistenceOfDependency(transaction_t commit_id, CatalogEntry &entry);
+	//! Verify we can still drop the entry while committing
+	DUCKDB_API void CommitDrop(transaction_t commit_id, transaction_t start_time, CatalogEntry &entry);
+
+	DUCKDB_API DuckCatalog &GetCatalog();
+
+	bool AlterOwnership(CatalogTransaction transaction, ChangeOwnershipInfo &info);
+
+	void CleanupEntry(CatalogEntry &catalog_entry);
+
+	//! Returns the entry with the specified name
+	DUCKDB_API EntryLookup GetEntryDetailed(CatalogTransaction transaction, const string &name);
+	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(CatalogTransaction transaction, const string &name);
+	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name);
+
+	//! Gets the entry that is most similar to the given name (i.e. smallest levenshtein distance), or empty string if
+	//! none is found. The returned pair consists of the entry name and the distance (smaller means closer).
+	SimilarCatalogEntry SimilarEntry(CatalogTransaction transaction, const string &name);
+
+	//! Rollback <entry> to be the currently valid entry for a certain catalog
+	//! entry
+	void Undo(CatalogEntry &entry);
+
+	//! Scan the catalog set, invoking the callback method for every committed entry
+	DUCKDB_API void Scan(const std::function<void(CatalogEntry &)> &callback);
+	//! Scan the catalog set, invoking the callback method for every entry
+	DUCKDB_API void ScanWithPrefix(CatalogTransaction transaction, const std::function<void(CatalogEntry &)> &callback,
+	                               const string &prefix);
+	DUCKDB_API void Scan(CatalogTransaction transaction, const std::function<void(CatalogEntry &)> &callback);
+	DUCKDB_API void ScanWithReturn(CatalogTransaction transaction, const std::function<bool(CatalogEntry &)> &callback);
+	DUCKDB_API void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
+	DUCKDB_API void ScanWithReturn(ClientContext &context, const std::function<bool(CatalogEntry &)> &callback);
+
+	template <class T>
+	vector<reference<T>> GetEntries(CatalogTransaction transaction) {
+		vector<reference<T>> result;
+		Scan(transaction, [&](CatalogEntry &entry) { result.push_back(entry.Cast<T>()); });
+		return result;
+	}
+
+	DUCKDB_API bool CreatedByOtherActiveTransaction(CatalogTransaction transaction, transaction_t timestamp);
+	DUCKDB_API bool CommittedAfterStarting(CatalogTransaction transaction, transaction_t timestamp);
+	DUCKDB_API bool HasConflict(CatalogTransaction transaction, transaction_t timestamp);
+	DUCKDB_API bool UseTimestamp(CatalogTransaction transaction, transaction_t timestamp);
+	static bool IsCommitted(transaction_t timestamp);
+
+	static void UpdateTimestamp(CatalogEntry &entry, transaction_t timestamp);
+
+	mutex &GetCatalogLock() {
+		return catalog_lock;
+	}
+
+	void Verify(Catalog &catalog);
+
+	//! Override the default generator - this should not be used after the catalog set has been used
+	void SetDefaultGenerator(unique_ptr<DefaultGenerator> defaults);
+
+private:
+	bool DropDependencies(CatalogTransaction transaction, const string &name, bool cascade,
+	                      bool allow_drop_internal = false);
+	//! Given a root entry, gets the entry valid for this transaction, 'visible' is used to indicate whether the entry
+	//! is actually visible to the transaction
+	CatalogEntry &GetEntryForTransaction(CatalogTransaction transaction, CatalogEntry &current, bool &visible);
+	//! Given a root entry, gets the entry valid for this transaction
+	CatalogEntry &GetEntryForTransaction(CatalogTransaction transaction, CatalogEntry &current);
+	CatalogEntry &GetCommittedEntry(CatalogEntry &current);
+	optional_ptr<CatalogEntry> GetEntryInternal(CatalogTransaction transaction, const string &name);
+	optional_ptr<CatalogEntry> CreateCommittedEntry(unique_ptr<CatalogEntry> entry);
+
+	//! Create all default entries
+	void CreateDefaultEntries(CatalogTransaction transaction, unique_lock<mutex> &lock);
+	//! Attempt to create a default entry with the specified name. Returns the entry if successful, nullptr otherwise.
+	optional_ptr<CatalogEntry> CreateDefaultEntry(CatalogTransaction transaction, const string &name,
+	                                              unique_lock<mutex> &lock);
+
+	bool DropEntryInternal(CatalogTransaction transaction, const string &name, bool allow_drop_internal = false);
+
+	bool CreateEntryInternal(CatalogTransaction transaction, const string &name, unique_ptr<CatalogEntry> value,
+	                         unique_lock<mutex> &read_lock, bool should_be_empty = true);
+	void CheckCatalogEntryInvariants(CatalogEntry &value, const string &name);
+	//! Verify that the previous entry in the chain is dropped.
+	bool VerifyVacancy(CatalogTransaction transaction, CatalogEntry &entry);
+	//! Start the catalog entry chain with a dummy node
+	bool StartChain(CatalogTransaction transaction, const string &name, unique_lock<mutex> &read_lock);
+	bool RenameEntryInternal(CatalogTransaction transaction, CatalogEntry &old, const string &new_name,
+	                         AlterInfo &alter_info, unique_lock<mutex> &read_lock);
+
+private:
+	DuckCatalog &catalog;
+	//! The catalog lock is used to make changes to the data
+	mutex catalog_lock;
+	CatalogEntryMap map;
+	//! The generator used to generate default internal entries
+	unique_ptr<DefaultGenerator> defaults;
+};
+} // namespace duckdb
+
+
+
+namespace duckdb {
+class ClientContext;
+
+class StandardEntry;
+class TableCatalogEntry;
+class TableFunctionCatalogEntry;
+class SequenceCatalogEntry;
+
+enum class OnCreateConflict : uint8_t;
+
+struct AlterTableInfo;
+struct CreateIndexInfo;
+struct CreateFunctionInfo;
+struct CreateCollationInfo;
+struct CreateViewInfo;
+struct BoundCreateTableInfo;
+struct CreatePragmaFunctionInfo;
+struct CreateSequenceInfo;
+struct CreateSchemaInfo;
+struct CreateTableFunctionInfo;
+struct CreateCopyFunctionInfo;
+struct CreateTypeInfo;
+
+struct DropInfo;
+
+//! A schema in the catalog
+class SchemaCatalogEntry : public InCatalogEntry {
+public:
+	static constexpr const CatalogType Type = CatalogType::SCHEMA_ENTRY;
+	static constexpr const char *Name = "schema";
+
+public:
+	SchemaCatalogEntry(Catalog &catalog, CreateSchemaInfo &info);
+
+public:
+	unique_ptr<CreateInfo> GetInfo() const override;
+
+	//! Scan the specified catalog set, invoking the callback method for every entry
+	virtual void Scan(ClientContext &context, CatalogType type,
+	                  const std::function<void(CatalogEntry &)> &callback) = 0;
+	//! Scan the specified catalog set, invoking the callback method for every committed entry
+	virtual void Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) = 0;
+
+	string ToSQL() const override;
+
+	//! Creates an index with the given name in the schema
+	virtual optional_ptr<CatalogEntry> CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,
+	                                               TableCatalogEntry &table) = 0;
+	optional_ptr<CatalogEntry> CreateIndex(ClientContext &context, CreateIndexInfo &info, TableCatalogEntry &table);
+	//! Create a scalar or aggregate function within the given schema
+	virtual optional_ptr<CatalogEntry> CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) = 0;
+	//! Creates a table with the given name in the schema
+	virtual optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) = 0;
+	//! Creates a view with the given name in the schema
+	virtual optional_ptr<CatalogEntry> CreateView(CatalogTransaction transaction, CreateViewInfo &info) = 0;
+	//! Creates a sequence with the given name in the schema
+	virtual optional_ptr<CatalogEntry> CreateSequence(CatalogTransaction transaction, CreateSequenceInfo &info) = 0;
+	//! Create a table function within the given schema
+	virtual optional_ptr<CatalogEntry> CreateTableFunction(CatalogTransaction transaction,
+	                                                       CreateTableFunctionInfo &info) = 0;
+	//! Create a copy function within the given schema
+	virtual optional_ptr<CatalogEntry> CreateCopyFunction(CatalogTransaction transaction,
+	                                                      CreateCopyFunctionInfo &info) = 0;
+	//! Create a pragma function within the given schema
+	virtual optional_ptr<CatalogEntry> CreatePragmaFunction(CatalogTransaction transaction,
+	                                                        CreatePragmaFunctionInfo &info) = 0;
+	//! Create a collation within the given schema
+	virtual optional_ptr<CatalogEntry> CreateCollation(CatalogTransaction transaction, CreateCollationInfo &info) = 0;
+	//! Create a enum within the given schema
+	virtual optional_ptr<CatalogEntry> CreateType(CatalogTransaction transaction, CreateTypeInfo &info) = 0;
+
+	//! Lookup an entry in the schema
+	DUCKDB_API virtual optional_ptr<CatalogEntry> LookupEntry(CatalogTransaction transaction,
+	                                                          const EntryLookupInfo &lookup_info) = 0;
+	DUCKDB_API virtual CatalogSet::EntryLookup LookupEntryDetailed(CatalogTransaction transaction,
+	                                                               const EntryLookupInfo &lookup_info);
+	DUCKDB_API virtual SimilarCatalogEntry GetSimilarEntry(CatalogTransaction transaction,
+	                                                       const EntryLookupInfo &lookup_info);
+
+	DUCKDB_API optional_ptr<CatalogEntry> GetEntry(CatalogTransaction transaction, CatalogType type,
+	                                               const string &name);
+
+	//! Drops an entry from the schema
+	virtual void DropEntry(ClientContext &context, DropInfo &info) = 0;
+
+	//! Alters a catalog entry
+	virtual void Alter(CatalogTransaction transaction, AlterInfo &info) = 0;
+
+	CatalogTransaction GetCatalogTransaction(ClientContext &context);
+};
+} // namespace duckdb
 
 
 
@@ -24539,7 +24167,7 @@ typedef enum duckdb_statement_type {
 	DUCKDB_STATEMENT_TYPE_DETACH = 26,
 	DUCKDB_STATEMENT_TYPE_MULTI = 27,
 } duckdb_statement_type;
-//! An enum over DuckDB's different result types.
+//! An enum over DuckDB's different error types.
 typedef enum duckdb_error_type {
 	DUCKDB_ERROR_INVALID = 0,
 	DUCKDB_ERROR_OUT_OF_RANGE = 1,
@@ -24595,11 +24223,14 @@ typedef enum duckdb_cast_mode { DUCKDB_CAST_NORMAL = 0, DUCKDB_CAST_TRY = 1 } du
 //! DuckDB's index type.
 typedef uint64_t idx_t;
 
+//! Type used for the selection vector
+typedef uint32_t sel_t;
+
 //! The callback that will be called to destroy data, e.g.,
 //! bind data (if any), init data (if any), extra data for replacement scans (if any)
 typedef void (*duckdb_delete_callback_t)(void *data);
 
-//! Used for threading, contains a task state. Must be destroyed with `duckdb_destroy_state`.
+//! Used for threading, contains a task state. Must be destroyed with `duckdb_destroy_task_state`.
 typedef void *duckdb_task_state;
 
 //===--------------------------------------------------------------------===//
@@ -24744,6 +24375,12 @@ typedef struct _duckdb_vector {
 	void *internal_ptr;
 } * duckdb_vector;
 
+//! A selection vector is a possibly duplicative vector of indices, which refer to values in a vector.
+//! The resulting vector is make up of the values at each index in the selection vector.
+typedef struct _duckdb_selection_vector {
+	void *internal_ptr;
+} * duckdb_selection_vector;
+
 //===--------------------------------------------------------------------===//
 // Types (explicit freeing/destroying)
 //===--------------------------------------------------------------------===//
@@ -24812,6 +24449,11 @@ typedef struct _duckdb_connection {
 	void *internal_ptr;
 } * duckdb_connection;
 
+//! A client context of a duckdb connection. Must be destroyed with `duckdb_destroy_context`.
+typedef struct _duckdb_client_context {
+	void *internal_ptr;
+} * duckdb_client_context;
+
 //! A prepared statement is a parameterized query that allows you to bind parameters to it.
 //! Must be destroyed with `duckdb_destroy_prepare`.
 typedef struct _duckdb_prepared_statement {
@@ -24879,6 +24521,7 @@ typedef struct _duckdb_profiling_info {
 //===--------------------------------------------------------------------===//
 // C API Extension info
 //===--------------------------------------------------------------------===//
+
 //! Holds state during the C API extension intialization process
 typedef struct _duckdb_extension_info {
 	void *internal_ptr;
@@ -24887,14 +24530,23 @@ typedef struct _duckdb_extension_info {
 //===--------------------------------------------------------------------===//
 // Function types
 //===--------------------------------------------------------------------===//
-//! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
+
+//! Additional function info.
+//! When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_function_info {
 	void *internal_ptr;
 } * duckdb_function_info;
 
+//! The bind info of a function.
+//! When setting this info, it is necessary to pass a destroy-callback function.
+typedef struct _duckdb_bind_info {
+	void *internal_ptr;
+} * duckdb_bind_info;
+
 //===--------------------------------------------------------------------===//
 // Scalar function types
 //===--------------------------------------------------------------------===//
+
 //! A scalar function. Must be destroyed with `duckdb_destroy_scalar_function`.
 typedef struct _duckdb_scalar_function {
 	void *internal_ptr;
@@ -24904,6 +24556,9 @@ typedef struct _duckdb_scalar_function {
 typedef struct _duckdb_scalar_function_set {
 	void *internal_ptr;
 } * duckdb_scalar_function_set;
+
+//! The bind function of the scalar function.
+typedef void (*duckdb_scalar_function_bind_t)(duckdb_bind_info info);
 
 //! The main function of the scalar function.
 typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
@@ -24950,11 +24605,6 @@ typedef void (*duckdb_aggregate_finalize_t)(duckdb_function_info info, duckdb_ag
 typedef struct _duckdb_table_function {
 	void *internal_ptr;
 } * duckdb_table_function;
-
-//! The bind info of the function. When setting this info, it is necessary to pass a destroy-callback function.
-typedef struct _duckdb_bind_info {
-	void *internal_ptr;
-} * duckdb_bind_info;
 
 //! Additional function init info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_init_info {
@@ -25142,11 +24792,47 @@ Closes the specified connection and de-allocates all memory allocated for that c
 DUCKDB_C_API void duckdb_disconnect(duckdb_connection *connection);
 
 /*!
+Retrieves the client context of the connection.
+
+* @param connection The connection.
+* @param out_context The client context of the connection. Must be destroyed with `duckdb_destroy_client_context`.
+*/
+DUCKDB_C_API void duckdb_connection_get_client_context(duckdb_connection connection,
+                                                       duckdb_client_context *out_context);
+
+/*!
+Returns the connection id of the client context.
+
+* @param context The client context.
+* @return The connection id of the client context.
+*/
+DUCKDB_C_API idx_t duckdb_client_context_get_connection_id(duckdb_client_context context);
+
+/*!
+Destroys the client context and deallocates its memory.
+
+* @param context The client context to destroy.
+*/
+DUCKDB_C_API void duckdb_destroy_client_context(duckdb_client_context *context);
+
+/*!
 Returns the version of the linked DuckDB, with a version postfix for dev versions
 
 Usually used for developing C extensions that must return this for a compatibility check.
 */
 DUCKDB_C_API const char *duckdb_library_version();
+
+/*!
+Get the list of (fully qualified) table names of the query.
+
+* @param connection The connection for which to get the table names.
+* @param query The query for which to get the table names.
+* @param qualified Returns fully qualified table names (catalog.schema.table), if set to true, else only the (not
+escaped) table names.
+* @return A duckdb_value of type VARCHAR[] containing the (fully qualified) table names of the query. Must be destroyed
+with duckdb_destroy_value.
+*/
+DUCKDB_C_API duckdb_value duckdb_get_table_names(duckdb_connection connection, const char *query, bool qualified);
 
 //===--------------------------------------------------------------------===//
 // Configuration
@@ -25231,7 +24917,7 @@ query fails, otherwise the error stored within the result will not be freed corr
 DUCKDB_C_API duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out_result);
 
 /*!
-Closes the result and de-allocates all memory allocated for that connection.
+Closes the result and de-allocates all memory allocated for that result.
 
 * @param result The result to destroy.
 */
@@ -25954,7 +25640,7 @@ Returns the statement type of the statement to be executed
 DUCKDB_C_API duckdb_statement_type duckdb_prepared_statement_type(duckdb_prepared_statement statement);
 
 //===--------------------------------------------------------------------===//
-// Bind Values To Prepared Statements
+// Bind Values to Prepared Statements
 //===--------------------------------------------------------------------===//
 
 /*!
@@ -26001,7 +25687,7 @@ DUCKDB_C_API duckdb_state duckdb_bind_hugeint(duckdb_prepared_statement prepared
                                               duckdb_hugeint val);
 
 /*!
-Binds an duckdb_uhugeint value to the prepared statement at the specified index.
+Binds a duckdb_uhugeint value to the prepared statement at the specified index.
 */
 DUCKDB_C_API duckdb_state duckdb_bind_uhugeint(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                                duckdb_uhugeint val);
@@ -26013,24 +25699,24 @@ DUCKDB_C_API duckdb_state duckdb_bind_decimal(duckdb_prepared_statement prepared
                                               duckdb_decimal val);
 
 /*!
-Binds an uint8_t value to the prepared statement at the specified index.
+Binds a uint8_t value to the prepared statement at the specified index.
 */
 DUCKDB_C_API duckdb_state duckdb_bind_uint8(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint8_t val);
 
 /*!
-Binds an uint16_t value to the prepared statement at the specified index.
+Binds a uint16_t value to the prepared statement at the specified index.
 */
 DUCKDB_C_API duckdb_state duckdb_bind_uint16(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                              uint16_t val);
 
 /*!
-Binds an uint32_t value to the prepared statement at the specified index.
+Binds a uint32_t value to the prepared statement at the specified index.
 */
 DUCKDB_C_API duckdb_state duckdb_bind_uint32(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                              uint32_t val);
 
 /*!
-Binds an uint64_t value to the prepared statement at the specified index.
+Binds a uint64_t value to the prepared statement at the specified index.
 */
 DUCKDB_C_API duckdb_state duckdb_bind_uint64(duckdb_prepared_statement prepared_statement, idx_t param_idx,
                                              uint64_t val);
@@ -26331,7 +26017,7 @@ Creates a value from a boolean
 DUCKDB_C_API duckdb_value duckdb_create_bool(bool input);
 
 /*!
-Creates a value from a int8_t (a tinyint)
+Creates a value from an int8_t (a tinyint)
 
 * @param input The tinyint value
 * @return The value. This must be destroyed with `duckdb_destroy_value`.
@@ -26347,7 +26033,7 @@ Creates a value from a uint8_t (a utinyint)
 DUCKDB_C_API duckdb_value duckdb_create_uint8(uint8_t input);
 
 /*!
-Creates a value from a int16_t (a smallint)
+Creates a value from an int16_t (a smallint)
 
 * @param input The smallint value
 * @return The value. This must be destroyed with `duckdb_destroy_value`.
@@ -26363,7 +26049,7 @@ Creates a value from a uint16_t (a usmallint)
 DUCKDB_C_API duckdb_value duckdb_create_uint16(uint16_t input);
 
 /*!
-Creates a value from a int32_t (an integer)
+Creates a value from an int32_t (an integer)
 
 * @param input The integer value
 * @return The value. This must be destroyed with `duckdb_destroy_value`.
@@ -26582,7 +26268,7 @@ DUCKDB_C_API uint16_t duckdb_get_uint16(duckdb_value val);
 /*!
 Returns the int32_t value of the given value.
 
-* @param val A duckdb_value containing a integer
+* @param val A duckdb_value containing an integer
 * @return A int32_t, or MinValue<int32> if the value cannot be converted
 */
 DUCKDB_C_API int32_t duckdb_get_int32(duckdb_value val);
@@ -26807,6 +26493,31 @@ Must be destroyed with `duckdb_destroy_value`.
 DUCKDB_C_API duckdb_value duckdb_create_array_value(duckdb_logical_type type, duckdb_value *values, idx_t value_count);
 
 /*!
+Creates a map value from a map type and two arrays, one for the keys and one for the values, each of length
+`entry_count`. Must be destroyed with `duckdb_destroy_value`.
+
+* @param map_type The map type
+* @param keys The keys of the map
+* @param values The values of the map
+* @param entry_count The number of entrys (key-value pairs) in the map
+* @return The map value, or nullptr, if the parameters are invalid.
+*/
+DUCKDB_C_API duckdb_value duckdb_create_map_value(duckdb_logical_type map_type, duckdb_value *keys,
+                                                  duckdb_value *values, idx_t entry_count);
+
+/*!
+Creates a union value from a union type, a tag index, and a value.
+Must be destroyed with `duckdb_destroy_value`.
+
+* @param union_type The union type
+* @param tag_index The index of the tag of the union
+* @param value The value of the union
+* @return The union value, or nullptr, if the parameters are invalid.
+*/
+DUCKDB_C_API duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, idx_t tag_index,
+                                                    duckdb_value value);
+
+/*!
 Returns the number of elements in a MAP value.
 
 * @param value The MAP value.
@@ -26889,6 +26600,14 @@ Returns the STRUCT child at index as a duckdb_value.
 * @return The child as a duckdb_value.
 */
 DUCKDB_C_API duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index);
+
+/*!
+Returns the SQL string representation of the given value.
+
+* @param value A duckdb_value.
+* @return The SQL string representation as a null-terminated string. The result must be freed with `duckdb_free`.
+*/
+DUCKDB_C_API char *duckdb_value_to_string(duckdb_value value);
 
 //===--------------------------------------------------------------------===//
 // Logical Type Interface
@@ -27250,6 +26969,18 @@ DUCKDB_C_API void duckdb_data_chunk_set_size(duckdb_data_chunk chunk, idx_t size
 //===--------------------------------------------------------------------===//
 
 /*!
+Creates a flat vector.
+
+*/
+DUCKDB_C_API duckdb_vector duckdb_create_vector(duckdb_logical_type type, idx_t capacity);
+
+/*!
+Destroys the vector and de-allocates all memory allocated for that vector, if unused else where.
+
+*/
+DUCKDB_C_API void duckdb_destroy_vector(duckdb_vector *vector);
+
+/*!
 Retrieves the column type of the specified vector.
 
 The result must be destroyed with `duckdb_destroy_logical_type`.
@@ -27373,7 +27104,7 @@ The resulting vector is valid as long as the parent vector is valid.
 DUCKDB_C_API duckdb_vector duckdb_struct_vector_get_child(duckdb_vector vector, idx_t index);
 
 /*!
-Retrieves the child vector of a array vector.
+Retrieves the child vector of an array vector.
 
 The resulting vector is valid as long as the parent vector is valid.
 The resulting vector has the size of the parent vector multiplied by the array size.
@@ -27382,6 +27113,30 @@ The resulting vector has the size of the parent vector multiplied by the array s
 * @return The child vector
 */
 DUCKDB_C_API duckdb_vector duckdb_array_vector_get_child(duckdb_vector vector);
+
+/*!
+Slice a vector with a selection vector.
+
+The max value in the selection vector must be less than the length of the vector
+
+The resulting vector happens to be a dictionary vector.
+
+* @param vector The vector which is to become a dictionary
+* @param selection The selection vector
+* @param len The length of the selection vector
+*/
+DUCKDB_C_API void duckdb_slice_vector(duckdb_vector vector, duckdb_selection_vector selection, idx_t len);
+
+/*!
+Copies the value from `value` to `vector`.
+*/
+DUCKDB_C_API void duckdb_vector_reference_value(duckdb_vector vector, duckdb_value value);
+
+/*!
+References the `from` vector in the `to` vector, this makes take shared ownership of the values buffer
+
+*/
+DUCKDB_C_API void duckdb_vector_reference_vector(duckdb_vector to_vector, duckdb_vector from_vector);
 
 //===--------------------------------------------------------------------===//
 // Validity Mask Functions
@@ -27435,7 +27190,7 @@ DUCKDB_C_API void duckdb_validity_set_row_valid(uint64_t *validity, idx_t row);
 /*!
 Creates a new empty scalar function.
 
-The return value should be destroyed with `duckdb_destroy_scalar_function`.
+The return value must be destroyed with `duckdb_destroy_scalar_function`.
 
 * @return The scalar function object.
 */
@@ -27467,8 +27222,7 @@ duckdb_scalar_function_add_parameter.
 DUCKDB_C_API void duckdb_scalar_function_set_varargs(duckdb_scalar_function scalar_function, duckdb_logical_type type);
 
 /*!
-Sets the parameters of the given scalar function to varargs. Does not require adding parameters with
-duckdb_scalar_function_add_parameter.
+Sets the scalar function's null-handling behavior to special.
 
 * @param scalar_function The scalar function.
 */
@@ -27505,10 +27259,38 @@ Assigns extra information to the scalar function that can be fetched during bind
 
 * @param scalar_function The scalar function
 * @param extra_info The extra information
-* @param destroy The callback that will be called to destroy the bind data (if any)
+* @param destroy The callback that will be called to destroy the extra information (if any)
 */
 DUCKDB_C_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function scalar_function, void *extra_info,
                                                         duckdb_delete_callback_t destroy);
+
+/*!
+Sets the (optional) bind function of the scalar function.
+
+* @param scalar_function The scalar function
+* @param bind The bind function
+*/
+DUCKDB_C_API void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function,
+                                                  duckdb_scalar_function_bind_t bind);
+
+/*!
+Sets the user-provided bind data in the bind object of the scalar function.
+This object can be retrieved again during execution.
+
+* @param info The bind info of the scalar function.
+* @param bind_data The bind data object.
+* @param destroy The callback to destroy the bind data (if any).
+*/
+DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data,
+                                                       duckdb_delete_callback_t destroy);
+
+/*!
+Report that an error has occurred while calling bind on a scalar function.
+
+* @param info The bind info object
+* @param error The error message
+*/
+DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
 
 /*!
 Sets the main function of the scalar function.
@@ -27542,6 +27324,24 @@ Retrieves the extra info of the function as set in `duckdb_scalar_function_set_e
 DUCKDB_C_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info info);
 
 /*!
+Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`.
+
+Note that the bind data is read-only.
+
+* @param info The function info.
+* @return The bind data object.
+*/
+DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);
+
+/*!
+Retrieves the client context of the bind info of a scalar function.
+
+* @param info The bind info object of the scalar function.
+* @param out_context The client context of the bind info. Must be destroyed with `duckdb_destroy_client_context`.
+*/
+DUCKDB_C_API void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
+
+/*!
 Report that an error has occurred while executing the scalar function.
 
 * @param info The info object.
@@ -27552,7 +27352,7 @@ DUCKDB_C_API void duckdb_scalar_function_set_error(duckdb_function_info info, co
 /*!
 Creates a new empty scalar function set.
 
-The return value should be destroyed with `duckdb_destroy_scalar_function_set`.
+The return value must be destroyed with `duckdb_destroy_scalar_function_set`.
 
 * @return The scalar function set object.
 */
@@ -27587,6 +27387,25 @@ If the set is incomplete or a function with this name already exists DuckDBError
 * @return Whether or not the registration was successful.
 */
 DUCKDB_C_API duckdb_state duckdb_register_scalar_function_set(duckdb_connection con, duckdb_scalar_function_set set);
+
+//===--------------------------------------------------------------------===//
+// Selection Vector Interface
+//===--------------------------------------------------------------------===//
+
+/*!
+Creates a new selection vector of size `size`.
+*/
+DUCKDB_C_API duckdb_selection_vector duckdb_create_selection_vector(idx_t size);
+
+/*!
+Destroys a selection vector.
+*/
+DUCKDB_C_API void duckdb_destroy_selection_vector(duckdb_selection_vector vector);
+
+/*!
+Access the data pointer of a selection vector.
+*/
+DUCKDB_C_API sel_t *duckdb_selection_vector_get_data_ptr(duckdb_selection_vector vector);
 
 //===--------------------------------------------------------------------===//
 // Aggregate Functions
@@ -27684,7 +27503,7 @@ Assigns extra information to the scalar function that can be fetched during bind
 
 * @param aggregate_function The aggregate function
 * @param extra_info The extra information
-* @param destroy The callback that will be called to destroy the bind data (if any)
+* @param destroy The callback that will be called to destroy the extra information (if any)
 */
 DUCKDB_C_API void duckdb_aggregate_function_set_extra_info(duckdb_aggregate_function aggregate_function,
                                                            void *extra_info, duckdb_delete_callback_t destroy);
@@ -27796,7 +27615,7 @@ Assigns extra information to the table function that can be fetched during bindi
 
 * @param table_function The table function
 * @param extra_info The extra information
-* @param destroy The callback that will be called to destroy the bind data (if any)
+* @param destroy The callback that will be called to destroy the extra information (if any)
 */
 DUCKDB_C_API void duckdb_table_function_set_extra_info(duckdb_table_function table_function, void *extra_info,
                                                        duckdb_delete_callback_t destroy);
@@ -27915,11 +27734,12 @@ The result must be destroyed with `duckdb_destroy_value`.
 DUCKDB_C_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name);
 
 /*!
-Sets the user-provided bind data in the bind object. This object can be retrieved again during execution.
+Sets the user-provided bind data in the bind object of the table function.
+This object can be retrieved again during execution.
 
-* @param info The info object
+* @param info The bind info of the table function.
 * @param bind_data The bind data object.
-* @param destroy The callback that will be called to destroy the bind data (if any)
+* @param destroy The callback to destroy the bind data (if any).
 */
 DUCKDB_C_API void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
 
@@ -27932,7 +27752,7 @@ Sets the cardinality estimate for the table function, used for optimization.
 DUCKDB_C_API void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact);
 
 /*!
-Report that an error has occurred while calling bind.
+Report that an error has occurred while calling bind on a table function.
 
 * @param info The info object
 * @param error The error message
@@ -28021,13 +27841,13 @@ Retrieves the extra info of the function as set in `duckdb_table_function_set_ex
 DUCKDB_C_API void *duckdb_function_get_extra_info(duckdb_function_info info);
 
 /*!
-Gets the bind data set by `duckdb_bind_set_bind_data` during the bind.
+Gets the table function's bind data set by `duckdb_bind_set_bind_data`.
 
-Note that the bind data should be considered as read-only.
+Note that the bind data is read-only.
 For tracking state, use the init data instead.
 
-* @param info The info object
-* @return The bind data object
+* @param info The function info object.
+* @return The bind data object.
 */
 DUCKDB_C_API void *duckdb_function_get_bind_data(duckdb_function_info info);
 
@@ -28942,6 +28762,7 @@ using std::chrono::duration_cast;
 using std::chrono::high_resolution_clock;
 using std::chrono::milliseconds;
 using std::chrono::nanoseconds;
+using std::chrono::steady_clock;
 using std::chrono::system_clock;
 using std::chrono::time_point;
 } // namespace duckdb
@@ -28982,7 +28803,7 @@ private:
 	bool finished = false;
 };
 
-using Profiler = BaseProfiler<system_clock>;
+using Profiler = BaseProfiler<steady_clock>;
 
 } // namespace duckdb
 
@@ -29179,6 +29000,8 @@ enum class MetricsType : uint8_t {
     LATENCY,
     ROWS_RETURNED,
     OPERATOR_NAME,
+    SYSTEM_PEAK_BUFFER_MEMORY,
+    SYSTEM_PEAK_TEMP_DIR_SIZE,
     ALL_OPTIMIZERS,
     CUMULATIVE_OPTIMIZER_TIMING,
     PLANNER,
@@ -29235,6 +29058,7 @@ public:
 
     static bool IsOptimizerMetric(MetricsType type);
     static bool IsPhaseTimingMetric(MetricsType type);
+    static bool IsQueryGlobalMetric(MetricsType type);
 };
 
 } // namespace duckdb
@@ -29289,22 +29113,112 @@ public:
 	}
 
 	template <class METRIC_TYPE>
-	void AddToMetric(const MetricsType type, const Value &value) {
-		D_ASSERT(!metrics[type].IsNull());
+	void MetricUpdate(const MetricsType type, const Value &value,
+	                  const std::function<METRIC_TYPE(const METRIC_TYPE &, const METRIC_TYPE &)> &update_fun) {
 		if (metrics.find(type) == metrics.end()) {
 			metrics[type] = value;
 			return;
 		}
-		auto new_value = metrics[type].GetValue<METRIC_TYPE>() + value.GetValue<METRIC_TYPE>();
+		auto new_value = update_fun(metrics[type].GetValue<METRIC_TYPE>(), value.GetValue<METRIC_TYPE>());
 		metrics[type] = Value::CreateValue(new_value);
 	}
 
 	template <class METRIC_TYPE>
-	void AddToMetric(const MetricsType type, const METRIC_TYPE &value) {
+	void MetricUpdate(const MetricsType type, const METRIC_TYPE &value,
+	                  const std::function<METRIC_TYPE(const METRIC_TYPE &, const METRIC_TYPE &)> &update_fun) {
 		auto new_value = Value::CreateValue(value);
-		return AddToMetric<METRIC_TYPE>(type, new_value);
+		MetricUpdate<METRIC_TYPE>(type, new_value, update_fun);
+	}
+
+	template <class METRIC_TYPE>
+	void MetricSum(const MetricsType type, const Value &value) {
+		MetricUpdate<METRIC_TYPE>(type, value, [](const METRIC_TYPE &old_value, const METRIC_TYPE &new_value) {
+			return old_value + new_value;
+		});
+	}
+
+	template <class METRIC_TYPE>
+	void MetricSum(const MetricsType type, const METRIC_TYPE &value) {
+		auto new_value = Value::CreateValue(value);
+		return MetricSum<METRIC_TYPE>(type, new_value);
+	}
+
+	template <class METRIC_TYPE>
+	void MetricMax(const MetricsType type, const Value &value) {
+		MetricUpdate<METRIC_TYPE>(type, value, [](const METRIC_TYPE &old_value, const METRIC_TYPE &new_value) {
+			return MaxValue(old_value, new_value);
+		});
+	}
+	template <class METRIC_TYPE>
+	void MetricMax(const MetricsType type, const METRIC_TYPE &value) {
+		auto new_value = Value::CreateValue(value);
+		return MetricMax<METRIC_TYPE>(type, new_value);
 	}
 };
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/expression/lambda_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+enum class LambdaSyntax : uint8_t { DEFAULT = 0, ENABLE_SINGLE_ARROW = 1, DISABLE_SINGLE_ARROW = 2 };
+enum class LambdaSyntaxType : uint8_t { SINGLE_ARROW_STORAGE = 0, SINGLE_ARROW = 1, LAMBDA_KEYWORD = 2 };
+
+//! DuckDB 1.3. introduced a new lambda syntax: lambda x, y: x + y.
+//! The new syntax resolves any ambiguity with the JSON arrow operator.
+//! Currently, we're still using a LambdaExpression for both cases.
+class LambdaExpression : public ParsedExpression {
+public:
+	static constexpr const ExpressionClass TYPE = ExpressionClass::LAMBDA;
+
+public:
+	LambdaExpression(vector<string> named_parameters_p, unique_ptr<ParsedExpression> expr);
+	LambdaExpression(unique_ptr<ParsedExpression> lhs, unique_ptr<ParsedExpression> expr);
+
+	//! The syntax type.
+	LambdaSyntaxType syntax_type;
+	//! The LHS of a lambda expression or the JSON "->"-operator. We need the context
+	//! to determine if the LHS is a list of column references (lambda parameters) or an expression (JSON)
+	unique_ptr<ParsedExpression> lhs;
+	//! The lambda or JSON expression (RHS)
+	unique_ptr<ParsedExpression> expr;
+	//! Band-aid for conflicts between lambda binding and JSON binding.
+	unique_ptr<ParsedExpression> copied_expr;
+
+public:
+	//! Returns a vector to the column references in the LHS expression, and fills the error message,
+	//! if the LHS is not a valid lambda parameter list
+	vector<reference<const ParsedExpression>> ExtractColumnRefExpressions(string &error_message) const;
+	//! Returns the error message for an invalid lambda parameter list
+	static string InvalidParametersErrorMessage();
+	//! Returns true, if the column_name is a lambda parameter name
+	static bool IsLambdaParameter(const vector<unordered_set<string>> &lambda_params, const string &column_name);
+
+	string ToString() const override;
+	static bool Equal(const LambdaExpression &a, const LambdaExpression &b);
+	hash_t Hash() const override;
+	unique_ptr<ParsedExpression> Copy() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<ParsedExpression> Deserialize(Deserializer &deserializer);
+
+private:
+	LambdaExpression();
+};
+
 } // namespace duckdb
 
 
@@ -29313,7 +29227,6 @@ namespace duckdb {
 class ClientContext;
 class PhysicalResultCollector;
 class PreparedStatementData;
-class HTTPLogger;
 
 typedef std::function<unique_ptr<PhysicalResultCollector>(ClientContext &context, PreparedStatementData &data)>
     get_result_collector_t;
@@ -29393,6 +29306,8 @@ struct ClientConfig {
 	idx_t nested_loop_join_threshold = 5;
 	//! The number of rows we need on either table to choose a merge join over an IE join
 	idx_t merge_join_threshold = 1000;
+	//! The maximum number of rows to use the nested loop join implementation
+	idx_t asof_loop_join_threshold = 64;
 
 	//! The maximum amount of memory to keep buffered in a streaming query result. Default: 1mb.
 	idx_t streaming_buffer_size = 1000000;
@@ -29423,6 +29338,11 @@ struct ClientConfig {
 	bool ieee_floating_point_ops = true;
 	//! Allow ordering by non-integer literals - ordering by such literals has no effect
 	bool order_by_non_integer_literal = false;
+	//! Disable casting from timestamp => timestamptz (naïve timestamps)
+	bool disable_timestamptz_casts = false;
+	//! If DEFAULT or ENABLE_SINGLE_ARROW, it is possible to use the deprecated single arrow operator (->) for lambda
+	//! functions. Otherwise, DISABLE_SINGLE_ARROW.
+	LambdaSyntax lambda_syntax = LambdaSyntax::DEFAULT;
 
 	//! Output error messages as structured JSON instead of as a raw string
 	bool errors_as_json = false;
@@ -29438,9 +29358,10 @@ struct ClientConfig {
 	get_result_collector_t result_collector = nullptr;
 
 	//! If HTTP logging is enabled or not.
-	bool enable_http_logging = false;
-	//! The file to save query HTTP logging information to, instead of printing it to the console
-	//! (empty = print to console)
+	bool enable_http_logging = true;
+
+	//! **DEPRECATED** The file to save query HTTP logging information to, instead of printing it to the console
+	//! (empty = output to the DuckDB logger)
 	string http_logging_output;
 
 public:
@@ -29647,7 +29568,7 @@ protected:
 
 namespace duckdb {
 
-enum class ArrowTypeInfoType : uint8_t { LIST, STRUCT, DATE_TIME, STRING, ARRAY };
+enum class ArrowTypeInfoType : uint8_t { LIST, STRUCT, DATE_TIME, STRING, ARRAY, DECIMAL };
 
 } // namespace duckdb
 
@@ -29748,6 +29669,23 @@ public:
 
 private:
 	ArrowDateTimeType size_type;
+};
+
+enum class DecimalBitWidth : uint8_t { DECIMAL_32, DECIMAL_64, DECIMAL_128, DECIMAL_256 };
+
+struct ArrowDecimalInfo final : public ArrowTypeInfo {
+public:
+	static constexpr const ArrowTypeInfoType TYPE = ArrowTypeInfoType::DECIMAL;
+
+public:
+	explicit ArrowDecimalInfo(DecimalBitWidth bit_width);
+	~ArrowDecimalInfo() override;
+
+public:
+	DecimalBitWidth GetBitWidth() const;
+
+private:
+	DecimalBitWidth bit_width;
 };
 
 struct ArrowStringInfo : public ArrowTypeInfo {
@@ -30077,13 +30015,6 @@ class CGroups {
 public:
 	static optional_idx GetMemoryLimit(FileSystem &fs);
 	static idx_t GetCPULimit(FileSystem &fs, idx_t physical_cores);
-
-private:
-	static optional_idx GetCGroupV2MemoryLimit(FileSystem &fs);
-	static optional_idx GetCGroupV1MemoryLimit(FileSystem &fs);
-	static string ReadCGroupPath(FileSystem &fs, const char *cgroup_file);
-	static string ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file);
-	static optional_idx ReadCGroupValue(FileSystem &fs, const char *file_path);
 };
 
 } // namespace duckdb
@@ -30107,11 +30038,10 @@ namespace duckdb {
 class EncryptionState {
 
 public:
-	DUCKDB_API EncryptionState();
+	DUCKDB_API explicit EncryptionState(const std::string *key = nullptr);
 	DUCKDB_API virtual ~EncryptionState();
 
 public:
-	DUCKDB_API virtual bool IsOpenSSL();
 	DUCKDB_API virtual void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key);
 	DUCKDB_API virtual void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key);
 	DUCKDB_API virtual size_t Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len);
@@ -30120,6 +30050,7 @@ public:
 
 public:
 	enum Mode { ENCRYPT, DECRYPT };
+	enum Cipher { GCM, CTR };
 };
 
 class EncryptionUtil {
@@ -30128,7 +30059,7 @@ public:
 	DUCKDB_API explicit EncryptionUtil() {};
 
 public:
-	virtual shared_ptr<EncryptionState> CreateEncryptionState() const {
+	virtual shared_ptr<EncryptionState> CreateEncryptionState(const std::string *key = nullptr) const {
 		return make_shared_ptr<EncryptionState>();
 	}
 
@@ -30239,6 +30170,234 @@ enum class WindowAggregationMode : uint32_t {
 
 
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/physical_plan_generator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/joinside.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+//! JoinCondition represents a left-right comparison join condition
+struct JoinCondition {
+public:
+	JoinCondition() {
+	}
+
+	//! Turns the JoinCondition into an expression; note that this destroys the JoinCondition as the expression inherits
+	//! the left/right expressions
+	static unique_ptr<Expression> CreateExpression(JoinCondition cond);
+	static unique_ptr<Expression> CreateExpression(vector<JoinCondition> conditions);
+
+	void Serialize(Serializer &serializer) const;
+	static JoinCondition Deserialize(Deserializer &deserializer);
+
+public:
+	unique_ptr<Expression> left;
+	unique_ptr<Expression> right;
+	ExpressionType comparison;
+};
+
+class JoinSide {
+public:
+	enum JoinValue : uint8_t { NONE, LEFT, RIGHT, BOTH };
+
+	JoinSide() = default;
+	constexpr JoinSide(JoinValue val) : value(val) { // NOLINT: Allow implicit conversion from `join_value`
+	}
+
+	bool operator==(JoinSide a) const {
+		return value == a.value;
+	}
+	bool operator!=(JoinSide a) const {
+		return value != a.value;
+	}
+
+	static JoinSide CombineJoinSide(JoinSide left, JoinSide right);
+	static JoinSide GetJoinSide(idx_t table_binding, const unordered_set<idx_t> &left_bindings,
+	                            const unordered_set<uint64_t> &right_bindings);
+	static JoinSide GetJoinSide(Expression &expression, const unordered_set<idx_t> &left_bindings,
+	                            const unordered_set<idx_t> &right_bindings);
+	static JoinSide GetJoinSide(const unordered_set<idx_t> &bindings, const unordered_set<idx_t> &left_bindings,
+	                            const unordered_set<idx_t> &right_bindings);
+
+private:
+	JoinValue value;
+};
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+class ClientContext;
+class ColumnDataCollection;
+
+class PhysicalPlan {
+public:
+	explicit PhysicalPlan(Allocator &allocator) : arena(allocator) {};
+
+	~PhysicalPlan() {
+		// Call the destructor of each physical operator.
+		for (auto &op : ops) {
+			auto &op_ref = op.get();
+			op_ref.~PhysicalOperator();
+		}
+	}
+
+public:
+	template <class T, class... ARGS>
+	PhysicalOperator &Make(ARGS &&... args) {
+		static_assert(std::is_base_of<PhysicalOperator, T>::value, "T must be a physical operator");
+		auto mem = arena.AllocateAligned(sizeof(T));
+		auto ptr = new (mem) T(std::forward<ARGS>(args)...);
+		ops.push_back(*ptr);
+		return *ptr;
+	}
+
+	PhysicalOperator &Root() {
+		D_ASSERT(root);
+		return *root;
+	}
+	void SetRoot(PhysicalOperator &op) {
+		root = op;
+	}
+
+private:
+	//! The arena allocator storing the physical operator memory.
+	ArenaAllocator arena;
+	//! References to the physical operators.
+	vector<reference<PhysicalOperator>> ops;
+	//! The root of the physical plan.
+	optional_ptr<PhysicalOperator> root;
+};
+
+//! The physical plan generator generates a physical execution plan from a logical query plan.
+class PhysicalPlanGenerator {
+public:
+	explicit PhysicalPlanGenerator(ClientContext &context);
+	~PhysicalPlanGenerator();
+
+	LogicalDependencyList dependencies;
+	//! Recursive CTEs require at least one ChunkScan, referencing the working_table.
+	//! This data structure is used to establish it.
+	unordered_map<idx_t, shared_ptr<ColumnDataCollection>> recursive_cte_tables;
+	//! Used to reference the recurring tables
+	unordered_map<idx_t, shared_ptr<ColumnDataCollection>> recurring_cte_tables;
+	//! Materialized CTE ids must be collected.
+	unordered_map<idx_t, vector<const_reference<PhysicalOperator>>> materialized_ctes;
+	//! The index for duplicate eliminated joins.
+	idx_t delim_index = 0;
+
+public:
+	//! Creates and returns the physical plan from the logical operator.
+	//! Performs a verification pass.
+	unique_ptr<PhysicalPlan> Plan(unique_ptr<LogicalOperator> logical);
+	PhysicalOperator &CreatePlan(LogicalOperator &op);
+
+	//! Whether or not we can (or should) use a batch-index based operator for executing the given sink
+	static bool UseBatchIndex(ClientContext &context, PhysicalOperator &plan);
+	//! Whether or not we should preserve insertion order for executing the given sink
+	static bool PreserveInsertionOrder(ClientContext &context, PhysicalOperator &plan);
+	//! The order preservation type of the given operator decided by recursively looking at its children
+	static OrderPreservationType OrderPreservationRecursive(PhysicalOperator &op);
+
+	template <class T, class... ARGS>
+	PhysicalOperator &Make(ARGS &&... args) {
+		return physical_plan->Make<T>(std::forward<ARGS>(args)...);
+	}
+
+public:
+	PhysicalOperator &ResolveDefaultsProjection(LogicalInsert &op, PhysicalOperator &child);
+
+protected:
+	PhysicalOperator &CreatePlan(LogicalAggregate &op);
+	PhysicalOperator &CreatePlan(LogicalAnyJoin &op);
+	PhysicalOperator &CreatePlan(LogicalColumnDataGet &op);
+	PhysicalOperator &CreatePlan(LogicalComparisonJoin &op);
+	PhysicalOperator &CreatePlan(LogicalCopyDatabase &op);
+	PhysicalOperator &CreatePlan(LogicalCreate &op);
+	PhysicalOperator &CreatePlan(LogicalCreateTable &op);
+	PhysicalOperator &CreatePlan(LogicalCreateIndex &op);
+	PhysicalOperator &CreatePlan(LogicalCreateSecret &op);
+	PhysicalOperator &CreatePlan(LogicalCrossProduct &op);
+	PhysicalOperator &CreatePlan(LogicalDelete &op);
+	PhysicalOperator &CreatePlan(LogicalDelimGet &op);
+	PhysicalOperator &CreatePlan(LogicalDistinct &op);
+	PhysicalOperator &CreatePlan(LogicalDummyScan &expr);
+	PhysicalOperator &CreatePlan(LogicalEmptyResult &op);
+	PhysicalOperator &CreatePlan(LogicalExpressionGet &op);
+	PhysicalOperator &CreatePlan(LogicalExport &op);
+	PhysicalOperator &CreatePlan(LogicalFilter &op);
+	PhysicalOperator &CreatePlan(LogicalGet &op);
+	PhysicalOperator &CreatePlan(LogicalLimit &op);
+	PhysicalOperator &CreatePlan(LogicalOrder &op);
+	PhysicalOperator &CreatePlan(LogicalTopN &op);
+	PhysicalOperator &CreatePlan(LogicalPositionalJoin &op);
+	PhysicalOperator &CreatePlan(LogicalProjection &op);
+	PhysicalOperator &CreatePlan(LogicalInsert &op);
+	PhysicalOperator &CreatePlan(LogicalCopyToFile &op);
+	PhysicalOperator &CreatePlan(LogicalExplain &op);
+	PhysicalOperator &CreatePlan(LogicalSetOperation &op);
+	PhysicalOperator &CreatePlan(LogicalUpdate &op);
+	PhysicalOperator &CreatePlan(LogicalPrepare &expr);
+	PhysicalOperator &CreatePlan(LogicalWindow &expr);
+	PhysicalOperator &CreatePlan(LogicalExecute &op);
+	PhysicalOperator &CreatePlan(LogicalPragma &op);
+	PhysicalOperator &CreatePlan(LogicalSample &op);
+	PhysicalOperator &CreatePlan(LogicalSet &op);
+	PhysicalOperator &CreatePlan(LogicalReset &op);
+	PhysicalOperator &CreatePlan(LogicalSimple &op);
+	PhysicalOperator &CreatePlan(LogicalVacuum &op);
+	PhysicalOperator &CreatePlan(LogicalUnnest &op);
+	PhysicalOperator &CreatePlan(LogicalRecursiveCTE &op);
+	PhysicalOperator &CreatePlan(LogicalMaterializedCTE &op);
+	PhysicalOperator &CreatePlan(LogicalCTERef &op);
+	PhysicalOperator &CreatePlan(LogicalPivot &op);
+
+	PhysicalOperator &PlanAsOfJoin(LogicalComparisonJoin &op);
+	PhysicalOperator &PlanComparisonJoin(LogicalComparisonJoin &op);
+	PhysicalOperator &PlanDelimJoin(LogicalComparisonJoin &op);
+	PhysicalOperator &ExtractAggregateExpressions(PhysicalOperator &child, vector<unique_ptr<Expression>> &expressions,
+	                                              vector<unique_ptr<Expression>> &groups);
+
+private:
+	ClientContext &context;
+	unique_ptr<PhysicalPlan> physical_plan;
+
+private:
+	PhysicalOperator &ResolveAndPlan(unique_ptr<LogicalOperator> logical);
+	unique_ptr<PhysicalPlan> PlanInternal(LogicalOperator &logical);
+	bool PreserveInsertionOrder(PhysicalOperator &plan);
+	bool UseBatchIndex(PhysicalOperator &plan);
+	optional_ptr<PhysicalOperator> PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOperator &probe,
+	                                                PhysicalOperator &build);
+};
+} // namespace duckdb
+
 
 namespace duckdb {
 
@@ -30273,15 +30432,17 @@ struct CreateIndexInput {
 struct PlanIndexInput {
 	ClientContext &context;
 	LogicalCreateIndex &op;
-	unique_ptr<PhysicalOperator> &table_scan;
+	PhysicalPlanGenerator &planner;
+	PhysicalOperator &table_scan;
 
-	PlanIndexInput(ClientContext &context_p, LogicalCreateIndex &op_p, unique_ptr<PhysicalOperator> &table_scan_p)
-	    : context(context_p), op(op_p), table_scan(table_scan_p) {
+	PlanIndexInput(ClientContext &context_p, LogicalCreateIndex &op_p, PhysicalPlanGenerator &planner,
+	               PhysicalOperator &table_scan_p)
+	    : context(context_p), op(op_p), planner(planner), table_scan(table_scan_p) {
 	}
 };
 
 typedef unique_ptr<BoundIndex> (*index_create_function_t)(CreateIndexInput &input);
-typedef unique_ptr<PhysicalOperator> (*index_plan_function_t)(PlanIndexInput &input);
+typedef PhysicalOperator &(*index_plan_function_t)(PlanIndexInput &input);
 
 //! A index "type"
 class IndexType {
@@ -30392,6 +30553,10 @@ struct CastParameters {
 	bool strict = false;
 	// out: error message in case cast has failed
 	string *error_message = nullptr;
+	//! Source expression
+	optional_ptr<const Expression> cast_source;
+	//! Target expression
+	optional_ptr<const Expression> cast_target;
 	//! Local state
 	optional_ptr<FunctionLocalState> local_state;
 	//! Query location (if any)
@@ -30745,183 +30910,6 @@ public:
 
 
 
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/execution/physical_plan_generator.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-
-//===----------------------------------------------------------------------===//
-//                         DuckDB
-//
-// duckdb/planner/joinside.hpp
-//
-//
-//===----------------------------------------------------------------------===//
-
-
-
-
-
-
-namespace duckdb {
-
-//! JoinCondition represents a left-right comparison join condition
-struct JoinCondition {
-public:
-	JoinCondition() {
-	}
-
-	//! Turns the JoinCondition into an expression; note that this destroys the JoinCondition as the expression inherits
-	//! the left/right expressions
-	static unique_ptr<Expression> CreateExpression(JoinCondition cond);
-	static unique_ptr<Expression> CreateExpression(vector<JoinCondition> conditions);
-
-	void Serialize(Serializer &serializer) const;
-	static JoinCondition Deserialize(Deserializer &deserializer);
-
-public:
-	unique_ptr<Expression> left;
-	unique_ptr<Expression> right;
-	ExpressionType comparison;
-};
-
-class JoinSide {
-public:
-	enum JoinValue : uint8_t { NONE, LEFT, RIGHT, BOTH };
-
-	JoinSide() = default;
-	constexpr JoinSide(JoinValue val) : value(val) { // NOLINT: Allow implicit conversion from `join_value`
-	}
-
-	bool operator==(JoinSide a) const {
-		return value == a.value;
-	}
-	bool operator!=(JoinSide a) const {
-		return value != a.value;
-	}
-
-	static JoinSide CombineJoinSide(JoinSide left, JoinSide right);
-	static JoinSide GetJoinSide(idx_t table_binding, const unordered_set<idx_t> &left_bindings,
-	                            const unordered_set<uint64_t> &right_bindings);
-	static JoinSide GetJoinSide(Expression &expression, const unordered_set<idx_t> &left_bindings,
-	                            const unordered_set<idx_t> &right_bindings);
-	static JoinSide GetJoinSide(const unordered_set<idx_t> &bindings, const unordered_set<idx_t> &left_bindings,
-	                            const unordered_set<idx_t> &right_bindings);
-
-private:
-	JoinValue value;
-};
-
-} // namespace duckdb
-
-
-
-
-
-namespace duckdb {
-class ClientContext;
-class ColumnDataCollection;
-
-//! The physical plan generator generates a physical execution plan from a
-//! logical query plan
-class PhysicalPlanGenerator {
-public:
-	explicit PhysicalPlanGenerator(ClientContext &context);
-	~PhysicalPlanGenerator();
-
-	LogicalDependencyList dependencies;
-	//! Recursive CTEs require at least one ChunkScan, referencing the working_table.
-	//! This data structure is used to establish it.
-	unordered_map<idx_t, shared_ptr<ColumnDataCollection>> recursive_cte_tables;
-	//! Materialized CTE ids must be collected.
-	unordered_map<idx_t, vector<const_reference<PhysicalOperator>>> materialized_ctes;
-
-public:
-	//! Creates a plan from the logical operator. This involves resolving column bindings and generating physical
-	//! operator nodes.
-	unique_ptr<PhysicalOperator> CreatePlan(unique_ptr<LogicalOperator> logical);
-
-	//! Whether or not we can (or should) use a batch-index based operator for executing the given sink
-	static bool UseBatchIndex(ClientContext &context, PhysicalOperator &plan);
-	//! Whether or not we should preserve insertion order for executing the given sink
-	static bool PreserveInsertionOrder(ClientContext &context, PhysicalOperator &plan);
-	//! The order preservation type of the given operator decided by recursively looking at its children
-	static OrderPreservationType OrderPreservationRecursive(PhysicalOperator &op);
-
-protected:
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalOperator &op);
-
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalAggregate &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalAnyJoin &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalColumnDataGet &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalComparisonJoin &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCopyDatabase &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCreate &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCreateTable &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCreateIndex &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCreateSecret &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCrossProduct &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalDelete &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalDelimGet &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalDistinct &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalDummyScan &expr);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalEmptyResult &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalExpressionGet &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalExport &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalFilter &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalGet &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalLimit &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalOrder &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalTopN &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalPositionalJoin &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalProjection &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalInsert &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCopyToFile &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalExplain &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalSetOperation &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalUpdate &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalPrepare &expr);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalWindow &expr);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalExecute &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalPragma &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalSample &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalSet &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalReset &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalSimple &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalVacuum &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalUnnest &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalRecursiveCTE &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalMaterializedCTE &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalCTERef &op);
-	unique_ptr<PhysicalOperator> CreatePlan(LogicalPivot &op);
-
-	unique_ptr<PhysicalOperator> PlanAsOfJoin(LogicalComparisonJoin &op);
-	unique_ptr<PhysicalOperator> PlanComparisonJoin(LogicalComparisonJoin &op);
-	unique_ptr<PhysicalOperator> PlanDelimJoin(LogicalComparisonJoin &op);
-	unique_ptr<PhysicalOperator> ExtractAggregateExpressions(unique_ptr<PhysicalOperator> child,
-	                                                         vector<unique_ptr<Expression>> &expressions,
-	                                                         vector<unique_ptr<Expression>> &groups);
-
-private:
-	bool PreserveInsertionOrder(PhysicalOperator &plan);
-	bool UseBatchIndex(PhysicalOperator &plan);
-
-public:
-	idx_t delim_index = 0;
-
-private:
-	ClientContext &context;
-};
-} // namespace duckdb
 
 //===----------------------------------------------------------------------===//
 //                         DuckDB
@@ -31215,8 +31203,6 @@ public:
 public:
 	//! Convert the object to a string
 	virtual string ToString() const = 0;
-	string BaseToString(string result) const;
-	string BaseToString(string result, const vector<string> &column_name_alias) const;
 	void Print();
 
 	virtual bool Equals(const TableRef &other) const;
@@ -31246,6 +31232,12 @@ public:
 		}
 		return reinterpret_cast<const TARGET &>(*this);
 	}
+
+protected:
+	string BaseToString(string result) const;
+	string BaseToString(string result, const vector<string> &column_name_alias) const;
+	string AliasToString(const vector<string> &column_name_alias) const;
+	string SampleToString() const;
 };
 } // namespace duckdb
 
@@ -31315,6 +31307,7 @@ class SelectStatement;
 
 struct CommonTableExpressionInfo {
 	vector<string> aliases;
+	vector<unique_ptr<ParsedExpression>> key_targets;
 	unique_ptr<SelectStatement> query;
 	CTEMaterialize materialized = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
 
@@ -31455,7 +31448,1131 @@ public:
 };
 } // namespace duckdb
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/tokens.hpp
+//
+//
+//===----------------------------------------------------------------------===//
 
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Statements
+//===--------------------------------------------------------------------===//
+class SQLStatement;
+
+class AlterStatement;
+class AttachStatement;
+class CallStatement;
+class CopyStatement;
+class CreateStatement;
+class DetachStatement;
+class DeleteStatement;
+class DropStatement;
+class ExtensionStatement;
+class InsertStatement;
+class SelectStatement;
+class TransactionStatement;
+class UpdateStatement;
+class UpdateExtensionsStatement;
+class PrepareStatement;
+class ExecuteStatement;
+class PragmaStatement;
+class ExplainStatement;
+class ExportStatement;
+class VacuumStatement;
+class RelationStatement;
+class SetStatement;
+class SetVariableStatement;
+class ResetVariableStatement;
+class LoadStatement;
+class LogicalPlanStatement;
+class MultiStatement;
+class CopyDatabaseStatement;
+
+//===--------------------------------------------------------------------===//
+// Query Node
+//===--------------------------------------------------------------------===//
+class QueryNode;
+class SelectNode;
+class SetOperationNode;
+class RecursiveCTENode;
+class CTENode;
+
+//===--------------------------------------------------------------------===//
+// Expressions
+//===--------------------------------------------------------------------===//
+class ParsedExpression;
+
+class BetweenExpression;
+class CaseExpression;
+class CastExpression;
+class CollateExpression;
+class ColumnRefExpression;
+class ComparisonExpression;
+class ConjunctionExpression;
+class ConstantExpression;
+class DefaultExpression;
+class FunctionExpression;
+class LambdaExpression;
+class OperatorExpression;
+class ParameterExpression;
+class PositionalReferenceExpression;
+class StarExpression;
+class SubqueryExpression;
+class WindowExpression;
+
+//===--------------------------------------------------------------------===//
+// Constraints
+//===--------------------------------------------------------------------===//
+class Constraint;
+
+class NotNullConstraint;
+class CheckConstraint;
+class UniqueConstraint;
+class ForeignKeyConstraint;
+
+//===--------------------------------------------------------------------===//
+// TableRefs
+//===--------------------------------------------------------------------===//
+class TableRef;
+
+class BaseTableRef;
+class JoinRef;
+class SubqueryRef;
+class TableFunctionRef;
+class EmptyTableRef;
+class ExpressionListRef;
+class ColumnDataRef;
+class PivotRef;
+class ShowRef;
+
+//===--------------------------------------------------------------------===//
+// Other
+//===--------------------------------------------------------------------===//
+class SampleOptions;
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/bind_context.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/expression/columnref_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+struct BindingAlias;
+
+//! Represents a reference to a column from either the FROM clause or from an
+//! alias
+class ColumnRefExpression : public ParsedExpression {
+public:
+	static constexpr const ExpressionClass TYPE = ExpressionClass::COLUMN_REF;
+
+public:
+	//! Specify both the column and table name
+	ColumnRefExpression(string column_name, string table_name);
+	//! Specify both the column and table alias
+	ColumnRefExpression(string column_name, const BindingAlias &alias);
+	//! Only specify the column name, the table name will be derived later
+	explicit ColumnRefExpression(string column_name);
+	//! Specify a set of names
+	explicit ColumnRefExpression(vector<string> column_names);
+
+	//! The stack of names in order of which they appear (column_names[0].column_names[1].column_names[2]....)
+	vector<string> column_names;
+
+public:
+	bool IsQualified() const;
+	const string &GetColumnName() const;
+	const string &GetTableName() const;
+	bool IsScalar() const override {
+		return false;
+	}
+
+	string GetName() const override;
+	string ToString() const override;
+
+	static bool Equal(const ColumnRefExpression &a, const ColumnRefExpression &b);
+	hash_t Hash() const override;
+
+	unique_ptr<ParsedExpression> Copy() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<ParsedExpression> Deserialize(Deserializer &deserializer);
+
+private:
+	ColumnRefExpression();
+};
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/qualified_name_set.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct QualifiedColumnHashFunction {
+	uint64_t operator()(const QualifiedColumnName &a) const {
+		// hash only on the column name - since we match based on the shortest possible match
+		return StringUtil::CIHash(a.column);
+	}
+};
+
+struct QualifiedColumnEquality {
+	bool operator()(const QualifiedColumnName &a, const QualifiedColumnName &b) const {
+		// qualified column names follow a prefix comparison
+		// so "tbl.i"  and "i" are equivalent, as are "schema.tbl.i" and "i"
+		// but "tbl.i" and "tbl2.i" are not equivalent
+		if (!a.catalog.empty() && !b.catalog.empty() && !StringUtil::CIEquals(a.catalog, b.catalog)) {
+			return false;
+		}
+		if (!a.schema.empty() && !b.schema.empty() && !StringUtil::CIEquals(a.schema, b.schema)) {
+			return false;
+		}
+		if (!a.table.empty() && !b.table.empty() && !StringUtil::CIEquals(a.table, b.table)) {
+			return false;
+		}
+		return StringUtil::CIEquals(a.column, b.column);
+	}
+};
+
+using qualified_column_set_t = unordered_set<QualifiedColumnName, QualifiedColumnHashFunction, QualifiedColumnEquality>;
+
+template <class T>
+using qualified_column_map_t =
+    unordered_map<QualifiedColumnName, T, QualifiedColumnHashFunction, QualifiedColumnEquality>;
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression_binder.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/stack_checker.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+namespace duckdb {
+
+template <class RECURSIVE_CLASS>
+class StackChecker {
+public:
+	StackChecker(RECURSIVE_CLASS &recursive_class_p, idx_t stack_usage_p)
+	    : recursive_class(recursive_class_p), stack_usage(stack_usage_p) {
+		recursive_class.stack_depth += stack_usage;
+	}
+	~StackChecker() {
+		recursive_class.stack_depth -= stack_usage;
+	}
+	StackChecker(StackChecker &&other) noexcept
+	    : recursive_class(other.recursive_class), stack_usage(other.stack_usage) {
+		other.stack_usage = 0;
+	}
+	StackChecker(const StackChecker &) = delete;
+
+private:
+	RECURSIVE_CLASS &recursive_class;
+	idx_t stack_usage;
+};
+
+} // namespace duckdb
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/expression/bound_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+//! BoundExpression is an intermediate dummy class used by the binder. It is a ParsedExpression but holds an Expression.
+//! It represents a successfully bound expression. It is used in the Binder to prevent re-binding of already bound parts
+//! when dealing with subqueries.
+class BoundExpression : public ParsedExpression {
+public:
+	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_EXPRESSION;
+
+public:
+	explicit BoundExpression(unique_ptr<Expression> expr);
+
+	unique_ptr<Expression> expr;
+
+public:
+	static unique_ptr<Expression> &GetExpression(ParsedExpression &expr);
+
+	string ToString() const override;
+
+	bool Equals(const BaseExpression &other) const override;
+	hash_t Hash() const override;
+
+	unique_ptr<ParsedExpression> Copy() const override;
+
+	void Serialize(Serializer &serializer) const override;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/expression/lambdaref_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+struct DummyBinding;
+
+//! Represents a reference to a lambda parameter
+class LambdaRefExpression : public ParsedExpression {
+public:
+	static constexpr const ExpressionClass TYPE = ExpressionClass::LAMBDA_REF;
+
+public:
+	//! Constructs a LambdaRefExpression from a lambda_idx and a column_name. We do not specify a table name,
+	//! because we use dummy tables to bind lambda parameters
+	LambdaRefExpression(idx_t lambda_idx, string column_name_p);
+
+	//! The index of the lambda parameter in the lambda_bindings vector
+	idx_t lambda_idx;
+	//! The name of the lambda parameter (in a specific Binding in lambda_bindings)
+	string column_name;
+
+public:
+	bool IsScalar() const override;
+	string GetName() const override;
+	string ToString() const override;
+	hash_t Hash() const override;
+	unique_ptr<ParsedExpression> Copy() const override;
+
+	//! Traverses the lambda_bindings to find a matching binding for the column_name
+	static unique_ptr<ParsedExpression> FindMatchingBinding(optional_ptr<vector<DummyBinding>> &lambda_bindings,
+	                                                        const string &parameter_name);
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<ParsedExpression> Deserialize(Deserializer &deserializer);
+};
+} // namespace duckdb
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/catalog_entry_retriever.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+#include <functional>
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/catalog/catalog_search_path.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+#include <functional>
+
+
+
+
+
+namespace duckdb {
+
+class ClientContext;
+
+struct CatalogSearchEntry {
+	CatalogSearchEntry(string catalog, string schema);
+
+	string catalog;
+	string schema;
+
+public:
+	string ToString() const;
+	static string ListToString(const vector<CatalogSearchEntry> &input);
+	static CatalogSearchEntry Parse(const string &input);
+	static vector<CatalogSearchEntry> ParseList(const string &input);
+
+private:
+	static CatalogSearchEntry ParseInternal(const string &input, idx_t &pos);
+	static string WriteOptionallyQuoted(const string &input);
+};
+
+enum class CatalogSetPathType { SET_SCHEMA, SET_SCHEMAS, SET_DIRECTLY };
+
+//! The schema search path, in order by which entries are searched if no schema entry is provided
+class CatalogSearchPath {
+public:
+	DUCKDB_API explicit CatalogSearchPath(ClientContext &client_p);
+	DUCKDB_API CatalogSearchPath(ClientContext &client_p, vector<CatalogSearchEntry> entries);
+	CatalogSearchPath(const CatalogSearchPath &other) = delete;
+
+	DUCKDB_API void Set(CatalogSearchEntry new_value, CatalogSetPathType set_type);
+	DUCKDB_API void Set(vector<CatalogSearchEntry> new_paths, CatalogSetPathType set_type);
+	DUCKDB_API void Reset();
+
+	DUCKDB_API const vector<CatalogSearchEntry> &Get() const;
+	const vector<CatalogSearchEntry> &GetSetPaths() const {
+		return set_paths;
+	}
+	DUCKDB_API const CatalogSearchEntry &GetDefault() const;
+	//! FIXME: this method is deprecated
+	DUCKDB_API string GetDefaultSchema(const string &catalog) const;
+	DUCKDB_API string GetDefaultSchema(ClientContext &context, const string &catalog) const;
+	DUCKDB_API string GetDefaultCatalog(const string &schema) const;
+
+	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog) const;
+	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema) const;
+
+	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name,
+	                                   const string &schema_name) const;
+
+private:
+	//! Set paths without checking if they exist
+	void SetPathsInternal(vector<CatalogSearchEntry> new_paths);
+	string GetSetName(CatalogSetPathType set_type);
+
+private:
+	ClientContext &context;
+	vector<CatalogSearchEntry> paths;
+	//! Only the paths that were explicitly set (minus the always included paths)
+	vector<CatalogSearchEntry> set_paths;
+};
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+class ClientContext;
+class Catalog;
+class CatalogEntry;
+
+using catalog_entry_callback_t = std::function<void(CatalogEntry &)>;
+
+// Wraps the Catalog::GetEntry method
+class CatalogEntryRetriever {
+public:
+	explicit CatalogEntryRetriever(ClientContext &context) : context(context) {
+	}
+	CatalogEntryRetriever(const CatalogEntryRetriever &other) : callback(other.callback), context(other.context) {
+	}
+
+public:
+	void Inherit(const CatalogEntryRetriever &parent);
+	ClientContext &GetContext() {
+		return context;
+	}
+
+	optional_ptr<CatalogEntry> GetEntry(const string &catalog, const string &schema, const EntryLookupInfo &lookup_info,
+	                                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::THROW_EXCEPTION);
+
+	optional_ptr<CatalogEntry> GetEntry(Catalog &catalog, const string &schema, const EntryLookupInfo &lookup_info,
+	                                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::THROW_EXCEPTION);
+
+	LogicalType GetType(const string &catalog, const string &schema, const string &name,
+	                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::RETURN_NULL);
+	LogicalType GetType(Catalog &catalog, const string &schema, const string &name,
+	                    OnEntryNotFound on_entry_not_found = OnEntryNotFound::RETURN_NULL);
+
+	optional_ptr<SchemaCatalogEntry> GetSchema(const string &catalog, const EntryLookupInfo &schema_lookup,
+	                                           OnEntryNotFound on_entry_not_found = OnEntryNotFound::THROW_EXCEPTION);
+
+	const CatalogSearchPath &GetSearchPath() const;
+	void SetSearchPath(vector<CatalogSearchEntry> entries);
+
+	void SetCallback(catalog_entry_callback_t callback);
+	catalog_entry_callback_t GetCallback();
+
+	optional_ptr<BoundAtClause> GetAtClause() const;
+	void SetAtClause(optional_ptr<BoundAtClause> at_clause);
+
+private:
+	optional_ptr<CatalogEntry> ReturnAndCallback(optional_ptr<CatalogEntry> result);
+
+private:
+	//! (optional) callback, called on every successful entry retrieval
+	catalog_entry_callback_t callback = nullptr;
+	ClientContext &context;
+	shared_ptr<CatalogSearchPath> search_path;
+	optional_ptr<BoundAtClause> at_clause;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression/bound_lambda_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+class BoundLambdaExpression : public Expression {
+public:
+	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_LAMBDA;
+
+public:
+	BoundLambdaExpression(ExpressionType type_p, LogicalType return_type_p, unique_ptr<Expression> lambda_expr_p,
+	                      idx_t parameter_count_p);
+
+	//! The lambda expression that we'll use in the expression executor during execution
+	unique_ptr<Expression> lambda_expr;
+	//! Non-lambda constants, column references, and outer lambda parameters that we need to pass
+	//! into the execution chunk
+	vector<unique_ptr<Expression>> captures;
+	//! The number of lhs parameters of the lambda function
+	idx_t parameter_count;
+
+public:
+	string ToString() const override;
+	bool Equals(const BaseExpression &other) const override;
+	unique_ptr<Expression> Copy() const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<Expression> Deserialize(Deserializer &deserializer);
+};
+} // namespace duckdb
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/collation_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+enum class CollationType { ALL_COLLATIONS, COMBINABLE_COLLATIONS };
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class Binder;
+class ClientContext;
+class QueryNode;
+
+class ScalarFunctionCatalogEntry;
+class AggregateFunctionCatalogEntry;
+class ScalarMacroCatalogEntry;
+class CatalogEntry;
+class SimpleFunction;
+
+struct DummyBinding;
+struct SelectBindState;
+
+struct BoundColumnReferenceInfo {
+	string name;
+	optional_idx query_location;
+};
+
+struct BindResult {
+	BindResult() {
+	}
+	explicit BindResult(const Exception &ex) : error(ex) {
+	}
+	explicit BindResult(const string &error_msg) : error(ExceptionType::BINDER, error_msg) {
+	}
+	explicit BindResult(ErrorData error) : error(std::move(error)) {
+	}
+	explicit BindResult(unique_ptr<Expression> expr) : expression(std::move(expr)) {
+	}
+
+	bool HasError() const {
+		return error.HasError();
+	}
+	void SetError(const string &error_message) {
+		error = ErrorData(ExceptionType::BINDER, error_message);
+	}
+
+	unique_ptr<Expression> expression;
+	ErrorData error;
+};
+
+class ExpressionBinder {
+	friend class StackChecker<ExpressionBinder>;
+
+public:
+	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
+	virtual ~ExpressionBinder();
+
+	//! The target type that should result from the binder. If the result is not of this type, a cast to this type will
+	//! be added. Defaults to INVALID.
+	LogicalType target_type;
+
+	optional_ptr<DummyBinding> macro_binding;
+	optional_ptr<vector<DummyBinding>> lambda_bindings;
+
+public:
+	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> &expr, optional_ptr<LogicalType> result_type = nullptr,
+	                            bool root_expression = true);
+
+	//! Returns whether or not any columns have been bound by the expression binder
+	bool HasBoundColumns() {
+		return !bound_columns.empty();
+	}
+	const vector<BoundColumnReferenceInfo> &GetBoundColumns() {
+		return bound_columns;
+	}
+
+	void SetCatalogLookupCallback(catalog_entry_callback_t callback);
+	ErrorData Bind(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression = false);
+
+	//! Returns the STRUCT_EXTRACT operator expression
+	unique_ptr<ParsedExpression> CreateStructExtract(unique_ptr<ParsedExpression> base, const string &field_name);
+	//! Returns a STRUCT_PACK function expression
+	unique_ptr<ParsedExpression> CreateStructPack(ColumnRefExpression &col_ref);
+
+	BindResult BindQualifiedColumnName(ColumnRefExpression &colref, const string &table_name);
+
+	//! Returns a qualified column reference from a column name
+	unique_ptr<ParsedExpression> QualifyColumnName(const string &column_name, ErrorData &error);
+	//! Returns a qualified column reference from a column reference with column_names.size() > 2
+	unique_ptr<ParsedExpression> QualifyColumnNameWithManyDots(ColumnRefExpression &col_ref, ErrorData &error);
+	//! Returns a qualified column reference from a column reference
+	virtual unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &col_ref, ErrorData &error);
+	//! Enables special-handling of lambda parameters by tracking them in the lambda_params vector
+	void QualifyColumnNamesInLambda(FunctionExpression &function, vector<unordered_set<string>> &lambda_params);
+	//! Recursively qualifies the column references in the (children) of the expression. Passes on the
+	//! within_function_expression state from outer expressions, or sets it
+	void QualifyColumnNames(unique_ptr<ParsedExpression> &expr, vector<unordered_set<string>> &lambda_params,
+	                        const bool within_function_expression = false);
+	//! Entry point for qualifying the column references of the expression
+	static void QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpression> &expr);
+	static void QualifyColumnNames(ExpressionBinder &binder, unique_ptr<ParsedExpression> &expr);
+
+	static bool PushCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
+	                          CollationType type = CollationType::ALL_COLLATIONS);
+	static void TestCollation(ClientContext &context, const string &collation);
+
+	BindResult BindCorrelatedColumns(unique_ptr<ParsedExpression> &expr, ErrorData error_message);
+
+	void BindChild(unique_ptr<ParsedExpression> &expr, idx_t depth, ErrorData &error);
+	static void ExtractCorrelatedExpressions(Binder &binder, Expression &expr);
+
+	static bool ContainsNullType(const LogicalType &type);
+	static LogicalType ExchangeNullType(const LogicalType &type);
+	static bool ContainsType(const LogicalType &type, LogicalTypeId target);
+	static LogicalType ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type);
+
+	virtual bool TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result);
+	virtual bool QualifyColumnAlias(const ColumnRefExpression &colref);
+
+	//! Bind the given expression. Unlike Bind(), this does *not* mute the given ParsedExpression.
+	//! Exposed to be used from sub-binders that aren't subclasses of ExpressionBinder.
+	virtual BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
+	                                  bool root_expression = false);
+
+	//! FIXME: Generalise this for extensibility.
+	//! Recursively replaces macro parameters with the provided input parameters.
+	void ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr, vector<unordered_set<string>> &lambda_params);
+	//! Enables special-handling of lambda parameters during macro replacement by tracking them in the lambda_params
+	//! vector.
+	void ReplaceMacroParametersInLambda(FunctionExpression &function, vector<unordered_set<string>> &lambda_params);
+	//! Recursively qualifies column references in ON CONFLICT DO UPDATE SET expressions.
+	void DoUpdateSetQualify(unique_ptr<ParsedExpression> &expr, const string &table_name,
+	                        vector<unordered_set<string>> &lambda_params);
+	//! Enables special-handling of lambda parameters during ON CONFLICT TO UPDATE SET qualification by tracking them in
+	//! the lambda_params vector.
+	void DoUpdateSetQualifyInLambda(FunctionExpression &function, const string &table_name,
+	                                vector<unordered_set<string>> &lambda_params);
+
+	static LogicalType GetExpressionReturnType(const Expression &expr);
+
+private:
+	//! Current stack depth
+	idx_t stack_depth = DConstants::INVALID_INDEX;
+
+	void InitializeStackCheck();
+	StackChecker<ExpressionBinder> StackCheck(const ParsedExpression &expr, idx_t extra_stack = 1);
+
+protected:
+	BindResult BindExpression(BetweenExpression &expr, idx_t depth);
+	BindResult BindExpression(CaseExpression &expr, idx_t depth);
+	BindResult BindExpression(CollateExpression &expr, idx_t depth);
+	BindResult BindExpression(CastExpression &expr, idx_t depth);
+	BindResult BindExpression(ColumnRefExpression &expr, idx_t depth, bool root_expression);
+	BindResult BindExpression(LambdaRefExpression &expr, idx_t depth);
+	BindResult BindExpression(ComparisonExpression &expr, idx_t depth);
+	BindResult BindExpression(ConjunctionExpression &expr, idx_t depth);
+	BindResult BindExpression(ConstantExpression &expr, idx_t depth);
+	BindResult BindExpression(FunctionExpression &expr, idx_t depth, unique_ptr<ParsedExpression> &expr_ptr);
+
+	BindResult BindExpression(LambdaExpression &expr, idx_t depth, const vector<LogicalType> &function_child_types,
+	                          optional_ptr<bind_lambda_function_t> bind_lambda_function);
+	BindResult BindExpression(OperatorExpression &expr, idx_t depth);
+	BindResult BindExpression(ParameterExpression &expr, idx_t depth);
+	BindResult BindExpression(SubqueryExpression &expr, idx_t depth);
+	BindResult BindPositionalReference(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression);
+
+	void TransformCapturedLambdaColumn(unique_ptr<Expression> &original, unique_ptr<Expression> &replacement,
+	                                   BoundLambdaExpression &bound_lambda_expr,
+	                                   const optional_ptr<bind_lambda_function_t> bind_lambda_function,
+	                                   const vector<LogicalType> &function_child_types);
+
+	void CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_expr, unique_ptr<Expression> &expr,
+	                          const optional_ptr<bind_lambda_function_t> bind_lambda_function,
+	                          const vector<LogicalType> &function_child_types);
+
+	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
+
+	LogicalType ResolveOperatorType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
+	LogicalType ResolveCoalesceType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
+	LogicalType ResolveNotType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
+
+	BindResult BindUnsupportedExpression(ParsedExpression &expr, idx_t depth, const string &message);
+
+protected:
+	virtual BindResult BindGroupingFunction(OperatorExpression &op, idx_t depth);
+	virtual BindResult BindFunction(FunctionExpression &expr, ScalarFunctionCatalogEntry &function, idx_t depth);
+	virtual BindResult BindLambdaFunction(FunctionExpression &expr, ScalarFunctionCatalogEntry &function, idx_t depth);
+	virtual BindResult BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry &function, idx_t depth);
+	virtual BindResult BindUnnest(FunctionExpression &expr, idx_t depth, bool root_expression);
+	virtual BindResult BindMacro(FunctionExpression &expr, ScalarMacroCatalogEntry &macro, idx_t depth,
+	                             unique_ptr<ParsedExpression> &expr_ptr);
+	void UnfoldMacroExpression(FunctionExpression &function, ScalarMacroCatalogEntry &macro_func,
+	                           unique_ptr<ParsedExpression> &expr);
+
+	virtual string UnsupportedAggregateMessage();
+	virtual string UnsupportedUnnestMessage();
+	optional_ptr<CatalogEntry> GetCatalogEntry(const string &catalog, const string &schema,
+	                                           const EntryLookupInfo &lookup_info, OnEntryNotFound on_entry_not_found);
+
+	Binder &binder;
+	ClientContext &context;
+	optional_ptr<ExpressionBinder> stored_binder;
+	vector<BoundColumnReferenceInfo> bound_columns;
+
+	//! Returns true if the function name is an alias for the UNNEST function
+	static bool IsUnnestFunction(const string &function_name);
+	BindResult TryBindLambdaOrJson(FunctionExpression &function, idx_t depth, CatalogEntry &func,
+	                               const LambdaSyntaxType syntax_type);
+
+	unique_ptr<ParsedExpression> QualifyColumnNameWithManyDotsInternal(ColumnRefExpression &col_ref, ErrorData &error,
+	                                                                   idx_t &struct_extract_start);
+	virtual void ThrowIfUnnestInLambda(const ColumnBinding &column_binding);
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/table_binding.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+class BindContext;
+class BoundQueryNode;
+class ColumnRefExpression;
+class SubqueryRef;
+class LogicalGet;
+class TableCatalogEntry;
+class TableFunctionCatalogEntry;
+class BoundTableFunction;
+class StandardEntry;
+struct ColumnBinding;
+
+enum class BindingType { BASE, TABLE, DUMMY, CATALOG_ENTRY };
+
+//! A Binding represents a binding to a table, table-producing function or subquery with a specified table index.
+struct Binding {
+	Binding(BindingType binding_type, BindingAlias alias, vector<LogicalType> types, vector<string> names, idx_t index);
+	virtual ~Binding() = default;
+
+	//! The type of Binding
+	BindingType binding_type;
+	//! The alias of the binding
+	BindingAlias alias;
+	//! The table index of the binding
+	idx_t index;
+	//! The types of the bound columns
+	vector<LogicalType> types;
+	//! Column names of the subquery
+	vector<string> names;
+	//! Name -> index for the names
+	case_insensitive_map_t<column_t> name_map;
+
+public:
+	bool TryGetBindingIndex(const string &column_name, column_t &column_index);
+	column_t GetBindingIndex(const string &column_name);
+	bool HasMatchingBinding(const string &column_name);
+	virtual ErrorData ColumnNotFoundError(const string &column_name) const;
+	virtual BindResult Bind(ColumnRefExpression &colref, idx_t depth);
+	virtual optional_ptr<StandardEntry> GetStandardEntry();
+	string GetAlias() const;
+
+	static BindingAlias GetAlias(const string &explicit_alias, const StandardEntry &entry);
+	static BindingAlias GetAlias(const string &explicit_alias, optional_ptr<StandardEntry> entry);
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		if (binding_type != TARGET::TYPE) {
+			throw InternalException("Failed to cast binding to type - binding type mismatch");
+		}
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		if (binding_type != TARGET::TYPE) {
+			throw InternalException("Failed to cast binding to type - binding type mismatch");
+		}
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+struct EntryBinding : public Binding {
+public:
+	static constexpr const BindingType TYPE = BindingType::CATALOG_ENTRY;
+
+public:
+	EntryBinding(const string &alias, vector<LogicalType> types, vector<string> names, idx_t index,
+	             StandardEntry &entry);
+	StandardEntry &entry;
+
+public:
+	optional_ptr<StandardEntry> GetStandardEntry() override;
+};
+
+//! TableBinding is exactly like the Binding, except it keeps track of which columns were bound in the linked LogicalGet
+//! node for projection pushdown purposes.
+struct TableBinding : public Binding {
+public:
+	static constexpr const BindingType TYPE = BindingType::TABLE;
+
+public:
+	TableBinding(const string &alias, vector<LogicalType> types, vector<string> names,
+	             vector<ColumnIndex> &bound_column_ids, optional_ptr<StandardEntry> entry, idx_t index,
+	             virtual_column_map_t virtual_columns);
+
+	//! A reference to the set of bound column ids
+	vector<ColumnIndex> &bound_column_ids;
+	//! The underlying catalog entry (if any)
+	optional_ptr<StandardEntry> entry;
+	//! Virtual columns
+	virtual_column_map_t virtual_columns;
+
+public:
+	unique_ptr<ParsedExpression> ExpandGeneratedColumn(const string &column_name);
+	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override;
+	optional_ptr<StandardEntry> GetStandardEntry() override;
+	ErrorData ColumnNotFoundError(const string &column_name) const override;
+	// These are columns that are present in the name_map, appearing in the order that they're bound
+	const vector<ColumnIndex> &GetBoundColumnIds() const;
+
+protected:
+	ColumnBinding GetColumnBinding(column_t column_index);
+};
+
+//! DummyBinding is like the Binding, except the alias and index are set by default.
+//! Used for binding lambdas and macro parameters.
+struct DummyBinding : public Binding {
+public:
+	static constexpr const BindingType TYPE = BindingType::DUMMY;
+	// NOTE: changing this string conflicts with the storage version
+	static constexpr const char *DUMMY_NAME = "0_macro_parameters";
+
+public:
+	DummyBinding(vector<LogicalType> types, vector<string> names, string dummy_name);
+
+	//! Arguments (for macros)
+	vector<unique_ptr<ParsedExpression>> *arguments;
+	//! The name of the dummy binding
+	string dummy_name;
+
+public:
+	//! Binding macros
+	BindResult Bind(ColumnRefExpression &col_ref, idx_t depth) override;
+	//! Binding lambdas
+	BindResult Bind(LambdaRefExpression &lambda_ref, idx_t depth);
+
+	//! Returns a copy of the col_ref parameter as a parsed expression
+	unique_ptr<ParsedExpression> ParamToArg(ColumnRefExpression &col_ref);
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class Binder;
+class LogicalGet;
+class BoundQueryNode;
+
+class StarExpression;
+
+class TableCatalogEntry;
+class TableFunctionCatalogEntry;
+
+struct UsingColumnSet {
+	BindingAlias primary_binding;
+	vector<BindingAlias> bindings;
+};
+
+enum class ColumnBindType { EXPAND_GENERATED_COLUMNS, DO_NOT_EXPAND_GENERATED_COLUMNS };
+
+//! The BindContext object keeps track of all the tables and columns that are
+//! encountered during the binding process.
+class BindContext {
+public:
+	explicit BindContext(Binder &binder);
+
+	//! Keep track of recursive CTE references
+	case_insensitive_map_t<shared_ptr<idx_t>> cte_references;
+
+public:
+	//! Given a column name, find the matching table it belongs to. Throws an
+	//! exception if no table has a column of the given name.
+	optional_ptr<Binding> GetMatchingBinding(const string &column_name);
+	//! Like GetMatchingBinding, but instead of throwing an error if multiple tables have the same binding it will
+	//! return a list of all the matching ones
+	vector<reference<Binding>> GetMatchingBindings(const string &column_name);
+	//! Like GetMatchingBindings, but returns the top 3 most similar bindings (in levenshtein distance) instead of the
+	//! matching ones
+	vector<string> GetSimilarBindings(const string &column_name);
+
+	optional_ptr<Binding> GetCTEBinding(const string &ctename);
+	//! Binds a column expression to the base table. Returns the bound expression
+	//! or throws an exception if the column could not be bound.
+	BindResult BindColumn(ColumnRefExpression &colref, idx_t depth);
+	string BindColumn(PositionalReferenceExpression &ref, string &table_name, string &column_name);
+	unique_ptr<ColumnRefExpression> PositionToColumn(PositionalReferenceExpression &ref);
+
+	unique_ptr<ParsedExpression> ExpandGeneratedColumn(TableBinding &table_binding, const string &column_name);
+
+	unique_ptr<ParsedExpression>
+	CreateColumnReference(const string &table_name, const string &column_name,
+	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
+	unique_ptr<ParsedExpression>
+	CreateColumnReference(const string &schema_name, const string &table_name, const string &column_name,
+	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
+	unique_ptr<ParsedExpression>
+	CreateColumnReference(const string &catalog_name, const string &schema_name, const string &table_name,
+	                      const string &column_name,
+	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
+	unique_ptr<ParsedExpression>
+	CreateColumnReference(const BindingAlias &table_alias, const string &column_name,
+	                      ColumnBindType bind_type = ColumnBindType::EXPAND_GENERATED_COLUMNS);
+
+	//! Generate column expressions for all columns that are present in the
+	//! referenced tables. This is used to resolve the * expression in a
+	//! selection list.
+	void GenerateAllColumnExpressions(StarExpression &expr, vector<unique_ptr<ParsedExpression>> &new_select_list);
+
+	const vector<unique_ptr<Binding>> &GetBindingsList() {
+		return bindings_list;
+	}
+	vector<BindingAlias> GetBindingAliases();
+
+	void GetTypesAndNames(vector<string> &result_names, vector<LogicalType> &result_types);
+
+	//! Adds a base table with the given alias to the BindContext.
+	void AddBaseTable(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
+	                  vector<ColumnIndex> &bound_column_ids, TableCatalogEntry &entry, bool add_row_id = true);
+	void AddBaseTable(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
+	                  vector<ColumnIndex> &bound_column_ids, const string &table_name);
+	//! Adds a call to a table function with the given alias to the BindContext.
+	void AddTableFunction(idx_t index, const string &alias, const vector<string> &names,
+	                      const vector<LogicalType> &types, vector<ColumnIndex> &bound_column_ids,
+	                      optional_ptr<StandardEntry> entry, virtual_column_map_t virtual_columns);
+	//! Adds a table view with a given alias to the BindContext.
+	void AddView(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery, ViewCatalogEntry &view);
+	//! Adds a subquery with a given alias to the BindContext.
+	void AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery);
+	//! Adds a subquery with a given alias to the BindContext.
+	void AddSubquery(idx_t index, const string &alias, TableFunctionRef &ref, BoundQueryNode &subquery);
+	//! Adds a binding to a catalog entry with a given alias to the BindContext.
+	void AddEntryBinding(idx_t index, const string &alias, const vector<string> &names,
+	                     const vector<LogicalType> &types, StandardEntry &entry);
+	//! Adds a base table with the given alias to the BindContext.
+	void AddGenericBinding(idx_t index, const string &alias, const vector<string> &names,
+	                       const vector<LogicalType> &types);
+
+	//! Adds a base table with the given alias to the CTE BindContext.
+	//! We need this to correctly bind recursive CTEs with multiple references.
+	void AddCTEBinding(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
+	                   bool using_key = false);
+
+	//! Add an implicit join condition (e.g. USING (x))
+	void AddUsingBinding(const string &column_name, UsingColumnSet &set);
+
+	void AddUsingBindingSet(unique_ptr<UsingColumnSet> set);
+
+	//! Returns any using column set for the given column name, or nullptr if there is none. On conflict (multiple using
+	//! column sets with the same name) throw an exception.
+	optional_ptr<UsingColumnSet> GetUsingBinding(const string &column_name);
+	//! Returns any using column set for the given column name, or nullptr if there is none
+	optional_ptr<UsingColumnSet> GetUsingBinding(const string &column_name, const BindingAlias &binding);
+	//! Erase a using binding from the set of using bindings
+	void RemoveUsingBinding(const string &column_name, UsingColumnSet &set);
+	//! Transfer a using binding from one bind context to this bind context
+	void TransferUsingBinding(BindContext &current_context, optional_ptr<UsingColumnSet> current_set,
+	                          UsingColumnSet &new_set, const string &using_column);
+
+	//! Fetch the actual column name from the given binding, or throws if none exists
+	//! This can be different from "column_name" because of case insensitivity
+	//! (e.g. "column_name" might return "COLUMN_NAME")
+	string GetActualColumnName(const BindingAlias &binding_alias, const string &column_name);
+	string GetActualColumnName(Binding &binding, const string &column_name);
+
+	case_insensitive_map_t<shared_ptr<Binding>> GetCTEBindings() {
+		return cte_bindings;
+	}
+	void SetCTEBindings(case_insensitive_map_t<shared_ptr<Binding>> bindings) {
+		cte_bindings = std::move(bindings);
+	}
+
+	//! Alias a set of column names for the specified table, using the original names if there are not enough aliases
+	//! specified.
+	static vector<string> AliasColumnNames(const string &table_name, const vector<string> &names,
+	                                       const vector<string> &column_aliases);
+
+	//! Add all the bindings from a BindContext to this BindContext. The other BindContext is destroyed in the process.
+	void AddContext(BindContext other);
+	//! For semi and anti joins we remove the binding context of the right table after binding the condition.
+	void RemoveContext(const vector<BindingAlias> &aliases);
+
+	//! Gets a binding of the specified name. Returns a nullptr and sets the out_error if the binding could not be
+	//! found.
+	optional_ptr<Binding> GetBinding(const string &name, ErrorData &out_error);
+
+	optional_ptr<Binding> GetBinding(const BindingAlias &alias, ErrorData &out_error);
+
+	optional_ptr<Binding> GetBinding(const BindingAlias &alias, const string &column_name, ErrorData &out_error);
+
+	//! Get all bindings that match a specific binding alias - returns an error if none match
+	vector<reference<Binding>> GetBindings(const BindingAlias &alias, ErrorData &out_error);
+
+private:
+	void AddBinding(unique_ptr<Binding> binding);
+	static string AmbiguityException(const BindingAlias &alias, const vector<reference<Binding>> &bindings);
+
+private:
+	Binder &binder;
+	//! The list of bindings in insertion order
+	vector<unique_ptr<Binding>> bindings_list;
+	//! The set of columns used in USING join conditions
+	case_insensitive_map_t<reference_set_t<UsingColumnSet>> using_columns;
+	//! Using column sets
+	vector<unique_ptr<UsingColumnSet>> using_column_sets;
+
+	//! The set of CTE bindings
+	case_insensitive_map_t<shared_ptr<Binding>> cte_bindings;
+};
+} // namespace duckdb
 
 
 
@@ -31509,6 +32626,73 @@ public:
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<Expression> Deserialize(Deserializer &deserializer);
+};
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/expression/star_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+enum class StarExpressionType : uint8_t { STAR, COLUMNS, UNPACKED, NONE };
+
+//! Represents a * expression in the SELECT clause
+class StarExpression : public ParsedExpression {
+public:
+	static constexpr const ExpressionClass TYPE = ExpressionClass::STAR;
+
+public:
+	explicit StarExpression(string relation_name = string());
+
+	//! The relation name in case of tbl.*, or empty if this is a normal *
+	string relation_name;
+	//! List of columns to exclude from the STAR expression
+	qualified_column_set_t exclude_list;
+	//! List of columns to replace with another expression
+	case_insensitive_map_t<unique_ptr<ParsedExpression>> replace_list;
+	//! List of columns to rename
+	qualified_column_map_t<string> rename_list;
+	//! The expression to select the columns (regular expression or list)
+	unique_ptr<ParsedExpression> expr;
+	//! Whether or not this is a COLUMNS expression
+	bool columns = false;
+
+public:
+	string ToString() const override;
+
+	static bool Equal(const StarExpression &a, const StarExpression &b);
+	static bool IsStar(const ParsedExpression &a);
+	static bool IsColumns(const ParsedExpression &a);
+	static bool IsColumnsUnpacked(const ParsedExpression &a);
+
+	unique_ptr<ParsedExpression> Copy() const override;
+
+	static unique_ptr<ParsedExpression>
+	DeserializeStarExpression(string &&relation_name, const case_insensitive_set_t &exclude_list,
+	                          case_insensitive_map_t<unique_ptr<ParsedExpression>> &&replace_list, bool columns,
+	                          unique_ptr<ParsedExpression> expr, bool unpacked,
+	                          const qualified_column_set_t &qualified_exclude_list,
+	                          qualified_column_map_t<string> &&rename_list);
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<ParsedExpression> Deserialize(Deserializer &deserializer);
+
+public:
+	// these methods exist for backwards compatibility of (de)serialization
+	StarExpression(const case_insensitive_set_t &exclude_list, qualified_column_set_t qualified_set);
+
+	case_insensitive_set_t SerializedExcludeList() const;
+	qualified_column_set_t SerializedQualifiedExcludeList() const;
 };
 } // namespace duckdb
 
@@ -31631,6 +32815,11 @@ public:
 } // namespace duckdb
 
 
+//! fwd declare
+namespace duckdb_re2 {
+class RE2;
+} // namespace duckdb_re2
+
 namespace duckdb {
 class BoundResultModifier;
 class BoundSelectNode;
@@ -31650,6 +32839,8 @@ class ExternalDependency;
 class TableFunction;
 class TableStorageInfo;
 class BoundConstraint;
+class AtClause;
+class BoundAtClause;
 
 struct CreateInfo;
 struct BoundCreateTableInfo;
@@ -31657,10 +32848,16 @@ struct CommonTableExpressionInfo;
 struct BoundParameterMap;
 struct BoundPragmaInfo;
 struct BoundLimitNode;
+struct EntryLookupInfo;
 struct PivotColumnEntry;
 struct UnpivotEntry;
 
-enum class BindingMode : uint8_t { STANDARD_BINDING, EXTRACT_NAMES, EXTRACT_REPLACEMENT_SCANS };
+enum class BindingMode : uint8_t {
+	STANDARD_BINDING,
+	EXTRACT_NAMES,
+	EXTRACT_REPLACEMENT_SCANS,
+	EXTRACT_QUALIFIED_NAMES
+};
 enum class BinderType : uint8_t { REGULAR_BINDER, VIEW_BINDER };
 
 struct CorrelatedColumnInfo {
@@ -31760,9 +32957,8 @@ public:
 	//! Generates an unused index for a table
 	idx_t GenerateTableIndex();
 
-	optional_ptr<CatalogEntry> GetCatalogEntry(CatalogType type, const string &catalog, const string &schema,
-	                                           const string &name, OnEntryNotFound on_entry_not_found,
-	                                           QueryErrorContext &error_context);
+	optional_ptr<CatalogEntry> GetCatalogEntry(const string &catalog, const string &schema,
+	                                           const EntryLookupInfo &lookup_info, OnEntryNotFound on_entry_not_found);
 
 	//! Add a common table expression to the binder
 	void AddCTE(const string &name, CommonTableExpressionInfo &cte);
@@ -31824,6 +33020,11 @@ public:
 	void SetAlwaysRequireRebind();
 
 	StatementProperties &GetStatementProperties();
+	static void ReplaceStarExpression(unique_ptr<ParsedExpression> &expr, unique_ptr<ParsedExpression> &replacement);
+	static string ReplaceColumnsAlias(const string &alias, const string &column_name,
+	                                  optional_ptr<duckdb_re2::RE2> regex);
+
+	unique_ptr<LogicalOperator> UnionOperators(vector<unique_ptr<LogicalOperator>> nodes);
 
 private:
 	//! The parent binder (if any)
@@ -31844,7 +33045,7 @@ private:
 	optional_ptr<SQLStatement> root_statement;
 	//! Binding mode
 	BindingMode mode = BindingMode::STANDARD_BINDING;
-	//! Table names extracted for BindingMode::EXTRACT_NAMES
+	//! Table names extracted for BindingMode::EXTRACT_NAMES or BindingMode::EXTRACT_QUALIFIED_NAMES.
 	unordered_set<string> table_names;
 	//! Replacement Scans extracted for BindingMode::EXTRACT_REPLACEMENT_SCANS
 	case_insensitive_map_t<unique_ptr<TableRef>> replacement_scans;
@@ -31907,6 +33108,7 @@ private:
 	BoundStatement Bind(CopyDatabaseStatement &stmt);
 	BoundStatement Bind(UpdateExtensionsStatement &stmt);
 
+	void BindRowIdColumns(TableCatalogEntry &table, LogicalGet &get, vector<unique_ptr<Expression>> &expressions);
 	BoundStatement BindReturning(vector<unique_ptr<ParsedExpression>> returning_list, TableCatalogEntry &table,
 	                             const string &alias, idx_t update_table_index,
 	                             unique_ptr<LogicalOperator> child_operator, BoundStatement result);
@@ -31951,6 +33153,8 @@ private:
 	unique_ptr<BoundTableRef> BindBoundPivot(PivotRef &expr);
 	void ExtractUnpivotEntries(Binder &child_binder, PivotColumnEntry &entry, vector<UnpivotEntry> &unpivot_entries);
 	void ExtractUnpivotColumnName(ParsedExpression &expr, vector<string> &result);
+
+	unique_ptr<BoundAtClause> BindAtClause(optional_ptr<AtClause> at_clause);
 
 	bool BindTableFunctionParameters(TableFunctionCatalogEntry &table_function,
 	                                 vector<unique_ptr<ParsedExpression>> &expressions, vector<LogicalType> &arguments,
@@ -32012,14 +33216,16 @@ private:
 	void ExpandStarExpressions(vector<unique_ptr<ParsedExpression>> &select_list,
 	                           vector<unique_ptr<ParsedExpression>> &new_select_list);
 	void ExpandStarExpression(unique_ptr<ParsedExpression> expr, vector<unique_ptr<ParsedExpression>> &new_select_list);
-	bool FindStarExpression(unique_ptr<ParsedExpression> &expr, StarExpression **star, bool is_root, bool in_columns);
+	StarExpressionType FindStarExpression(unique_ptr<ParsedExpression> &expr, StarExpression **star, bool is_root,
+	                                      bool in_columns);
 	void ReplaceUnpackedStarExpression(unique_ptr<ParsedExpression> &expr,
-	                                   vector<unique_ptr<ParsedExpression>> &replacements);
-	void ReplaceStarExpression(unique_ptr<ParsedExpression> &expr, unique_ptr<ParsedExpression> &replacement);
+	                                   vector<unique_ptr<ParsedExpression>> &replacements, StarExpression &star,
+	                                   optional_ptr<duckdb_re2::RE2> regex);
 	void BindWhereStarExpression(unique_ptr<ParsedExpression> &expr);
 
 	//! If only a schema name is provided (e.g. "a.b") then figure out if "a" is a schema or a catalog name
 	void BindSchemaOrCatalog(string &catalog_name, string &schema_name);
+	static void BindSchemaOrCatalog(CatalogEntryRetriever &retriever, string &catalog, string &schema);
 	const string BindCatalog(string &catalog_name);
 	SchemaCatalogEntry &BindCreateSchema(CreateInfo &info);
 
@@ -32035,8 +33241,6 @@ private:
 	unique_ptr<BoundTableRef> BindShowQuery(ShowRef &ref);
 	unique_ptr<BoundTableRef> BindShowTable(ShowRef &ref);
 	unique_ptr<BoundTableRef> BindSummarize(ShowRef &ref);
-
-	unique_ptr<LogicalOperator> UnionOperators(vector<unique_ptr<LogicalOperator>> nodes);
 
 private:
 	Binder(ClientContext &context, shared_ptr<Binder> parent, BinderType binder_type);
@@ -32145,8 +33349,9 @@ class Deserializer;
 
 class Block : public FileBuffer {
 public:
-	Block(Allocator &allocator, const block_id_t id, const idx_t block_size);
-	Block(Allocator &allocator, block_id_t id, uint32_t internal_size);
+	Block(Allocator &allocator, const block_id_t id, const idx_t block_size, const idx_t block_header_size);
+	Block(Allocator &allocator, block_id_t id, uint32_t internal_size, idx_t block_header_size);
+	Block(Allocator &allocator, const block_id_t id, BlockManager &block_manager);
 	Block(FileBuffer &source, block_id_t id);
 
 	block_id_t id;
@@ -32722,6 +33927,7 @@ struct PersistentRowGroupData;
 struct RowGroupPointer;
 struct TransactionData;
 class CollectionScanState;
+class TableFilter;
 class TableFilterSet;
 struct ColumnFetchState;
 struct RowGroupAppendState;
@@ -32782,7 +33988,7 @@ public:
 	unique_ptr<RowGroup> RemoveColumn(RowGroupCollection &collection, idx_t removed_column);
 
 	void CommitDrop();
-	void CommitDropColumn(idx_t index);
+	void CommitDropColumn(const idx_t column_index);
 
 	void InitializeEmpty(const vector<LogicalType> &types);
 
@@ -32862,6 +34068,8 @@ public:
 	static RowGroupPointer Deserialize(Deserializer &deserializer);
 
 	idx_t GetRowGroupSize() const;
+
+	static FilterPropagateResult CheckRowIdFilter(const TableFilter &filter, idx_t beg_row, idx_t end_row);
 
 private:
 	optional_ptr<RowVersionManager> GetVersionInfo();
@@ -32960,51 +34168,75 @@ namespace duckdb {
 
 struct DBConfig;
 
+class EncodingFunction;
+
+struct CSVEncoderBuffer;
 //! Decode function, basically takes information about the decoded and the encoded buffers.
-typedef void (*encode_t)(const char *encoded_buffer, idx_t &encoded_buffer_current_position,
-                         const idx_t encoded_buffer_size, char *decoded_buffer, idx_t &decoded_buffer_current_position,
-                         const idx_t decoded_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size);
+typedef void (*encode_t)(CSVEncoderBuffer &encoded_buffer, char *decoded_buffer, idx_t &decoded_buffer_current_position,
+                         const idx_t decoded_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size,
+                         EncodingFunction *encoding_function);
+
+//! Encoding Map Entry Struct used for byte replacement
+typedef struct {
+	size_t key_len;
+	const char *key;
+	size_t value_len;
+	const char *value;
+} map_entry_encoding;
 
 class EncodingFunction {
 public:
-	EncodingFunction() : encode_function(nullptr), ratio(0), bytes_per_iteration(0) {
+	DUCKDB_API EncodingFunction() : encode_function(nullptr), max_bytes_per_iteration(0) {
 	}
 
-	EncodingFunction(const string &encode_type, encode_t encode_function, const idx_t ratio,
-	                 const idx_t bytes_per_iteration)
-	    : encoding_type(encode_type), encode_function(encode_function), ratio(ratio),
-	      bytes_per_iteration(bytes_per_iteration) {
-		D_ASSERT(ratio > 0);
+	DUCKDB_API EncodingFunction(const string &encode_name, encode_t encode_function, const idx_t bytes_per_iteration,
+	                            const idx_t lookup_bytes)
+	    : name(encode_name), encode_function(encode_function), max_bytes_per_iteration(bytes_per_iteration),
+	      lookup_bytes(lookup_bytes) {
 		D_ASSERT(encode_function);
 		D_ASSERT(bytes_per_iteration > 0);
+		D_ASSERT(lookup_bytes > 0);
 	};
 
-	~EncodingFunction() {};
+	DUCKDB_API EncodingFunction(const string &encode_name, encode_t encode_function, const idx_t bytes_per_iteration,
+	                            const idx_t lookup_bytes, const map_entry_encoding *map, const size_t map_size)
+	    : conversion_map(map), map_size(map_size), name(encode_name), encode_function(encode_function),
+	      max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
+		D_ASSERT(encode_function);
+		D_ASSERT(bytes_per_iteration > 0);
+		D_ASSERT(lookup_bytes > 0);
+	};
 
-	string GetType() const {
-		return encoding_type;
+	DUCKDB_API ~EncodingFunction() {};
+
+	DUCKDB_API string GetName() const {
+		return name;
 	}
-	encode_t GetFunction() const {
+	DUCKDB_API encode_t GetFunction() const {
 		return encode_function;
 	}
-	idx_t GetRatio() const {
-		return ratio;
+	DUCKDB_API idx_t GetBytesPerIteration() const {
+		return max_bytes_per_iteration;
 	}
-	idx_t GetBytesPerIteration() const {
-		return bytes_per_iteration;
+	DUCKDB_API idx_t GetLookupBytes() const {
+		return lookup_bytes;
 	}
 
-private:
+	//! Optional convertion map, that indicates byte replacements.
+	const map_entry_encoding *conversion_map {};
+	size_t map_size {};
+
+protected:
 	//! The encoding type of this function (e.g., utf-8)
-	string encoding_type;
+	string name;
 	//! The actual encoding function
 	encode_t encode_function;
-	//! Ratio of the max size this encoded buffer could ever reach on a decoded buffer
-	idx_t ratio;
 	//! How many bytes in the decoded buffer one iteration of the encoded function can cause.
 	//! e.g., one iteration of Latin-1 to UTF-8 can generate max 2 bytes.
 	//! However, one iteration of UTF-16 to UTF-8, can generate up to 3 UTF-8 bytes.
-	idx_t bytes_per_iteration;
+	idx_t max_bytes_per_iteration;
+	//! How many bytes we have to lookup before knowing the bytes we have to output
+	idx_t lookup_bytes = 1;
 };
 
 //! The set of encoding functions
@@ -33107,9 +34339,10 @@ struct LoggingContext {
 
 	LogContextScope scope;
 
-	optional_idx thread;
-	optional_idx client_context;
+	optional_idx thread_id;
+	optional_idx connection_id;
 	optional_idx transaction_id;
+	optional_idx query_id;
 };
 
 struct RegisteredLoggingContext {
@@ -33119,10 +34352,117 @@ struct RegisteredLoggingContext {
 
 } // namespace duckdb
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/logging/log_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
 
 
 
-#include <functional>
+
+
+
+namespace duckdb {
+
+struct FileHandle;
+struct BaseRequest;
+struct HTTPResponse;
+class PhysicalOperator;
+
+//! Log types provide some structure to the formats that the different log messages can have
+//! For now, this holds a type that the VARCHAR value will be auto-cast into.
+class LogType {
+public:
+	//! Construct an unstructured type
+	LogType(const string &name_p, const LogLevel &level_p)
+	    : name(name_p), level(level_p), is_structured(false), type(LogicalType::VARCHAR) {
+	}
+	//! Construct a structured type
+	LogType(const string &name_p, const LogLevel &level_p, LogicalType structured_type)
+	    : name(name_p), level(level_p), is_structured(true), type(std::move(structured_type)) {
+	}
+
+	string name;
+	LogLevel level;
+
+	bool is_structured;
+	LogicalType type;
+};
+
+class DefaultLogType : public LogType {
+public:
+	static constexpr const char *NAME = "";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	DefaultLogType() : LogType(NAME, LEVEL) {
+	}
+};
+
+class QueryLogType : public LogType {
+public:
+	static constexpr const char *NAME = "QueryLog";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	QueryLogType() : LogType(NAME, LEVEL) {};
+
+	static string ConstructLogMessage(const string &str) {
+		return str;
+	}
+};
+
+class FileSystemLogType : public LogType {
+public:
+	static constexpr const char *NAME = "FileSystem";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_TRACE;
+
+	//! Construct the log type
+	FileSystemLogType();
+
+	static LogicalType GetLogType();
+
+	static string ConstructLogMessage(const FileHandle &handle, const string &op, int64_t bytes, idx_t pos);
+	static string ConstructLogMessage(const FileHandle &handle, const string &op);
+};
+
+class HTTPLogType : public LogType {
+public:
+	static constexpr const char *NAME = "HTTP";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG;
+
+	//! Construct the log types
+	HTTPLogType();
+
+	static LogicalType GetLogType();
+
+	static string ConstructLogMessage(BaseRequest &request, optional_ptr<HTTPResponse> response);
+
+	// FIXME: HTTPLogType should be structured probably
+	static string ConstructLogMessage(const string &str) {
+		return str;
+	}
+};
+
+class PhysicalOperatorLogType : public LogType {
+public:
+	static constexpr const char *NAME = "PhysicalOperator";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG;
+
+	//! Construct the log type
+	PhysicalOperatorLogType();
+
+	static LogicalType GetLogType();
+
+	static string ConstructLogMessage(const PhysicalOperator &op, const string &class_p, const string &event,
+	                                  const vector<pair<string, string>> &info);
+};
+
+} // namespace duckdb
+
+
+
 
 namespace duckdb {
 class TableDescription;
@@ -33134,34 +34474,33 @@ class ThreadContext;
 class FileOpener;
 class LogStorage;
 class ExecutionContext;
+struct FileHandle;
 
-//! Logger Macro's are preferred method of calling logger
-#define DUCKDB_LOG(SOURCE, TYPE, LEVEL, ...)                                                                           \
+//! Internal
+#define DUCKDB_LOG_INTERNAL(SOURCE, TYPE, LEVEL, ...)                                                                  \
 	{                                                                                                                  \
-		auto &logger = Logger::Get(SOURCE);                                                                            \
-		if (logger.ShouldLog(TYPE, LEVEL)) {                                                                           \
-			logger.WriteLog(TYPE, LEVEL, __VA_ARGS__);                                                                 \
+		auto &logger_ref_ = Logger::Get(SOURCE);                                                                       \
+		if (logger_ref_.ShouldLog(TYPE, LEVEL)) {                                                                      \
+			logger_ref_.WriteLog(TYPE, LEVEL, __VA_ARGS__);                                                            \
 		}                                                                                                              \
 	}
 
-//! Use below macros to write to logger.
-// Parameters:
-//		SOURCE: the context to fetch the logger from, e.g. the ClientContext, or the DatabaseInstance, see Logger::Get
-//		TYPE  : a string describing the type of this log entry. Preferred format: `<duckdb/extension name>(.<sometype>)
-//				e.g. `duckdb.Extensions.ExtensionAutoloaded`, `my_extension` or `my_extension.some_type`
-//		PARAMS: Either a string-like type such as `const char *`, `string` or `string_t` or a format string plus the
-// 			string parameters
-//
-// Examples:
-//		DUCKDB_LOG_TRACE(client_context, "duckdb", "Something happened");
-//		DUCKDB_LOG_INFO(database_instance, "duckdb", CallFunctionThatReturnsString());
-//
-#define DUCKDB_LOG_TRACE(SOURCE, TYPE, ...) DUCKDB_LOG(SOURCE, TYPE, LogLevel::LOG_TRACE, __VA_ARGS__)
-#define DUCKDB_LOG_DEBUG(SOURCE, TYPE, ...) DUCKDB_LOG(SOURCE, TYPE, LogLevel::LOG_DEBUG, __VA_ARGS__)
-#define DUCKDB_LOG_INFO(SOURCE, TYPE, ...)  DUCKDB_LOG(SOURCE, TYPE, LogLevel::LOG_INFO, __VA_ARGS__)
-#define DUCKDB_LOG_WARN(SOURCE, TYPE, ...)  DUCKDB_LOG(SOURCE, TYPE, LogLevel::LOG_WARN, __VA_ARGS__)
-#define DUCKDB_LOG_ERROR(SOURCE, TYPE, ...) DUCKDB_LOG(SOURCE, TYPE, LogLevel::LOG_ERROR, __VA_ARGS__)
-#define DUCKDB_LOG_FATAL(SOURCE, TYPE, ...) DUCKDB_LOG(SOURCE, TYPE, LogLevel::LOG_FATAL, __VA_ARGS__)
+//! Default Loggers
+#define DUCKDB_LOG_TRACE(SOURCE, ...)                                                                                  \
+	DUCKDB_LOG_INTERNAL(SOURCE, DefaultLogType::NAME, LogLevel::LOG_TRACE, __VA_ARGS__)
+#define DUCKDB_LOG_DEBUG(SOURCE, ...)                                                                                  \
+	DUCKDB_LOG_INTERNAL(SOURCE, DefaultLogType::NAME, LogLevel::LOG_DEBUG, __VA_ARGS__)
+#define DUCKDB_LOG_INFO(SOURCE, ...) DUCKDB_LOG_INTERNAL(SOURCE, DefaultLogType::NAME, LogLevel::LOG_INFO, __VA_ARGS__)
+#define DUCKDB_LOG_WARN(SOURCE, ...) DUCKDB_LOG_INTERNAL(SOURCE, DefaultLogType::NAME, LogLevel::LOG_WARN, __VA_ARGS__)
+#define DUCKDB_LOG_ERROR(SOURCE, ...)                                                                                  \
+	DUCKDB_LOG_INTERNAL(SOURCE, DefaultLogType::NAME, LogLevel::LOG_ERROR, __VA_ARGS__)
+#define DUCKDB_LOG_FATAL(SOURCE, ...)                                                                                  \
+	DUCKDB_LOG_INTERNAL(SOURCE, DefaultLogType::NAME, LogLevel::LOG_FATAL, __VA_ARGS__)
+
+//! LogType based loggers
+#define DUCKDB_LOG(SOURCE, LOG_TYPE_CLASS, ...)                                                                        \
+	DUCKDB_LOG_INTERNAL(SOURCE, LOG_TYPE_CLASS::NAME, LOG_TYPE_CLASS::LEVEL,                                           \
+	                    LOG_TYPE_CLASS::ConstructLogMessage(__VA_ARGS__))
 
 //! Main logging interface
 class Logger {
@@ -33196,6 +34535,7 @@ public:
 	DUCKDB_API static Logger &Get(const ClientContext &client_context);
 	DUCKDB_API static Logger &Get(const FileOpener &opener);
 	DUCKDB_API static Logger &Get(const DatabaseInstance &db);
+	DUCKDB_API static Logger &Get(const shared_ptr<Logger> &logger);
 
 	template <class T>
 	static void Flush(T &log_context_source) {
@@ -33321,6 +34661,7 @@ public:
 
 
 namespace duckdb {
+class LogType;
 
 // Holds global logging state
 // - Handles configuration changes
@@ -33347,6 +34688,7 @@ public:
 
 	//! The global logger can be used whe
 	DUCKDB_API Logger &GlobalLogger();
+	DUCKDB_API shared_ptr<Logger> GlobalLoggerReference();
 
 	//! Flush everything
 	DUCKDB_API void Flush();
@@ -33362,7 +34704,15 @@ public:
 	DUCKDB_API void SetDisabledLogTypes(unordered_set<string> &disabled_log_types);
 	DUCKDB_API void SetLogStorage(DatabaseInstance &db, const string &storage_name);
 
+	DUCKDB_API void SetEnableStructuredLoggers(vector<string> &enabled_logger_types);
+
+	DUCKDB_API void TruncateLogStorage();
+
 	DUCKDB_API LogConfig GetConfig();
+
+	DUCKDB_API void RegisterLogType(unique_ptr<LogType> type);
+	DUCKDB_API optional_ptr<const LogType> LookupLogType(const string &type);
+	DUCKDB_API void RegisterDefaultLogTypes();
 
 protected:
 	RegisteredLoggingContext RegisterLoggingContextInternal(LoggingContext &context);
@@ -33373,10 +34723,12 @@ protected:
 	// This allows efficiently pushing a cached set of log entries into the log manager
 	void FlushCachedLogEntries(DataChunk &chunk, const RegisteredLoggingContext &context);
 
+	optional_ptr<const LogType> LookupLogTypeInternal(const string &type);
+
 	mutex lock;
 	LogConfig config;
 
-	unique_ptr<Logger> global_logger;
+	shared_ptr<Logger> global_logger;
 
 	shared_ptr<LogStorage> log_storage;
 
@@ -33384,9 +34736,36 @@ protected:
 
 	// Any additional LogStorages registered (by extensions for example)
 	case_insensitive_map_t<shared_ptr<LogStorage>> registered_log_storages;
+	case_insensitive_map_t<unique_ptr<LogType>> registered_log_types;
 };
 
 } // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/debug_vector_verification.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+enum class DebugVectorVerification : uint8_t {
+	NONE,
+	DICTIONARY_EXPRESSION,
+	DICTIONARY_OPERATOR,
+	CONSTANT_OPERATOR,
+	SEQUENCE_OPERATOR,
+	NESTED_SHUFFLE
+};
+
+} // namespace duckdb
+
 
 
 namespace duckdb {
@@ -33405,6 +34784,7 @@ class ExtensionCallback;
 class SecretManager;
 class CompressionInfo;
 class EncryptionUtil;
+class HTTPUtil;
 
 struct CompressionFunctionSet;
 struct DatabaseCacheEntry;
@@ -33616,6 +34996,8 @@ struct DBConfigOptions {
 	bool old_implicit_casting = false;
 	//! The default block allocation size for new duckdb database files (new as-in, they do not yet exist).
 	idx_t default_block_alloc_size = DUCKDB_BLOCK_ALLOC_SIZE;
+	//! The default block header size for new duckdb database files.
+	idx_t default_block_header_size = DUCKDB_BLOCK_HEADER_STORAGE_SIZE;
 	//!  Whether or not to abort if a serialization exception is thrown during WAL playback (when reading truncated WAL)
 	bool abort_on_wal_failure = false;
 	//! The index_scan_percentage sets a threshold for index scans.
@@ -33630,6 +35012,8 @@ struct DBConfigOptions {
 	idx_t catalog_error_max_schemas = 100;
 	//!  Whether or not to always write to the WAL file, even if this is not required
 	bool debug_skip_checkpoint_on_commit = false;
+	//! Vector verification to enable (debug setting only)
+	DebugVectorVerification debug_verify_vector = DebugVectorVerification::NONE;
 	//! The maximum amount of vacuum tasks to schedule during a checkpoint
 	idx_t max_vacuum_tasks = 100;
 	//! Paths that are explicitly allowed, even if enable_external_access is false
@@ -33638,6 +35022,16 @@ struct DBConfigOptions {
 	set<string> allowed_directories;
 	//! The log configuration
 	LogConfig log_config = LogConfig();
+	//! Whether to enable external file caching using CachingFileSystem
+	bool enable_external_file_cache = true;
+	//! Output version of arrow depending on the format version
+	ArrowFormatVersion arrow_output_version = V1_0;
+	//! Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries
+#ifdef DUCKDB_ALTERNATIVE_VERIFY
+	bool scheduler_process_partial = true;
+#else
+	bool scheduler_process_partial = false;
+#endif
 
 	bool operator==(const DBConfigOptions &other) const;
 };
@@ -33687,6 +35081,8 @@ public:
 	vector<unique_ptr<ExtensionCallback>> extension_callbacks;
 	//! Encryption Util for OpenSSL
 	shared_ptr<EncryptionUtil> encryption_util;
+	//! HTTP Request utility functions
+	shared_ptr<HTTPUtil> http_util;
 	//! Reference to the database cache entry (if any)
 	shared_ptr<DatabaseCacheEntry> db_cache_entry;
 
@@ -33863,11 +35259,14 @@ class Transaction;
 //! The MetaTransaction manages multiple transactions for different attached databases
 class MetaTransaction {
 public:
-	DUCKDB_API MetaTransaction(ClientContext &context, timestamp_t start_timestamp);
+	DUCKDB_API MetaTransaction(ClientContext &context, timestamp_t start_timestamp,
+	                           transaction_t global_transaction_id);
 
 	ClientContext &context;
 	//! The timestamp when the transaction started
 	timestamp_t start_timestamp;
+	//! The global identifier of the transaction
+	transaction_t global_transaction_id;
 	//! The validity checker of the transaction
 	ValidChecker transaction_validity;
 	//! The active query number
@@ -34028,6 +35427,10 @@ struct StorageOptions {
 	optional_idx row_group_size;
 	//! Target storage version (if any)
 	optional_idx storage_version;
+	//! Block header size (only used for encryption)
+	optional_idx block_header_size;
+	//! Whether the database is encrypted
+	bool encryption = false;
 };
 
 } // namespace duckdb
@@ -34091,11 +35494,12 @@ public:
 
 	//! Initializes the system catalog of the attached SYSTEM_DATABASE.
 	void InitializeSystemCatalog();
+	//! Finalize starting up the system
+	void FinalizeStartup();
 	//! Get an attached database by its name
 	optional_ptr<AttachedDatabase> GetDatabase(ClientContext &context, const string &name);
 	//! Attach a new database
-	optional_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, const AttachInfo &info,
-	                                              const AttachOptions &options);
+	optional_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, AttachInfo &info, AttachOptions &options);
 	//! Detach an existing database
 	void DetachDatabase(ClientContext &context, const string &name, OnEntryNotFound if_not_found);
 	//! Returns a reference to the system catalog
@@ -34115,7 +35519,10 @@ public:
 	void GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config, AttachOptions &options);
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
-	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context);
+	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context,
+	                                                 const optional_idx max_db_count = optional_idx());
+	//! Scans the catalog set and returns each committed database entry
+	vector<reference<AttachedDatabase>> GetDatabases();
 	//! Removes all databases from the catalog set. This is necessary for the database instance's destructor,
 	//! as the database manager has to be alive when destroying the catalog set objects.
 	void ResetDatabases(unique_ptr<TaskScheduler> &scheduler);
@@ -34125,6 +35532,12 @@ public:
 	}
 	transaction_t ActiveQueryNumber() const {
 		return current_query_number;
+	}
+	transaction_t GetNewTransactionNumber() {
+		return current_transaction_id++;
+	}
+	transaction_t ActiveTransactionNumber() const {
+		return current_transaction_id;
 	}
 	idx_t NextOid() {
 		return next_oid++;
@@ -34149,6 +35562,8 @@ private:
 	atomic<idx_t> next_oid;
 	//! The current query number
 	atomic<transaction_t> current_query_number;
+	//! The current transaction number
+	atomic<transaction_t> current_transaction_id;
 	//! The current default database
 	string default_database;
 
@@ -34527,6 +35942,28 @@ struct ArrowOutputListViewSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct ArrowOutputVersionSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "arrow_output_version";
+	static constexpr const char *Description =
+	    "Whether strings should be produced by DuckDB in Utf8View format instead of Utf8";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct AsofLoopJoinThresholdSetting {
+	using RETURN_TYPE = idx_t;
+	static constexpr const char *Name = "asof_loop_join_threshold";
+	static constexpr const char *Description =
+	    "The maximum number of rows we need on the left side of an ASOF join to use a nested loop join";
+	static constexpr const char *InputType = "UBIGINT";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct AutoinstallExtensionRepositorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "autoinstall_extension_repository";
@@ -34665,6 +36102,16 @@ struct DebugSkipCheckpointOnCommitSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct DebugVerifyVectorSetting {
+	using RETURN_TYPE = DebugVectorVerification;
+	static constexpr const char *Name = "debug_verify_vector";
+	static constexpr const char *Description = "DEBUG SETTING: enable vector verification";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct DebugWindowModeSetting {
 	using RETURN_TYPE = WindowAggregationMode;
 	static constexpr const char *Name = "debug_window_mode";
@@ -34725,6 +36172,16 @@ struct DefaultSecretStorageSetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct DisableTimestamptzCastsSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "disable_timestamptz_casts";
+	static constexpr const char *Description = "Disable casting from timestamp to timestamptz ";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
 };
 
@@ -34800,6 +36257,16 @@ struct EnableExternalAccessSetting {
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
 	static bool OnGlobalReset(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct EnableExternalFileCacheSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "enable_external_file_cache";
+	static constexpr const char *Description = "Allow the database to cache external files (e.g., Parquet) in memory.";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
 };
 
@@ -35097,6 +36564,17 @@ struct IntegerDivisionSetting {
 	static constexpr const char *Description =
 	    "Whether or not the / operator defaults to integer division, or to floating point division";
 	static constexpr const char *InputType = "BOOLEAN";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct LambdaSyntaxSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "lambda_syntax";
+	static constexpr const char *Description =
+	    "Configures the use of the deprecated single arrow operator (->) for lambda functions.";
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -35407,6 +36885,17 @@ struct ScalarSubqueryErrorOnMultipleRowsSetting {
 	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct SchedulerProcessPartialSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "scheduler_process_partial";
+	static constexpr const char *Description =
+	    "Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
 };
 
@@ -35926,7 +37415,7 @@ public:
 	//! Set of optional states (e.g. Caches) that can be held by the ClientContext
 	unique_ptr<RegisteredStateManager> registered_state;
 	//! The logger to be used by this ClientContext
-	unique_ptr<Logger> logger;
+	shared_ptr<Logger> logger;
 	//! The client configuration
 	ClientConfig config;
 	//! The set of client-specific data
@@ -36052,8 +37541,12 @@ public:
 	//! Returns the current query string (if any)
 	const string &GetCurrentQuery();
 
-	//! Fetch a list of table names that are required for a given query
-	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
+	connection_t GetConnectionId() const;
+
+	//! Fetch the set of tables names of the query.
+	//! Returns the fully qualified, escaped table names, if qualified is set to true,
+	//! else returns the not qualified, not escaped table names.
+	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 
 	DUCKDB_API ClientProperties GetClientProperties();
 
@@ -36150,6 +37643,8 @@ private:
 	unique_ptr<ActiveQueryContext> active_query;
 	//! The current query progress
 	QueryProgress query_progress;
+	//! The connection corresponding to this client context
+	connection_t connection_id;
 };
 
 class ClientContextLock {
@@ -36556,6 +38051,9 @@ public:
 	//! Interrupt execution of the current query
 	DUCKDB_API void Interrupt();
 
+	//! Get query progress of current query
+	DUCKDB_API double GetQueryProgress();
+
 	//! Enable query profiling
 	DUCKDB_API void EnableProfiling();
 	//! Disable query profiling
@@ -36629,6 +38127,8 @@ public:
 	//! Returns a relation that produces a table from this connection
 	DUCKDB_API shared_ptr<Relation> Table(const string &tname);
 	DUCKDB_API shared_ptr<Relation> Table(const string &schema_name, const string &table_name);
+	DUCKDB_API shared_ptr<Relation> Table(const string &catalog_name, const string &schema_name,
+	                                      const string &table_name);
 	//! Returns a relation that produces a view from this connection
 	DUCKDB_API shared_ptr<Relation> View(const string &tname);
 	DUCKDB_API shared_ptr<Relation> View(const string &schema_name, const string &table_name);
@@ -36667,8 +38167,10 @@ public:
 	DUCKDB_API bool IsAutoCommit();
 	DUCKDB_API bool HasActiveTransaction();
 
-	//! Fetch a list of table names that are required for a given query
-	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
+	//! Fetch the set of tables names of the query.
+	//! Returns the fully qualified, escaped table names, if qualified is set to true,
+	//! else returns the not qualified, not escaped table names.
+	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 
 	// NOLINTBEGIN
 	template <typename TR, typename... ARGS>
@@ -36737,6 +38239,10 @@ public:
 		UDFWrapper::RegisterAggrFunction(function, *context);
 	}
 	// NOLINTEND
+
+protected:
+	//! Identified used to uniquely identify connections to the database.
+	connection_t connection_id;
 
 private:
 	unique_ptr<QueryResult> QueryParamsRecursive(const string &query, vector<Value> &values);
@@ -37234,6 +38740,38 @@ typedef struct {
 
 	duckdb_state (*duckdb_append_default_to_chunk)(duckdb_appender appender, duckdb_data_chunk chunk, idx_t col,
 	                                               idx_t row);
+	// New functions around the client context
+
+	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);
+	void (*duckdb_destroy_client_context)(duckdb_client_context *context);
+	void (*duckdb_connection_get_client_context)(duckdb_connection connection, duckdb_client_context *out_context);
+	duckdb_value (*duckdb_get_table_names)(duckdb_connection connection, const char *query, bool qualified);
+	// New functions around scalar function binding
+
+	void (*duckdb_scalar_function_set_bind)(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
+	void (*duckdb_scalar_function_bind_set_error)(duckdb_bind_info info, const char *error);
+	void (*duckdb_scalar_function_get_client_context)(duckdb_bind_info info, duckdb_client_context *out_context);
+	void (*duckdb_scalar_function_set_bind_data)(duckdb_bind_info info, void *bind_data,
+	                                             duckdb_delete_callback_t destroy);
+	void *(*duckdb_scalar_function_get_bind_data)(duckdb_function_info info);
+	// New string functions that are added
+
+	char *(*duckdb_value_to_string)(duckdb_value value);
+	// New value functions that are added
+
+	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value *keys, duckdb_value *values,
+	                                        idx_t entry_count);
+	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, idx_t tag_index, duckdb_value value);
+	// An API to create new vector types
+
+	duckdb_vector (*duckdb_create_vector)(duckdb_logical_type type, idx_t capacity);
+	void (*duckdb_destroy_vector)(duckdb_vector *vector);
+	void (*duckdb_slice_vector)(duckdb_vector vector, duckdb_selection_vector selection, idx_t len);
+	void (*duckdb_vector_reference_value)(duckdb_vector vector, duckdb_value value);
+	void (*duckdb_vector_reference_vector)(duckdb_vector to_vector, duckdb_vector from_vector);
+	duckdb_selection_vector (*duckdb_create_selection_vector)(idx_t size);
+	void (*duckdb_destroy_selection_vector)(duckdb_selection_vector vector);
+	sel_t *(*duckdb_selection_vector_get_data_ptr)(duckdb_selection_vector vector);
 } duckdb_ext_api_v1;
 
 //===--------------------------------------------------------------------===//
@@ -37649,6 +39187,26 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_get_or_create_from_cache = duckdb_get_or_create_from_cache;
 	result.duckdb_destroy_instance_cache = duckdb_destroy_instance_cache;
 	result.duckdb_append_default_to_chunk = duckdb_append_default_to_chunk;
+	result.duckdb_client_context_get_connection_id = duckdb_client_context_get_connection_id;
+	result.duckdb_destroy_client_context = duckdb_destroy_client_context;
+	result.duckdb_connection_get_client_context = duckdb_connection_get_client_context;
+	result.duckdb_get_table_names = duckdb_get_table_names;
+	result.duckdb_scalar_function_set_bind = duckdb_scalar_function_set_bind;
+	result.duckdb_scalar_function_bind_set_error = duckdb_scalar_function_bind_set_error;
+	result.duckdb_scalar_function_get_client_context = duckdb_scalar_function_get_client_context;
+	result.duckdb_scalar_function_set_bind_data = duckdb_scalar_function_set_bind_data;
+	result.duckdb_scalar_function_get_bind_data = duckdb_scalar_function_get_bind_data;
+	result.duckdb_value_to_string = duckdb_value_to_string;
+	result.duckdb_create_map_value = duckdb_create_map_value;
+	result.duckdb_create_union_value = duckdb_create_union_value;
+	result.duckdb_create_vector = duckdb_create_vector;
+	result.duckdb_destroy_vector = duckdb_destroy_vector;
+	result.duckdb_slice_vector = duckdb_slice_vector;
+	result.duckdb_vector_reference_value = duckdb_vector_reference_value;
+	result.duckdb_vector_reference_vector = duckdb_vector_reference_vector;
+	result.duckdb_create_selection_vector = duckdb_create_selection_vector;
+	result.duckdb_destroy_selection_vector = duckdb_destroy_selection_vector;
+	result.duckdb_selection_vector_get_data_ptr = duckdb_selection_vector_get_data_ptr;
 	return result;
 }
 
@@ -37852,6 +39410,7 @@ struct AttachOptions;
 class DatabaseFileSystem;
 struct DatabaseCacheEntry;
 class LogManager;
+class ExternalFileCache;
 
 struct ExtensionInfo {
 	bool is_loaded;
@@ -37875,6 +39434,7 @@ public:
 	DUCKDB_API const BufferManager &GetBufferManager() const;
 	DUCKDB_API DatabaseManager &GetDatabaseManager();
 	DUCKDB_API FileSystem &GetFileSystem();
+	DUCKDB_API ExternalFileCache &GetExternalFileCache();
 	DUCKDB_API TaskScheduler &GetScheduler();
 	DUCKDB_API ObjectCache &GetObjectCache();
 	DUCKDB_API ConnectionManager &GetConnectionManager();
@@ -37894,8 +39454,8 @@ public:
 
 	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
 
-	unique_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, const AttachInfo &info,
-	                                                    const AttachOptions &options);
+	unique_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, AttachInfo &info,
+	                                                    AttachOptions &options);
 
 	void AddExtensionInfo(const string &name, const ExtensionLoadedInfo &info);
 
@@ -37916,6 +39476,7 @@ private:
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
 	shared_ptr<LogManager> log_manager;
+	unique_ptr<ExternalFileCache> external_file_cache;
 
 	duckdb_ext_api_v1 (*create_api_v1)();
 };
@@ -37963,6 +39524,7 @@ public:
 	DUCKDB_API idx_t NumberOfThreads();
 	DUCKDB_API static const char *SourceID();
 	DUCKDB_API static const char *LibraryVersion();
+	DUCKDB_API static const char *ReleaseCodename();
 	DUCKDB_API static idx_t StandardVectorSize();
 	DUCKDB_API static string Platform();
 	DUCKDB_API bool ExtensionIsLoaded(const string &name);
@@ -40607,11 +42169,13 @@ public:
 	DUCKDB_API static string ToBlob(string_t str, CastParameters &parameters);
 
 	// base 64 conversion functions
+	DUCKDB_API static string ToBase64(string_t blob);
 	//! Returns the string size of a blob -> base64 conversion
 	DUCKDB_API static idx_t ToBase64Size(string_t blob);
 	//! Converts a blob to a base64 string, output should have space for at least ToBase64Size(blob) bytes
 	DUCKDB_API static void ToBase64(string_t blob, char *output);
 
+	DUCKDB_API static string FromBase64(string_t blob);
 	//! Returns the string size of a base64 string -> blob conversion
 	DUCKDB_API static idx_t FromBase64Size(string_t str);
 	//! Converts a base64 string to a blob, output should have space for at least FromBase64Size(blob) bytes
@@ -40791,49 +42355,46 @@ public:
 	static hugeint_t Abs(hugeint_t n);
 
 	// comparison operators
-	// note that everywhere here we intentionally use bitwise ops
-	// this is because they seem to be consistently much faster (benchmarked on a Macbook Pro)
 	static bool Equals(uhugeint_t lhs, uhugeint_t rhs) {
-		int lower_equals = lhs.lower == rhs.lower;
-		int upper_equals = lhs.upper == rhs.upper;
-		return lower_equals & upper_equals;
+		bool lower_equals = lhs.lower == rhs.lower;
+		bool upper_equals = lhs.upper == rhs.upper;
+		return lower_equals && upper_equals;
 	}
 
 	static bool NotEquals(uhugeint_t lhs, uhugeint_t rhs) {
-		int lower_not_equals = lhs.lower != rhs.lower;
-		int upper_not_equals = lhs.upper != rhs.upper;
-		return lower_not_equals | upper_not_equals;
+		return !Equals(lhs, rhs);
 	}
 
 	static bool GreaterThan(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger = lhs.lower > rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger = lhs.lower > rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger);
 	}
 
 	static bool GreaterThanEquals(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger_equals = lhs.lower >= rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger_equals);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger_equals = lhs.lower >= rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger_equals);
 	}
 
 	static bool LessThan(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller = lhs.lower < rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller = lhs.lower < rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller);
 	}
 
 	static bool LessThanEquals(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller_equals = lhs.lower <= rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller_equals);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller_equals = lhs.lower <= rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller_equals);
 	}
 
-	static const uhugeint_t POWERS_OF_TEN[40];
+	static constexpr uint8_t CACHED_POWERS_OF_TEN = 39;
+	static const uhugeint_t POWERS_OF_TEN[CACHED_POWERS_OF_TEN];
 };
 
 template <>
@@ -40897,19 +42458,20 @@ bool Uhugeint::TryConvert(const char *value, uhugeint_t &result);
 
 
 
+#include <array>
+
 
 
 
 namespace duckdb {
-class ClientContext;
 class RandomEngine;
 
-//! The UUID class contains static operations for the UUID type
-class UUID {
+//! The BaseUUID class contains UUID related common and util functions.
+class BaseUUID {
 public:
 	constexpr static const uint8_t STRING_SIZE = 36;
 	//! Convert a uuid string to a hugeint object
-	static bool FromString(const string &str, hugeint_t &result);
+	static bool FromString(const string &str, hugeint_t &result, bool strict = false);
 	//! Convert a uuid string to a hugeint object
 	static bool FromCString(const char *str, idx_t len, hugeint_t &result) {
 		return FromString(string(str, 0, len), result);
@@ -40923,10 +42485,6 @@ public:
 	static uhugeint_t ToUHugeint(hugeint_t input);
 
 	//! Convert a hugeint object to a uuid style string
-	static hugeint_t GenerateRandomUUID(RandomEngine &engine);
-	static hugeint_t GenerateRandomUUID();
-
-	//! Convert a hugeint object to a uuid style string
 	static string ToString(hugeint_t input) {
 		char buff[STRING_SIZE];
 		ToString(input, buff);
@@ -40938,6 +42496,28 @@ public:
 		FromString(str, result);
 		return result;
 	}
+
+protected:
+	//! Util function, which converts uint8_t array to hugeint_t.
+	static hugeint_t Convert(const std::array<uint8_t, 16> &bytes);
+};
+
+//! The UUIDv4 class contains static operations for the UUIDv4 type
+class UUID : public BaseUUID {
+public:
+	//! Generate a random UUID v4 value.
+	static hugeint_t GenerateRandomUUID(RandomEngine &engine);
+	static hugeint_t GenerateRandomUUID();
+};
+
+using UUIDv4 = UUID;
+
+//! The UUIDv7 class contains static operations for the UUIDv7 type.
+class UUIDv7 : public BaseUUID {
+public:
+	//! Generate a random UUID v7 value.
+	static hugeint_t GenerateRandomUUID(RandomEngine &engine);
+	static hugeint_t GenerateRandomUUID();
 };
 
 } // namespace duckdb
@@ -41071,20 +42651,20 @@ private:
 public:
 	static constexpr idx_t DEFAULT_INITIAL_CAPACITY = 512;
 
-	// Create a new owning MemoryStream with an internal  backing buffer with the specified capacity. The stream will
-	// own the backing buffer, resize it when needed and free its memory when the stream is destroyed
+	//! Create a new owning MemoryStream with an internal  backing buffer with the specified capacity. The stream will
+	//! own the backing buffer, resize it when needed and free its memory when the stream is destroyed
 	explicit MemoryStream(Allocator &allocator, idx_t capacity = DEFAULT_INITIAL_CAPACITY);
 
-	// Create a new owning MemoryStream with an internal  backing buffer with the specified capacity. The stream will
-	// own the backing buffer, resize it when needed and free its memory when the stream is destroyed
+	//! Create a new owning MemoryStream with an internal  backing buffer with the specified capacity. The stream will
+	//! own the backing buffer, resize it when needed and free its memory when the stream is destroyed
 	explicit MemoryStream(idx_t capacity = DEFAULT_INITIAL_CAPACITY);
 
-	// Create a new non-owning MemoryStream over the specified external buffer and capacity. The stream will not take
-	// ownership of the backing buffer, will not attempt to resize it and will not free the memory when the stream
-	// is destroyed
+	//! Create a new non-owning MemoryStream over the specified external buffer and capacity. The stream will not take
+	//! ownership of the backing buffer, will not attempt to resize it and will not free the memory when the stream
+	//! is destroyed
 	explicit MemoryStream(data_ptr_t buffer, idx_t capacity);
 
-	// Cant copy!
+	//! Cant copy!
 	MemoryStream(const MemoryStream &) = delete;
 	MemoryStream &operator=(const MemoryStream &) = delete;
 
@@ -41093,47 +42673,51 @@ public:
 
 	~MemoryStream() override;
 
-	// Write data to the stream.
-	// Throws if the write would exceed the capacity of the stream and the backing buffer is not owned by the stream
+	//! Write data to the stream.
+	//! Throws if the write would exceed the capacity of the stream and the backing buffer is not owned by the stream
 	void WriteData(const_data_ptr_t buffer, idx_t write_size) override;
 
-	// Read data from the stream.
-	// Throws if the read would exceed the capacity of the stream
+	//! Read data from the stream.
+	//! Throws if the read would exceed the capacity of the stream
 	void ReadData(data_ptr_t buffer, idx_t read_size) override;
 
-	// Rewind the stream to the start, keeping the capacity and the backing buffer intact
+	//! Rewind the stream to the start, keeping the capacity and the backing buffer intact
 	void Rewind();
 
-	// Release ownership of the backing buffer and turn a owning stream into a non-owning one.
-	// The stream will no longer be responsible for freeing the data.
-	// The stream will also no longer attempt to automatically resize the buffer when the capacity is reached.
+	//! Release ownership of the backing buffer and turn a owning stream into a non-owning one.
+	//! The stream will no longer be responsible for freeing the data.
+	//! The stream will also no longer attempt to automatically resize the buffer when the capacity is reached.
 	void Release();
 
-	// Get a pointer to the underlying backing buffer
+	//! Get a pointer to the underlying backing buffer
 	data_ptr_t GetData() const;
 
-	// Get the current position in the stream
+	//! Get the current position in the stream
 	idx_t GetPosition() const;
 
-	// Get the capacity of the stream
+	//! Get the capacity of the stream
 	idx_t GetCapacity() const;
+
+	//! Set the position in the stream
+	void SetPosition(idx_t position);
 };
 
 } // namespace duckdb
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/parser/parsed_data/create_table_function_info.hpp
+// duckdb/main/extension_util.hpp
 //
 //
 //===----------------------------------------------------------------------===//
+
 
 
 
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/parser/parsed_data/create_function_info.hpp
+// duckdb/function/cast/cast_function_set.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -41142,29 +42726,63 @@ public:
 
 
 
-
 namespace duckdb {
+struct MapCastInfo;
+struct MapCastNode;
+struct DBConfig;
 
-struct FunctionDescription {
-	//! Parameter types (if any)
-	vector<LogicalType> parameter_types;
-	//! Parameter names (if any)
-	vector<string> parameter_names;
-	//! The description (if any)
-	string description;
-	//! Examples (if any)
-	vector<string> examples;
+typedef BoundCastInfo (*bind_cast_function_t)(BindCastInput &input, const LogicalType &source,
+                                              const LogicalType &target);
+typedef int64_t (*implicit_cast_cost_t)(const LogicalType &from, const LogicalType &to);
+
+struct GetCastFunctionInput {
+	explicit GetCastFunctionInput(optional_ptr<ClientContext> context = nullptr) : context(context) {
+	}
+	explicit GetCastFunctionInput(ClientContext &context) : context(&context) {
+	}
+
+	optional_ptr<ClientContext> context;
+	optional_idx query_location;
 };
 
-struct CreateFunctionInfo : public CreateInfo {
-	explicit CreateFunctionInfo(CatalogType type, string schema = DEFAULT_SCHEMA);
+struct BindCastFunction {
+	BindCastFunction(bind_cast_function_t function, // NOLINT: allow implicit cast
+	                 unique_ptr<BindCastInfo> info = nullptr);
 
-	//! Function name
-	string name;
-	//! Function description
-	vector<FunctionDescription> descriptions;
+	bind_cast_function_t function;
+	unique_ptr<BindCastInfo> info;
+};
 
-	DUCKDB_API void CopyFunctionProperties(CreateFunctionInfo &other) const;
+class CastFunctionSet {
+public:
+	CastFunctionSet();
+	explicit CastFunctionSet(DBConfig &config);
+
+public:
+	DUCKDB_API static CastFunctionSet &Get(ClientContext &context);
+	DUCKDB_API static CastFunctionSet &Get(DatabaseInstance &db);
+
+	//! Returns a cast function (from source -> target)
+	//! Note that this always returns a function - since a cast is ALWAYS possible if the value is NULL
+	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target,
+	                                         GetCastFunctionInput &input);
+	//! Returns the implicit cast cost of casting from source -> target
+	//! -1 means an implicit cast is not possible
+	DUCKDB_API int64_t ImplicitCastCost(const LogicalType &source, const LogicalType &target);
+	//! Register a new cast function from source to target
+	DUCKDB_API void RegisterCastFunction(const LogicalType &source, const LogicalType &target, BoundCastInfo function,
+	                                     int64_t implicit_cast_cost = -1);
+	DUCKDB_API void RegisterCastFunction(const LogicalType &source, const LogicalType &target,
+	                                     bind_cast_function_t bind, int64_t implicit_cast_cost = -1);
+
+private:
+	optional_ptr<DBConfig> config;
+	vector<BindCastFunction> bind_functions;
+	//! If any custom cast functions have been defined using RegisterCastFunction, this holds the map
+	optional_ptr<MapCastInfo> map_info;
+
+private:
+	void RegisterCastFunction(const LogicalType &source, const LogicalType &target, MapCastNode node);
 };
 
 } // namespace duckdb
@@ -41372,6 +42990,8331 @@ public:
 
 } // namespace duckdb
 
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/secret/secret.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/serializer/deserializer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/serializer/serialization_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/stack.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+#include <stack>
+
+namespace duckdb {
+using std::stack;
+}
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/bound_parameter_map.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class ParameterExpression;
+class BoundParameterExpression;
+
+using bound_parameter_map_t = case_insensitive_map_t<shared_ptr<BoundParameterData>>;
+
+struct BoundParameterMap {
+public:
+	explicit BoundParameterMap(case_insensitive_map_t<BoundParameterData> &parameter_data);
+
+public:
+	LogicalType GetReturnType(const string &identifier);
+
+	bound_parameter_map_t *GetParametersPtr();
+
+	const bound_parameter_map_t &GetParameters();
+
+	const case_insensitive_map_t<BoundParameterData> &GetParameterData();
+
+	unique_ptr<BoundParameterExpression> BindParameterExpression(ParameterExpression &expr);
+
+	//! Flag to indicate that we need to rebind this prepared statement before execution
+	bool rebind = false;
+
+private:
+	shared_ptr<BoundParameterData> CreateOrGetData(const string &identifier);
+	void CreateNewParameter(const string &id, const shared_ptr<BoundParameterData> &param_data);
+
+private:
+	bound_parameter_map_t parameters;
+	// Pre-provided parameter data if populated
+	case_insensitive_map_t<BoundParameterData> &parameter_data;
+};
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+class ClientContext;
+class Catalog;
+class DatabaseInstance;
+class CompressionInfo;
+enum class ExpressionType : uint8_t;
+
+struct SerializationData {
+	struct CustomData {
+		virtual ~CustomData() = default;
+	};
+
+	stack<reference<ClientContext>> contexts;
+	stack<reference<DatabaseInstance>> databases;
+	stack<reference<Catalog>> catalogs;
+	stack<idx_t> enums;
+	stack<reference<bound_parameter_map_t>> parameter_data;
+	stack<const_reference<LogicalType>> types;
+	stack<const_reference<CompressionInfo>> compression_infos;
+	duckdb::unordered_map<std::string, duckdb::stack<duckdb::reference<CustomData>>> customs;
+
+	template <class T>
+	void Set(T entry) = delete;
+
+	template <class T>
+	T Get() = delete;
+
+	template <class T>
+	optional_ptr<T> TryGet() = delete;
+
+	template <class T>
+	void Unset() = delete;
+
+	template <class T>
+	inline void AssertNotEmpty(const stack<T> &e) {
+		if (e.empty()) {
+			throw InternalException("SerializationData - unexpected empty stack");
+		}
+	}
+
+	template <typename T>
+	typename std::enable_if<std::is_base_of<CustomData, T>::value, T &>::type GetCustom() const {
+		std::string type = T::GetType();
+		auto iter = customs.find(type);
+		if (iter == customs.end()) {
+			throw duckdb::InternalException("SeserializationData - no stack for %s", type);
+		}
+		auto &stack = iter->second;
+		if (stack.empty()) {
+			throw duckdb::InternalException("SerializationData - unexpected empty stack for %s", type);
+		}
+		return dynamic_cast<T &>(stack.top().get());
+	}
+
+	template <typename T>
+	typename std::enable_if<std::is_base_of<CustomData, T>::value, void>::type SetCustom(T &data) {
+		std::string type = T::GetType();
+		auto iter = customs.find(type);
+		if (iter == customs.end()) {
+			iter = customs.emplace(type, duckdb::stack<duckdb::reference<CustomData>> {}).first;
+		}
+		auto &stack = iter->second;
+		stack.push(data);
+	}
+};
+
+template <>
+inline void SerializationData::Set(ExpressionType type) {
+	enums.push(idx_t(type));
+}
+
+template <>
+inline ExpressionType SerializationData::Get() {
+	AssertNotEmpty(enums);
+	return ExpressionType(enums.top());
+}
+
+template <>
+inline void SerializationData::Unset<ExpressionType>() {
+	AssertNotEmpty(enums);
+	enums.pop();
+}
+
+template <>
+inline void SerializationData::Set(LogicalOperatorType type) {
+	enums.push(idx_t(type));
+}
+
+template <>
+inline LogicalOperatorType SerializationData::Get() {
+	AssertNotEmpty(enums);
+	return LogicalOperatorType(enums.top());
+}
+
+template <>
+inline void SerializationData::Unset<LogicalOperatorType>() {
+	AssertNotEmpty(enums);
+	enums.pop();
+}
+
+template <>
+inline void SerializationData::Set(CompressionType type) {
+	enums.push(idx_t(type));
+}
+
+template <>
+inline CompressionType SerializationData::Get() {
+	AssertNotEmpty(enums);
+	return CompressionType(enums.top());
+}
+
+template <>
+inline void SerializationData::Unset<CompressionType>() {
+	AssertNotEmpty(enums);
+	enums.pop();
+}
+
+template <>
+inline void SerializationData::Set(CatalogType type) {
+	enums.push(idx_t(type));
+}
+
+template <>
+inline CatalogType SerializationData::Get() {
+	AssertNotEmpty(enums);
+	return CatalogType(enums.top());
+}
+
+template <>
+inline void SerializationData::Unset<CatalogType>() {
+	AssertNotEmpty(enums);
+	enums.pop();
+}
+
+template <>
+inline void SerializationData::Set(ClientContext &context) {
+	contexts.emplace(context);
+}
+
+template <>
+inline ClientContext &SerializationData::Get() {
+	AssertNotEmpty(contexts);
+	return contexts.top();
+}
+
+template <>
+inline void SerializationData::Unset<ClientContext>() {
+	AssertNotEmpty(contexts);
+	contexts.pop();
+}
+
+template <>
+inline void SerializationData::Set(Catalog &catalog) {
+	catalogs.emplace(catalog);
+}
+
+template <>
+inline Catalog &SerializationData::Get() {
+	AssertNotEmpty(catalogs);
+	return catalogs.top();
+}
+
+template <>
+inline optional_ptr<Catalog> SerializationData::TryGet() {
+	return catalogs.empty() ? nullptr : &catalogs.top().get();
+}
+
+template <>
+inline void SerializationData::Unset<Catalog>() {
+	AssertNotEmpty(catalogs);
+	catalogs.pop();
+}
+template <>
+inline void SerializationData::Set(DatabaseInstance &db) {
+	databases.emplace(db);
+}
+
+template <>
+inline DatabaseInstance &SerializationData::Get() {
+	AssertNotEmpty(databases);
+	return databases.top();
+}
+
+template <>
+inline void SerializationData::Unset<DatabaseInstance>() {
+	AssertNotEmpty(databases);
+	databases.pop();
+}
+
+template <>
+inline void SerializationData::Set(bound_parameter_map_t &context) {
+	parameter_data.emplace(context);
+}
+
+template <>
+inline bound_parameter_map_t &SerializationData::Get() {
+	AssertNotEmpty(parameter_data);
+	return parameter_data.top();
+}
+
+template <>
+inline void SerializationData::Unset<bound_parameter_map_t>() {
+	AssertNotEmpty(parameter_data);
+	parameter_data.pop();
+}
+
+template <>
+inline void SerializationData::Set(LogicalType &type) {
+	types.emplace(type);
+}
+
+template <>
+inline void SerializationData::Unset<LogicalType>() {
+	AssertNotEmpty(types);
+	types.pop();
+}
+
+template <>
+inline void SerializationData::Set(const LogicalType &type) {
+	types.emplace(type);
+}
+
+template <>
+inline const LogicalType &SerializationData::Get() {
+	AssertNotEmpty(types);
+	return types.top();
+}
+
+template <>
+inline void SerializationData::Unset<const LogicalType>() {
+	AssertNotEmpty(types);
+	types.pop();
+}
+
+template <>
+inline void SerializationData::Set(const CompressionInfo &compression_info) {
+	compression_infos.emplace(compression_info);
+}
+
+template <>
+inline const CompressionInfo &SerializationData::Get() {
+	AssertNotEmpty(compression_infos);
+	return compression_infos.top();
+}
+
+template <>
+inline void SerializationData::Unset<const CompressionInfo>() {
+	AssertNotEmpty(compression_infos);
+	compression_infos.pop();
+}
+
+} // namespace duckdb
+
+
+#include <type_traits>
+#include <cstdint>
+#include <atomic>
+
+
+
+
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/optionally_owned_ptr.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+class optionally_owned_ptr { // NOLINT: mimic std casing
+public:
+	optionally_owned_ptr() {
+	}
+	optionally_owned_ptr(T *ptr_p) : ptr(ptr_p) { // NOLINT: allow implicit creation from pointer
+	}
+	optionally_owned_ptr(T &ref) : ptr(&ref) { // NOLINT: allow implicit creation from reference
+	}
+	optionally_owned_ptr(unique_ptr<T> &&owned_p) // NOLINT: allow implicit creation from moved unique_ptr
+	    : owned(std::move(owned_p)), ptr(owned) {
+	}
+	// Move constructor
+	optionally_owned_ptr(optionally_owned_ptr &&other) noexcept : owned(std::move(other.owned)), ptr(other.ptr) {
+		other.ptr = nullptr;
+	}
+	// Copy constructor
+	optionally_owned_ptr(const optionally_owned_ptr &other) = delete;
+
+	operator bool() const { // NOLINT: allow implicit conversion to bool
+		return ptr;
+	}
+	T &operator*() {
+		return *ptr;
+	}
+	const T &operator*() const {
+		return *ptr;
+	}
+	T *operator->() {
+		return ptr.get();
+	}
+	const T *operator->() const {
+		return ptr.get();
+	}
+	T *get() { // NOLINT: mimic std casing
+		return ptr.get();
+	}
+	const T *get() const { // NOLINT: mimic std casing
+		return ptr.get();
+	}
+	bool is_owned() const { // NOLINT: mimic std casing
+		return owned != nullptr;
+	}
+	// this looks dirty - but this is the default behavior of raw pointers
+	T *get_mutable() const { // NOLINT: mimic std casing
+		return ptr.get();
+	}
+
+	optionally_owned_ptr<T> &operator=(T &ref) {
+		owned = nullptr;
+		ptr = optional_ptr<T>(ref);
+		return *this;
+	}
+	optionally_owned_ptr<T> &operator=(T *ref) {
+		owned = nullptr;
+		ptr = optional_ptr<T>(ref);
+		return *this;
+	}
+
+	bool operator==(const optionally_owned_ptr<T> &rhs) const {
+		if (owned != rhs.owned) {
+			return false;
+		}
+		return ptr == rhs.ptr;
+	}
+
+	bool operator!=(const optionally_owned_ptr<T> &rhs) const {
+		return !(*this == rhs);
+	}
+
+private:
+	unique_ptr<T> owned;
+	optional_ptr<T> ptr;
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class Serializer;   // Forward declare
+class Deserializer; // Forward declare
+
+typedef uint16_t field_id_t;
+const field_id_t MESSAGE_TERMINATOR_FIELD_ID = 0xFFFF;
+
+// Backport to c++11
+template <class...>
+using void_t = void;
+
+// NOLINTBEGIN: match STL case
+// Check for anything implementing a `void Serialize(Serializer &Serializer)` method
+template <typename T, typename = T>
+struct has_serialize : std::false_type {};
+
+template <typename T>
+struct has_serialize<
+    T, typename std::enable_if<
+           std::is_same<decltype(std::declval<T>().Serialize(std::declval<Serializer &>())), void>::value, T>::type>
+    : std::true_type {};
+
+template <typename T, typename = T>
+struct has_deserialize : std::false_type {};
+
+// Accept `static unique_ptr<T> Deserialize(Deserializer& deserializer)`
+template <typename T>
+struct has_deserialize<
+    T, typename std::enable_if<std::is_same<decltype(T::Deserialize), unique_ptr<T>(Deserializer &)>::value, T>::type>
+    : std::true_type {};
+
+// Accept `static shared_ptr<T> Deserialize(Deserializer& deserializer)`
+template <typename T>
+struct has_deserialize<
+    T, typename std::enable_if<std::is_same<decltype(T::Deserialize), shared_ptr<T>(Deserializer &)>::value, T>::type>
+    : std::true_type {};
+
+// Accept `static shared_ptr<T> Deserialize(Deserializer& deserializer)`
+template <typename T>
+struct has_deserialize<
+    T,
+    typename std::enable_if<std::is_same<decltype(T::Deserialize), std::shared_ptr<T>(Deserializer &)>::value, T>::type>
+    : std::true_type {};
+
+// Accept `static T Deserialize(Deserializer& deserializer)`
+template <typename T>
+struct has_deserialize<
+    T, typename std::enable_if<std::is_same<decltype(T::Deserialize), T(Deserializer &)>::value, T>::type>
+    : std::true_type {};
+
+// Check if T is a vector, and provide access to the inner type
+template <typename T>
+struct is_vector : std::false_type {};
+template <typename T>
+struct is_vector<typename duckdb::vector<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+template <typename T>
+struct is_unsafe_vector : std::false_type {};
+template <typename T>
+struct is_unsafe_vector<typename duckdb::unsafe_vector<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+// Check if T is a unordered map, and provide access to the inner type
+template <typename T>
+struct is_unordered_map : std::false_type {};
+template <typename... Args>
+struct is_unordered_map<typename duckdb::unordered_map<Args...>> : std::true_type {
+	typedef typename std::tuple_element<0, std::tuple<Args...>>::type KEY_TYPE;
+	typedef typename std::tuple_element<1, std::tuple<Args...>>::type VALUE_TYPE;
+	typedef typename std::tuple_element<2, std::tuple<Args...>>::type HASH_TYPE;
+	typedef typename std::tuple_element<3, std::tuple<Args...>>::type EQUAL_TYPE;
+};
+
+template <typename T>
+struct is_map : std::false_type {};
+template <typename... Args>
+struct is_map<typename duckdb::map<Args...>> : std::true_type {
+	typedef typename std::tuple_element<0, std::tuple<Args...>>::type KEY_TYPE;
+	typedef typename std::tuple_element<1, std::tuple<Args...>>::type VALUE_TYPE;
+	typedef typename std::tuple_element<2, std::tuple<Args...>>::type HASH_TYPE;
+	typedef typename std::tuple_element<3, std::tuple<Args...>>::type EQUAL_TYPE;
+};
+
+template <typename T>
+struct is_insertion_preserving_map : std::false_type {};
+template <typename... Args>
+struct is_insertion_preserving_map<typename duckdb::InsertionOrderPreservingMap<Args...>> : std::true_type {
+	typedef typename std::tuple_element<0, std::tuple<Args...>>::type VALUE_TYPE;
+};
+
+template <typename T>
+struct is_queue : std::false_type {};
+template <typename T>
+struct is_queue<typename std::priority_queue<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+template <typename T>
+struct is_unique_ptr : std::false_type {};
+template <typename T>
+struct is_unique_ptr<unique_ptr<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+template <typename T>
+struct is_shared_ptr : std::false_type {};
+template <typename T>
+struct is_shared_ptr<shared_ptr<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+template <typename T>
+struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+template <typename T>
+struct is_optional_ptr : std::false_type {};
+template <typename T>
+struct is_optional_ptr<optional_ptr<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+template <typename T>
+struct is_optionally_owned_ptr : std::false_type {};
+template <typename T>
+struct is_optionally_owned_ptr<optionally_owned_ptr<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+template <typename T>
+struct is_pair : std::false_type {};
+template <typename T, typename U>
+struct is_pair<std::pair<T, U>> : std::true_type {
+	typedef T FIRST_TYPE;
+	typedef U SECOND_TYPE;
+};
+
+template <typename T>
+struct is_unordered_set : std::false_type {};
+template <typename... Args>
+struct is_unordered_set<duckdb::unordered_set<Args...>> : std::true_type {
+	typedef typename std::tuple_element<0, std::tuple<Args...>>::type ELEMENT_TYPE;
+	typedef typename std::tuple_element<1, std::tuple<Args...>>::type HASH_TYPE;
+	typedef typename std::tuple_element<2, std::tuple<Args...>>::type EQUAL_TYPE;
+};
+
+template <typename T>
+struct is_set : std::false_type {};
+template <typename... Args>
+struct is_set<duckdb::set<Args...>> : std::true_type {
+	typedef typename std::tuple_element<0, std::tuple<Args...>>::type ELEMENT_TYPE;
+	typedef typename std::tuple_element<1, std::tuple<Args...>>::type HASH_TYPE;
+	typedef typename std::tuple_element<2, std::tuple<Args...>>::type EQUAL_TYPE;
+};
+
+template <typename T>
+struct is_atomic : std::false_type {};
+
+template <typename T>
+struct is_atomic<std::atomic<T>> : std::true_type {
+	typedef T TYPE;
+};
+
+// NOLINTEND
+
+struct SerializationDefaultValue {
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_atomic<T>::value, T>::type GetDefault() {
+		using INNER = typename is_atomic<T>::TYPE;
+		return static_cast<T>(GetDefault<INNER>());
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_atomic<T>::value, T>::type &value) {
+		using INNER = typename is_atomic<T>::TYPE;
+		return value == GetDefault<INNER>();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type GetDefault() {
+		return static_cast<T>(0);
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<std::is_arithmetic<T>::value, T>::type &value) {
+		return value == static_cast<T>(0);
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_unique_ptr<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_unique_ptr<T>::value, T>::type &value) {
+		return !value;
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_optional_ptr<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_optional_ptr<T>::value, T>::type &value) {
+		return !value;
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_optionally_owned_ptr<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_optionally_owned_ptr<T>::value, T>::type &value) {
+		return !value;
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_shared_ptr<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_shared_ptr<T>::value, T>::type &value) {
+		return !value;
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_vector<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_vector<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_queue<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_queue<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_unsafe_vector<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_unsafe_vector<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_unordered_set<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_unordered_set<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_unordered_map<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_unordered_map<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_map<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_map<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_insertion_preserving_map<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_insertion_preserving_map<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<std::is_same<T, string>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<std::is_same<T, string>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<std::is_same<T, optional_idx>::value, T>::type GetDefault() {
+		return optional_idx();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<std::is_same<T, optional_idx>::value, T>::type &value) {
+		return !value.IsValid();
+	}
+};
+
+} // namespace duckdb
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/csv_buffer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/csv_file_handle.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/encode/csv_encoder.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DBConfig;
+
+//! Struct that holds encoder buffers
+struct CSVEncoderBuffer {
+	CSVEncoderBuffer() : encoded_buffer_size(0) {};
+	void Initialize(idx_t encoded_buffer_size);
+
+	char *Ptr() const;
+
+	idx_t GetCapacity() const;
+
+	idx_t GetSize() const;
+
+	void SetSize(const idx_t buffer_size);
+
+	bool HasDataToRead() const;
+
+	void Reset();
+	idx_t cur_pos = 0;
+	//! The actual encoded buffer size, from the last file_handle read.
+	idx_t actual_encoded_buffer_size = 0;
+	//! If this is the last buffer
+	bool last_buffer = false;
+
+private:
+	//! The encoded buffer, we only have one per file, so we cache it and make sure to pass over unused bytes.
+	duckdb::unique_ptr<char[]> encoded_buffer;
+	//! The encoded buffer size is defined as buffer_size/GetRatio()
+	idx_t encoded_buffer_size;
+};
+
+class CSVEncoder {
+public:
+	//! Constructor, basically takes an encoding and the output buffer size
+	CSVEncoder(ClientContext &context, const string &encoding_name, idx_t buffer_size);
+	//! Main encode function, it reads the file into an encoded buffer and converts it to the output buffer
+	idx_t Encode(FileHandle &file_handle_input, char *output_buffer, const idx_t decoded_buffer_size);
+	string encoding_name;
+
+private:
+	//! The actual encoded buffer
+	CSVEncoderBuffer encoded_buffer;
+	//! Potential remaining bytes
+	CSVEncoderBuffer remaining_bytes_buffer;
+	//! Actual Encoding Function
+	optional_ptr<EncodingFunction> encoding_function;
+	//! Pass-on Byte, used to check if we are done with the file, but must be appended to next buffer
+	char pass_on_byte;
+	bool has_pass_on_byte = false;
+};
+} // namespace duckdb
+
+namespace duckdb {
+class Allocator;
+class FileSystem;
+struct CSVReaderOptions;
+
+class CSVFileHandle {
+public:
+	CSVFileHandle(ClientContext &context, unique_ptr<FileHandle> file_handle_p, const OpenFileInfo &file,
+	              const CSVReaderOptions &options);
+
+	mutex main_mutex;
+
+	bool CanSeek() const;
+	void Seek(idx_t position) const;
+	bool OnDiskFile() const;
+	bool IsPipe() const;
+
+	void Reset();
+
+	idx_t FileSize() const;
+
+	bool FinishedReading() const;
+
+	idx_t Read(void *buffer, idx_t nr_bytes);
+
+	string ReadLine();
+
+	string GetFilePath();
+
+	static unique_ptr<FileHandle> OpenFileHandle(FileSystem &fs, Allocator &allocator, const OpenFileInfo &file,
+	                                             FileCompressionType compression);
+	static unique_ptr<CSVFileHandle> OpenFile(ClientContext &context, const OpenFileInfo &file,
+	                                          const CSVReaderOptions &options);
+	FileCompressionType compression_type;
+
+	double GetProgress() const;
+
+private:
+	unique_ptr<FileHandle> file_handle;
+	CSVEncoder encoder;
+	const OpenFileInfo file;
+	bool can_seek = false;
+	bool on_disk_file = false;
+	bool is_pipe = false;
+	idx_t uncompressed_bytes_read = 0;
+
+	idx_t file_size = 0;
+
+	idx_t requested_bytes = 0;
+	//! If we finished reading the file
+	bool finished = false;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/buffer_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/block_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+class BlockHandle;
+class BufferHandle;
+class BufferManager;
+class ClientContext;
+class DatabaseInstance;
+class MetadataManager;
+
+//! BlockManager is an abstract representation to manage blocks on DuckDB. When writing or reading blocks, the
+//! BlockManager creates and accesses blocks. The concrete types implement specific block storage strategies.
+class BlockManager {
+public:
+	BlockManager() = delete;
+	BlockManager(BufferManager &buffer_manager, const optional_idx block_alloc_size_p,
+	             const optional_idx block_header_size_p);
+	virtual ~BlockManager() = default;
+
+	//! The buffer manager
+	BufferManager &buffer_manager;
+
+public:
+	//! Creates a new block inside the block manager
+	virtual unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) = 0;
+	virtual unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) = 0;
+	//! Return the next free block id
+	virtual block_id_t GetFreeBlockId() = 0;
+	virtual block_id_t PeekFreeBlockId() = 0;
+	//! Returns whether or not a specified block is the root block
+	virtual bool IsRootBlock(MetaBlockPointer root) = 0;
+	//! Mark a block as "free"; free blocks are immediately added to the free list and can be immediately overwritten
+	virtual void MarkBlockAsFree(block_id_t block_id) = 0;
+	//! Mark a block as "used"; either the block is removed from the free list, or the reference count is incremented
+	virtual void MarkBlockAsUsed(block_id_t block_id) = 0;
+	//! Mark a block as "modified"; modified blocks are added to the free list after a checkpoint (i.e. their data is
+	//! assumed to be rewritten)
+	virtual void MarkBlockAsModified(block_id_t block_id) = 0;
+	//! Increase the reference count of a block. The block should hold at least one reference before this method is
+	//! called.
+	virtual void IncreaseBlockReferenceCount(block_id_t block_id) = 0;
+	//! Get the first meta block id
+	virtual idx_t GetMetaBlock() = 0;
+	//! Read the content of the block from disk
+	virtual void Read(Block &block) = 0;
+	//! Read the content of the block from disk
+	virtual void ReadBlocks(FileBuffer &buffer, block_id_t start_block, idx_t block_count) = 0;
+	//! Writes the block to disk
+	virtual void Write(FileBuffer &block, block_id_t block_id) = 0;
+	//! Writes the block to disk
+	void Write(Block &block) {
+		Write(block, block.id);
+	}
+	//! Write the header; should be the final step of a checkpoint
+	virtual void WriteHeader(DatabaseHeader header) = 0;
+
+	//! Returns the number of total blocks
+	virtual idx_t TotalBlocks() = 0;
+	//! Returns the number of free blocks
+	virtual idx_t FreeBlocks() = 0;
+	//! Whether or not the attached database is a remote file (e.g. attached over s3/https)
+	virtual bool IsRemote() {
+		return false;
+	}
+	//! Whether or not the attached database is in-memory
+	virtual bool InMemory() = 0;
+
+	//! Sync changes made to the block manager
+	virtual void FileSync() = 0;
+	//! Truncate the underlying database file after a checkpoint
+	virtual void Truncate();
+
+	//! Register a block with the given block id in the base file
+	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id);
+	//! Convert an existing in-memory buffer into a persistent disk-backed block
+	shared_ptr<BlockHandle> ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block,
+	                                            BufferHandle old_handle);
+	shared_ptr<BlockHandle> ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block);
+
+	void UnregisterBlock(BlockHandle &block);
+	//! UnregisterBlock, only accepts non-temporary block ids
+	void UnregisterBlock(block_id_t id);
+
+	//! Returns a reference to the metadata manager of this block manager.
+	MetadataManager &GetMetadataManager();
+	//! Returns the block allocation size of this block manager.
+	inline idx_t GetBlockAllocSize() const {
+		return block_alloc_size.GetIndex();
+	}
+	//! Returns the possibly invalid block allocation size of this block manager.
+	inline optional_idx GetOptionalBlockAllocSize() const {
+		return block_alloc_size;
+	}
+	//! Returns the possibly invalid block header size of this block manager.
+	inline optional_idx GetOptionalBlockHeaderSize() const {
+		return block_header_size;
+	}
+	//! Block header size including the 8-byte checksum
+	inline idx_t GetBlockHeaderSize() const {
+		if (!block_header_size.IsValid()) {
+			return Storage::DEFAULT_BLOCK_HEADER_SIZE;
+		}
+		return block_header_size.GetIndex();
+	}
+	//! Size of the block available for the user
+	inline idx_t GetBlockSize() const {
+		return block_alloc_size.GetIndex() - block_header_size.GetIndex();
+	}
+	//! Sets the block allocation size. This should only happen when initializing an existing database.
+	//! When initializing an existing database, we construct the block manager before reading the file header,
+	//! which contains the file's actual block allocation size.
+	void SetBlockAllocSize(const optional_idx block_alloc_size_p) {
+		if (block_alloc_size.IsValid()) {
+			throw InternalException("the block allocation size must be set once");
+		}
+		block_alloc_size = block_alloc_size_p.GetIndex();
+	}
+	//! Sets the block header size. Idem as above.
+	//! This is only set once upon initialization of the database
+	//! For now this method is unused
+	void SetBlockHeaderSize(const optional_idx block_header_size_p) {
+		if (block_header_size.IsValid()) {
+			throw InternalException("block header size already set, must be set once");
+		}
+		block_header_size = block_header_size_p.GetIndex();
+	}
+	//! Verify the block usage count
+	virtual void VerifyBlocks(const unordered_map<block_id_t, idx_t> &block_usage_count) {
+	}
+
+private:
+	//! The lock for the set of blocks
+	mutex blocks_lock;
+	//! A mapping of block id -> BlockHandle
+	unordered_map<block_id_t, weak_ptr<BlockHandle>> blocks;
+	//! The metadata manager
+	unique_ptr<MetadataManager> metadata_manager;
+	//! The allocation size of blocks managed by this block manager. Defaults to DEFAULT_BLOCK_ALLOC_SIZE
+	//! for in-memory block managers. Default to default_block_alloc_size for file-backed block managers.
+	//! This is NOT the actual memory available on a block (block_size).
+	optional_idx block_alloc_size;
+	//! The size of the block headers (incl. checksum) in this block manager.
+	//! Defaults to DEFAULT_BLOCK_HEADER_SIZE for in-memory block managers.
+	//! Default to default_block_header_size for file-backed block managers.
+	optional_idx block_header_size;
+};
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/memory_tag.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+enum class MemoryTag : uint8_t {
+	BASE_TABLE = 0,
+	HASH_TABLE = 1,
+	PARQUET_READER = 2,
+	CSV_READER = 3,
+	ORDER_BY = 4,
+	ART_INDEX = 5,
+	COLUMN_DATA = 6,
+	METADATA = 7,
+	OVERFLOW_STRINGS = 8,
+	IN_MEMORY_TABLE = 9,
+	ALLOCATOR = 10,
+	EXTENSION = 11,
+	TRANSACTION = 12,
+	EXTERNAL_FILE_CACHE = 13,
+};
+
+static constexpr const idx_t MEMORY_TAG_COUNT = 14;
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/buffer/temporary_file_information.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+struct MemoryInformation {
+	MemoryTag tag;
+	idx_t size;
+	idx_t evicted_data;
+};
+
+struct TemporaryFileInformation {
+	string path;
+	idx_t size;
+};
+
+struct CachedFileInformation {
+	string path;
+	idx_t nr_bytes;
+	idx_t location;
+	bool loaded;
+};
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+class Allocator;
+class BufferPool;
+class TemporaryMemoryManager;
+
+class BufferManager {
+	friend class BufferHandle;
+	friend class BlockHandle;
+	friend class BlockManager;
+
+public:
+	BufferManager() {
+	}
+	virtual ~BufferManager() {
+	}
+
+public:
+	virtual shared_ptr<BlockHandle> AllocateTemporaryMemory(MemoryTag tag, idx_t block_size,
+	                                                        bool can_destroy = true) = 0;
+	virtual shared_ptr<BlockHandle> AllocateMemory(MemoryTag tag, BlockManager *block_manager,
+	                                               bool can_destroy = true) = 0;
+	virtual BufferHandle Allocate(MemoryTag tag, idx_t block_size, bool can_destroy = true) = 0;
+	virtual BufferHandle Allocate(MemoryTag tag, BlockManager *block_manager, bool can_destroy = true) = 0;
+	//! Reallocate an in-memory buffer that is pinned.
+	virtual void ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) = 0;
+	virtual BufferHandle Pin(shared_ptr<BlockHandle> &handle) = 0;
+	//! Prefetch a series of blocks. Note that this is a performance suggestion.
+	virtual void Prefetch(vector<shared_ptr<BlockHandle>> &handles) = 0;
+	virtual void Unpin(shared_ptr<BlockHandle> &handle) = 0;
+
+	//! Returns the currently allocated memory
+	virtual idx_t GetUsedMemory() const = 0;
+	//! Returns the maximum available memory
+	virtual idx_t GetMaxMemory() const = 0;
+	//! Returns the currently used swap space
+	virtual idx_t GetUsedSwap() const = 0;
+	//! Returns the maximum swap space that can be used
+	virtual optional_idx GetMaxSwap() const = 0;
+	//! Returns the block allocation size for buffer-managed blocks.
+	virtual idx_t GetBlockAllocSize() const = 0;
+	//! Returns the block size for buffer-managed blocks.
+	virtual idx_t GetBlockSize() const = 0;
+	//! Returns the block header size for buffer-managed blocks.
+	virtual idx_t GetTemporaryBlockHeaderSize() const = 0;
+
+	//! Returns a new block of transient memory.
+	virtual shared_ptr<BlockHandle> RegisterTransientMemory(const idx_t size, BlockManager &block_manager);
+	//! Returns a new block of memory that is smaller than the block size setting.
+	virtual shared_ptr<BlockHandle> RegisterSmallMemory(const idx_t size);
+	virtual shared_ptr<BlockHandle> RegisterSmallMemory(MemoryTag tag, const idx_t size);
+
+	virtual DUCKDB_API Allocator &GetBufferAllocator();
+	virtual DUCKDB_API void ReserveMemory(idx_t size);
+	virtual DUCKDB_API void FreeReservedMemory(idx_t size);
+	virtual vector<MemoryInformation> GetMemoryUsageInfo() const = 0;
+	//! Set a new memory limit to the buffer manager, throws an exception if the new limit is too low and not enough
+	//! blocks can be evicted
+	virtual void SetMemoryLimit(idx_t limit = (idx_t)-1);
+	virtual void SetSwapLimit(optional_idx limit = optional_idx());
+
+	virtual vector<TemporaryFileInformation> GetTemporaryFiles();
+	virtual const string &GetTemporaryDirectory() const;
+	virtual void SetTemporaryDirectory(const string &new_dir);
+	virtual bool HasTemporaryDirectory() const;
+
+	//! Construct a managed buffer.
+	virtual unique_ptr<FileBuffer> ConstructManagedBuffer(idx_t size, idx_t block_header_size,
+	                                                      unique_ptr<FileBuffer> &&source,
+	                                                      FileBufferType type = FileBufferType::MANAGED_BUFFER);
+	//! Get the underlying buffer pool responsible for managing the buffers
+	virtual BufferPool &GetBufferPool() const;
+
+	virtual DatabaseInstance &GetDatabase() = 0;
+	// Static methods
+	DUCKDB_API static BufferManager &GetBufferManager(DatabaseInstance &db);
+	DUCKDB_API static const BufferManager &GetBufferManager(const DatabaseInstance &db);
+	DUCKDB_API static BufferManager &GetBufferManager(ClientContext &context);
+	DUCKDB_API static const BufferManager &GetBufferManager(const ClientContext &context);
+	DUCKDB_API static BufferManager &GetBufferManager(AttachedDatabase &db);
+
+	static idx_t GetAllocSize(const idx_t alloc_size) {
+		return AlignValue<idx_t, Storage::SECTOR_SIZE>(alloc_size);
+	}
+
+	//! Returns the maximum available memory for a given query
+	idx_t GetQueryMaxMemory() const;
+
+	//! Get the manager that assigns reservations for temporary memory, e.g., for query intermediates
+	virtual TemporaryMemoryManager &GetTemporaryMemoryManager();
+
+protected:
+	virtual void PurgeQueue(const BlockHandle &handle) = 0;
+	virtual void AddToEvictionQueue(shared_ptr<BlockHandle> &handle);
+	virtual void WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer);
+	virtual unique_ptr<FileBuffer> ReadTemporaryBuffer(MemoryTag tag, BlockHandle &block,
+	                                                   unique_ptr<FileBuffer> buffer);
+	virtual void DeleteTemporaryFile(BlockHandle &block);
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/buffer/block_handle.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/destroy_buffer_upon.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+enum class DestroyBufferUpon : uint8_t {
+	BLOCK = 0,    //! Destroy the data buffer upon destroying the associated BlockHandle (block can be evicted)
+	EVICTION = 1, //! Destroy the data buffer upon eviction to storage (destroy instead of evict)
+	UNPIN = 2     //! Destroy the data buffer upon unpin (destroyed immediately, not added to eviction queue)
+};
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class BlockManager;
+class BufferHandle;
+class BufferPool;
+class DatabaseInstance;
+
+enum class BlockState : uint8_t { BLOCK_UNLOADED = 0, BLOCK_LOADED = 1 };
+
+struct BufferPoolReservation {
+	MemoryTag tag;
+	idx_t size {0};
+	BufferPool &pool;
+
+	BufferPoolReservation(MemoryTag tag, BufferPool &pool);
+	BufferPoolReservation(const BufferPoolReservation &) = delete;
+	BufferPoolReservation &operator=(const BufferPoolReservation &) = delete;
+
+	BufferPoolReservation(BufferPoolReservation &&) noexcept;
+	BufferPoolReservation &operator=(BufferPoolReservation &&) noexcept;
+
+	~BufferPoolReservation();
+
+	void Resize(idx_t new_size);
+	void Merge(BufferPoolReservation src);
+};
+
+struct TempBufferPoolReservation : BufferPoolReservation {
+	TempBufferPoolReservation(MemoryTag tag, BufferPool &pool, idx_t size) : BufferPoolReservation(tag, pool) {
+		Resize(size);
+	}
+	TempBufferPoolReservation(TempBufferPoolReservation &&) = default;
+	~TempBufferPoolReservation() {
+		Resize(0);
+	}
+};
+
+using BlockLock = unique_lock<mutex>;
+
+class BlockHandle : public enable_shared_from_this<BlockHandle> {
+public:
+	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag);
+	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag, unique_ptr<FileBuffer> buffer,
+	            DestroyBufferUpon destroy_buffer_upon, idx_t block_size, BufferPoolReservation &&reservation);
+	~BlockHandle();
+
+	BlockManager &block_manager;
+
+public:
+	block_id_t BlockId() const {
+		return block_id;
+	}
+
+	idx_t EvictionSequenceNumber() const {
+		return eviction_seq_num;
+	}
+
+	idx_t NextEvictionSequenceNumber() {
+		return ++eviction_seq_num;
+	}
+
+	int32_t Readers() const {
+		return readers;
+	}
+	int32_t DecrementReaders() {
+		return --readers;
+	}
+
+	inline bool IsSwizzled() const {
+		return !unswizzled;
+	}
+
+	inline void SetSwizzling(const char *unswizzler) {
+		unswizzled = unswizzler;
+	}
+
+	MemoryTag GetMemoryTag() const {
+		return tag;
+	}
+
+	inline void SetDestroyBufferUpon(DestroyBufferUpon destroy_buffer_upon_p) {
+		destroy_buffer_upon = destroy_buffer_upon_p;
+	}
+
+	inline bool MustAddToEvictionQueue() const {
+		return destroy_buffer_upon != DestroyBufferUpon::UNPIN;
+	}
+
+	inline bool MustWriteToTemporaryFile() const {
+		return destroy_buffer_upon == DestroyBufferUpon::BLOCK;
+	}
+
+	inline idx_t GetMemoryUsage() const {
+		return memory_usage;
+	}
+
+	bool IsUnloaded() const {
+		return state == BlockState::BLOCK_UNLOADED;
+	}
+
+	void SetEvictionQueueIndex(const idx_t index) {
+		// can only be set once
+		D_ASSERT(eviction_queue_idx == DConstants::INVALID_INDEX);
+		// MANAGED_BUFFER only (at least, for now)
+		D_ASSERT(GetBufferType() == FileBufferType::MANAGED_BUFFER);
+		eviction_queue_idx = index;
+	}
+
+	idx_t GetEvictionQueueIndex() const {
+		return eviction_queue_idx;
+	}
+
+	FileBufferType GetBufferType() const {
+		return buffer_type;
+	}
+
+	BlockState GetState() const {
+		return state;
+	}
+
+	int64_t GetLRUTimestamp() const {
+		return lru_timestamp_msec;
+	}
+
+	void SetLRUTimestamp(int64_t timestamp_msec) {
+		lru_timestamp_msec = timestamp_msec;
+	}
+
+	BlockLock GetLock() {
+		return BlockLock(lock);
+	}
+
+	//! Gets a reference to the buffer - the lock must be held
+	unique_ptr<FileBuffer> &GetBuffer(BlockLock &l);
+
+	void ChangeMemoryUsage(BlockLock &l, int64_t delta);
+	BufferPoolReservation &GetMemoryCharge(BlockLock &l);
+	//! Merge a new memory reservation
+	void MergeMemoryReservation(BlockLock &, BufferPoolReservation reservation);
+	//! Resize the memory allocation
+	void ResizeMemory(BlockLock &, idx_t alloc_size);
+
+	//! Resize the actual buffer
+	void ResizeBuffer(BlockLock &, idx_t block_size, int64_t memory_delta);
+	BufferHandle Load(unique_ptr<FileBuffer> buffer = nullptr);
+	BufferHandle LoadFromBuffer(BlockLock &l, data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer,
+	                            BufferPoolReservation reservation);
+	unique_ptr<FileBuffer> UnloadAndTakeBlock(BlockLock &);
+	void Unload(BlockLock &);
+
+	//! Returns whether or not the block can be unloaded
+	//! Note that while this method does not require a lock, whether or not a block can be unloaded can change if the
+	//! lock is not held
+	bool CanUnload() const;
+
+	void ConvertToPersistent(BlockLock &, BlockHandle &new_block, unique_ptr<FileBuffer> new_buffer);
+
+private:
+	void VerifyMutex(unique_lock<mutex> &l) const;
+
+private:
+	//! The block-level lock
+	mutex lock;
+	//! Whether or not the block is loaded/unloaded
+	atomic<BlockState> state;
+	//! Amount of concurrent readers
+	atomic<int32_t> readers;
+	//! The block id of the block
+	const block_id_t block_id;
+	//! Memory tag
+	const MemoryTag tag;
+	//! File buffer type
+	const FileBufferType buffer_type;
+	//! Pointer to loaded data (if any)
+	unique_ptr<FileBuffer> buffer;
+	//! Internal eviction sequence number
+	atomic<idx_t> eviction_seq_num;
+	//! LRU timestamp (for age-based eviction)
+	atomic<int64_t> lru_timestamp_msec;
+	//! When to destroy the data buffer
+	atomic<DestroyBufferUpon> destroy_buffer_upon;
+	//! The memory usage of the block (when loaded). If we are pinning/loading
+	//! an unloaded block, this tells us how much memory to reserve.
+	atomic<idx_t> memory_usage;
+	//! Current memory reservation / usage
+	BufferPoolReservation memory_charge;
+	//! Does the block contain any memory pointers?
+	const char *unswizzled;
+	//! Index for eviction queue (FileBufferType::MANAGED_BUFFER only, for now)
+	atomic<idx_t> eviction_queue_idx;
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class CSVBufferHandle {
+public:
+	CSVBufferHandle(BufferHandle handle_p, idx_t actual_size_p, idx_t requested_size_p, const bool is_final_buffer_p,
+	                idx_t buffer_index_p)
+	    : handle(std::move(handle_p)), actual_size(actual_size_p), requested_size(requested_size_p),
+	      is_last_buffer(is_final_buffer_p), buffer_idx(buffer_index_p) {};
+	CSVBufferHandle() : actual_size(0), requested_size(0), is_last_buffer(false), buffer_idx(0) {};
+	~CSVBufferHandle() {
+	}
+	//! Handle created during allocation
+	BufferHandle handle;
+	const idx_t actual_size;
+	const idx_t requested_size;
+	const bool is_last_buffer;
+	const idx_t buffer_idx;
+	inline char *Ptr() {
+		return char_ptr_cast(handle.Ptr());
+	}
+};
+
+//! CSV Buffers are parts of a decompressed CSV File.
+//! For a decompressed file of 100Mb. With our Buffer size set to 32Mb, we would generate 4 buffers.
+//! One for the first 32Mb, second and third for the other 32Mb, and the last one with 4 Mb
+//! These buffers are actually used for sniffing and parsing!
+class CSVBuffer {
+public:
+	//! Constructor for Initial Buffer
+	CSVBuffer(ClientContext &context, idx_t buffer_size_p, CSVFileHandle &file_handle,
+	          const idx_t &global_csv_current_position);
+
+	//! Constructor for `Next()` Buffers
+	CSVBuffer(CSVFileHandle &file_handle, ClientContext &context, idx_t buffer_size, idx_t global_csv_current_position,
+	          idx_t buffer_idx);
+
+	//! Creates a new buffer with the next part of the CSV File
+	shared_ptr<CSVBuffer> Next(CSVFileHandle &file_handle, idx_t buffer_size, bool &has_seeked) const;
+
+	//! Gets the buffer actual size
+	idx_t GetBufferSize() const;
+
+	//! If this buffer is the last buffer of the CSV File
+	bool IsCSVFileLastBuffer() const;
+
+	//! Allocates internal buffer, sets 'block' and 'handle' variables.
+	void AllocateBuffer(idx_t buffer_size);
+
+	void Reload(CSVFileHandle &file_handle);
+	//! Wrapper for the Pin Function, if it can seek, it means that the buffer might have been destroyed, hence we must
+	//! Scan it from the disk file again.
+	shared_ptr<CSVBufferHandle> Pin(CSVFileHandle &file_handle, bool &has_seeked);
+	//! Wrapper for unpin
+	void Unpin();
+	char *Ptr() {
+		return char_ptr_cast(handle.Ptr());
+	}
+	bool IsUnloaded() const {
+		return block->IsUnloaded();
+	}
+
+	//! By default, we use CSV_BUFFER_SIZE to allocate each buffer
+	static constexpr idx_t ROWS_PER_BUFFER = 16;
+	static constexpr idx_t MIN_ROWS_PER_BUFFER = 4;
+
+	bool last_buffer = false;
+
+private:
+	ClientContext &context;
+	//! Actual size can be smaller than the buffer size in case we allocate it too optimistically.
+	idx_t actual_buffer_size;
+	idx_t requested_size;
+	//! Global position from the CSV File where this buffer starts
+	idx_t global_csv_start = 0;
+	//! If we can seek in the file or not.
+	bool can_seek;
+	//! If this file is being fed by a pipe.
+	bool is_pipe;
+	//! Buffer Index, used as a batch index for insertion-order preservation
+	idx_t buffer_idx = 0;
+	//! -------- Allocated Block ---------//
+	//! Block created in allocation
+	shared_ptr<BlockHandle> block;
+	BufferHandle handle;
+};
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/csv_option.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/scalar/strftime_format.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+enum class StrTimeSpecifier : uint8_t {
+	ABBREVIATED_WEEKDAY_NAME = 0,    // %a - Abbreviated weekday name. (Sun, Mon, ...)
+	FULL_WEEKDAY_NAME = 1,           // %A Full weekday name. (Sunday, Monday, ...)
+	WEEKDAY_DECIMAL = 2,             // %w - Weekday as a decimal number. (0, 1, ..., 6)
+	DAY_OF_MONTH_PADDED = 3,         // %d - Day of the month as a zero-padded decimal. (01, 02, ..., 31)
+	DAY_OF_MONTH = 4,                // %-d - Day of the month as a decimal number. (1, 2, ..., 30)
+	ABBREVIATED_MONTH_NAME = 5,      // %b - Abbreviated month name. (Jan, Feb, ..., Dec)
+	FULL_MONTH_NAME = 6,             // %B - Full month name. (January, February, ...)
+	MONTH_DECIMAL_PADDED = 7,        // %m - Month as a zero-padded decimal number. (01, 02, ..., 12)
+	MONTH_DECIMAL = 8,               // %-m - Month as a decimal number. (1, 2, ..., 12)
+	YEAR_WITHOUT_CENTURY_PADDED = 9, // %y - Year without century as a zero-padded decimal number. (00, 01, ..., 99)
+	YEAR_WITHOUT_CENTURY = 10,       // %-y - Year without century as a decimal number. (0, 1, ..., 99)
+	YEAR_DECIMAL = 11,               // %Y - Year with century as a decimal number. (2013, 2019 etc.)
+	HOUR_24_PADDED = 12,             // %H - Hour (24-hour clock) as a zero-padded decimal number. (00, 01, ..., 23)
+	HOUR_24_DECIMAL = 13,            // %-H - Hour (24-hour clock) as a decimal number. (0, 1, ..., 23)
+	HOUR_12_PADDED = 14,             // %I - Hour (12-hour clock) as a zero-padded decimal number. (01, 02, ..., 12)
+	HOUR_12_DECIMAL = 15,            // %-I - Hour (12-hour clock) as a decimal number. (1, 2, ... 12)
+	AM_PM = 16,                      // %p - Locale’s AM or PM. (AM, PM)
+	MINUTE_PADDED = 17,              // %M - Minute as a zero-padded decimal number. (00, 01, ..., 59)
+	MINUTE_DECIMAL = 18,             // %-M - Minute as a decimal number. (0, 1, ..., 59)
+	SECOND_PADDED = 19,              // %S - Second as a zero-padded decimal number. (00, 01, ..., 59)
+	SECOND_DECIMAL = 20,             // %-S - Second as a decimal number. (0, 1, ..., 59)
+	MICROSECOND_PADDED = 21,         // %f - Microsecond as a decimal number, zero-padded on the left. (000000 - 999999)
+	MILLISECOND_PADDED = 22,         // %g - Millisecond as a decimal number, zero-padded on the left. (000 - 999)
+	UTC_OFFSET = 23,                 // %z - UTC offset in the form +HHMM or -HHMM. ( )
+	TZ_NAME = 24,                    // %Z - Time zone name. ( )
+	DAY_OF_YEAR_PADDED = 25,         // %j - Day of the year as a zero-padded decimal number. (001, 002, ..., 366)
+	DAY_OF_YEAR_DECIMAL = 26,        // %-j - Day of the year as a decimal number. (1, 2, ..., 366)
+	WEEK_NUMBER_PADDED_SUN_FIRST =
+	    27, // %U - Week number of the year (Sunday as the first day of the week). All days in a new year preceding the
+	        // first Sunday are considered to be in week 0. (00, 01, ..., 53)
+	WEEK_NUMBER_PADDED_MON_FIRST =
+	    28, // %W - Week number of the year (Monday as the first day of the week). All days in a new year preceding the
+	        // first Monday are considered to be in week 0. (00, 01, ..., 53)
+	LOCALE_APPROPRIATE_DATE_AND_TIME =
+	    29, // %c - Locale’s appropriate date and time representation. (Mon Sep 30 07:06:05 2013)
+	LOCALE_APPROPRIATE_DATE = 30, // %x - Locale’s appropriate date representation. (09/30/13)
+	LOCALE_APPROPRIATE_TIME = 31, // %X - Locale’s appropriate time representation. (07:06:05)
+	NANOSECOND_PADDED = 32, // %n - Nanosecond as a decimal number, zero-padded on the left. (000000000 - 999999999)
+	// Python 3.6 ISO directives https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+	YEAR_ISO =
+	    33, // %G - ISO 8601 year with century representing the year that contains the greater part of the ISO week
+	WEEKDAY_ISO = 34,     // %u - ISO 8601 weekday as a decimal number where 1 is Monday (1..7)
+	WEEK_NUMBER_ISO = 35, // %V - ISO 8601 week as a decimal number with Monday as the first day of the week.
+	                      // Week 01 is the week containing Jan 4. (01..53)
+};
+
+struct StrTimeFormat {
+public:
+	virtual ~StrTimeFormat() {
+	}
+
+	DUCKDB_API static string ParseFormatSpecifier(const string &format_string, StrTimeFormat &format);
+
+	inline bool HasFormatSpecifier(StrTimeSpecifier s) const {
+		return std::find(specifiers.begin(), specifiers.end(), s) != specifiers.end();
+	}
+	//! If the string format is empty
+	DUCKDB_API bool Empty() const;
+
+	//! The full format specifier, for error messages
+	string format_specifier;
+
+protected:
+	//! The format specifiers
+	vector<StrTimeSpecifier> specifiers;
+	//! The literals that appear in between the format specifiers
+	//! The following must hold: literals.size() = specifiers.size() + 1
+	//! Format is literals[0], specifiers[0], literals[1], ..., specifiers[n - 1], literals[n]
+	vector<string> literals;
+	//! The constant size that appears in the format string
+	idx_t constant_size = 0;
+	//! The max numeric width of the specifier (if it is parsed as a number), or -1 if it is not a number
+	vector<int> numeric_width;
+
+protected:
+	void AddLiteral(string literal);
+	DUCKDB_API virtual void AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier);
+};
+
+struct StrfTimeFormat : public StrTimeFormat { // NOLINT: work-around bug in clang-tidy
+	DUCKDB_API idx_t GetLength(date_t date, dtime_t time, int32_t utc_offset, const char *tz_name);
+
+	DUCKDB_API void FormatStringNS(date_t date, int32_t data[8], const char *tz_name, char *target) const;
+	DUCKDB_API void FormatString(date_t date, int32_t data[8], const char *tz_name, char *target);
+	void FormatString(date_t date, dtime_t time, char *target);
+
+	DUCKDB_API static string Format(timestamp_t timestamp, const string &format);
+
+	DUCKDB_API void ConvertDateVector(Vector &input, Vector &result, idx_t count);
+	DUCKDB_API void ConvertTimestampVector(Vector &input, Vector &result, idx_t count);
+	DUCKDB_API void ConvertTimestampNSVector(Vector &input, Vector &result, idx_t count);
+
+protected:
+	//! The variable-length specifiers. To determine total string size, these need to be checked.
+	vector<StrTimeSpecifier> var_length_specifiers;
+	//! Whether or not the current specifier is a special "date" specifier (i.e. one that requires a date_t object to
+	//! generate)
+	vector<bool> is_date_specifier;
+
+protected:
+	DUCKDB_API void AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) override;
+	static idx_t GetSpecifierLength(StrTimeSpecifier specifier, date_t date, int32_t data[8], const char *tz_name);
+	idx_t GetLength(date_t date, int32_t data[8], const char *tz_name) const;
+
+	string_t ConvertTimestampValue(const timestamp_t &input, Vector &result) const;
+	string_t ConvertTimestampValue(const timestamp_ns_t &input, Vector &result) const;
+
+	char *WriteString(char *target, const string_t &str) const;
+	char *Write2(char *target, uint8_t value) const;
+	char *WritePadded2(char *target, uint32_t value) const;
+	char *WritePadded3(char *target, uint32_t value) const;
+	char *WritePadded(char *target, uint32_t value, size_t padding) const;
+	bool IsDateSpecifier(StrTimeSpecifier specifier);
+	char *WriteDateSpecifier(StrTimeSpecifier specifier, date_t date, char *target) const;
+	char *WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name, size_t tz_len,
+	                             char *target) const;
+};
+
+struct StrpTimeFormat : public StrTimeFormat { // NOLINT: work-around bug in clang-tidy
+public:
+	StrpTimeFormat();
+
+	//! Type-safe parsing argument
+	struct ParseResult {
+		int32_t data[8]; // year, month, day, hour, min, sec, ns, offset
+		string tz;
+		string error_message;
+		optional_idx error_position;
+
+		bool is_special;
+		date_t special;
+
+		int32_t GetMicros() const;
+
+		date_t ToDate();
+		dtime_t ToTime();
+		int64_t ToTimeNS();
+		timestamp_t ToTimestamp();
+		timestamp_ns_t ToTimestampNS();
+
+		bool TryToDate(date_t &result);
+		bool TryToTime(dtime_t &result);
+		bool TryToTimestamp(timestamp_t &result);
+		bool TryToTimestampNS(timestamp_ns_t &result);
+
+		DUCKDB_API string FormatError(string_t input, const string &format_specifier);
+	};
+
+public:
+	bool operator!=(const StrpTimeFormat &other) const {
+		return format_specifier != other.format_specifier;
+	}
+	DUCKDB_API static ParseResult Parse(const string &format, const string &text);
+	DUCKDB_API static bool TryParse(const string &format, const string &text, ParseResult &result);
+
+	DUCKDB_API bool Parse(string_t str, ParseResult &result, bool strict = false) const;
+
+	DUCKDB_API bool Parse(const char *data, size_t size, ParseResult &result, bool strict = false) const;
+
+	DUCKDB_API bool TryParseDate(const char *data, size_t size, date_t &result) const;
+	DUCKDB_API bool TryParseTimestamp(const char *data, size_t size, timestamp_t &result) const;
+	DUCKDB_API bool TryParseTimestampNS(const char *data, size_t size, timestamp_ns_t &result) const;
+
+	DUCKDB_API bool TryParseDate(string_t str, date_t &result, string &error_message) const;
+	DUCKDB_API bool TryParseTime(string_t str, dtime_t &result, string &error_message) const;
+	DUCKDB_API bool TryParseTimestamp(string_t str, timestamp_t &result, string &error_message) const;
+	DUCKDB_API bool TryParseTimestampNS(string_t str, timestamp_ns_t &result, string &error_message) const;
+
+	void Serialize(Serializer &serializer) const;
+	static StrpTimeFormat Deserialize(Deserializer &deserializer);
+
+protected:
+	static string FormatStrpTimeError(const string &input, optional_idx position);
+	DUCKDB_API void AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) override;
+	int NumericSpecifierWidth(StrTimeSpecifier specifier);
+	int32_t TryParseCollection(const char *data, idx_t &pos, idx_t size, const string_t collection[],
+	                           idx_t collection_count) const;
+
+private:
+	explicit StrpTimeFormat(const string &format_string);
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+enum class NewLineIdentifier : uint8_t {
+	SINGLE_N = 1, // \n
+	CARRY_ON = 2, // \r\n
+	NOT_SET = 3,
+	SINGLE_R = 4 // \r
+
+};
+
+class Serializer;
+class Deserializer;
+
+//! Wrapper for CSV Options that can be manually set by the user
+//! It is important to make this difference for options that can be automatically sniffed AND manually set.
+template <typename T>
+struct CSVOption { // NOLINT: work-around bug in clang-tidy
+public:
+	CSVOption(T value_p) : value(value_p) { // NOLINT: allow implicit conversion from value
+	}
+	CSVOption(T value_p, bool set_by_user_p) : set_by_user(set_by_user_p), value(value_p) {
+	}
+
+	CSVOption() {};
+
+	//! Sets value.
+	//! If by user it also toggles the set_by user flag
+	void Set(T value_p, bool by_user = true) {
+		D_ASSERT(!(by_user && set_by_user));
+		if (!set_by_user) {
+			// If it's not set by user we can change the value
+			value = value_p;
+			set_by_user = by_user;
+		}
+	}
+
+	//! Sets value.
+	//! If by user it also toggles the set_by user flag
+	void Set(CSVOption value_p, bool by_user = true) {
+		D_ASSERT(!(by_user && set_by_user));
+		if (!set_by_user) {
+			// If it's not set by user we can change the value
+			value = value_p;
+			set_by_user = by_user;
+		}
+	}
+
+	// this is due to a hacky implementation in the read csv relation
+	void ChangeSetByUserTrue() {
+		set_by_user = true;
+	}
+
+	bool operator==(const CSVOption &other) const {
+		return value == other.value;
+	}
+
+	bool operator!=(const CSVOption &other) const {
+		return value != other.value;
+	}
+
+	bool operator==(const T &other) const {
+		return value == other;
+	}
+
+	bool operator!=(const T &other) const {
+		return value != other;
+	}
+	//! Returns CSV Option value
+	inline const T &GetValue() const {
+		return value;
+	}
+	bool IsSetByUser() const {
+		return set_by_user;
+	}
+
+	//! Returns a formatted string with information regarding how this option was set
+	string FormatSet() const {
+		if (set_by_user) {
+			return "(Set By User)";
+		}
+		return "(Auto-Detected)";
+	}
+
+	//! Returns a formatted string with the actual value of this option
+	string FormatValue() const {
+		return FormatValueInternal(value);
+	}
+
+	//! Serializes CSV Option
+	DUCKDB_API void Serialize(Serializer &serializer) const;
+
+	//! Deserializes CSV Option
+	DUCKDB_API static CSVOption<T> Deserialize(Deserializer &deserializer);
+
+private:
+	//! If this option was manually set by the user
+	bool set_by_user = false;
+	T value;
+
+	//! --------------------------------------------------- //
+	//! Functions used to convert a value to a string
+	//! --------------------------------------------------- //
+
+	template <typename U>
+	std::string FormatValueInternal(const U &val) const {
+		throw InternalException("Type not accepted as CSV Option.");
+	}
+
+	std::string FormatValueInternal(const std::string &val) const {
+		return val;
+	}
+
+	std::string FormatValueInternal(const idx_t &val) const {
+		return to_string(val);
+	}
+
+	std::string FormatValueInternal(const char &val) const {
+		string char_val;
+		if (val == '\0') {
+			char_val = "(empty)";
+			return char_val;
+		}
+		char_val += val;
+		return char_val;
+	}
+
+	std::string FormatValueInternal(const NewLineIdentifier &val) const {
+		switch (val) {
+		case NewLineIdentifier::SINGLE_N:
+			return "\\n";
+		case NewLineIdentifier::SINGLE_R:
+			return "\\r";
+		case NewLineIdentifier::CARRY_ON:
+			return "\\r\\n";
+		case NewLineIdentifier::NOT_SET:
+			return "Single-Line File";
+		default:
+			throw InternalException("Invalid Newline Detected.");
+		}
+	}
+
+	std::string FormatValueInternal(const StrpTimeFormat &val) const {
+		return val.format_specifier;
+	}
+
+	std::string FormatValueInternal(const bool &val) const {
+		if (val) {
+			return "true";
+		}
+		return "false";
+	}
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/state_machine_options.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+//! Struct that holds the configuration of a CSV State Machine
+//! Basically which char, quote and escape were used to generate it.
+struct CSVStateMachineOptions {
+	CSVStateMachineOptions() {};
+	CSVStateMachineOptions(string delimiter_p, char quote_p, char escape_p, char comment_p,
+	                       NewLineIdentifier new_line_p, bool strict_mode_p)
+	    : delimiter(std::move(delimiter_p)), quote(quote_p), escape(escape_p), comment(comment_p), new_line(new_line_p),
+	      strict_mode(strict_mode_p) {};
+
+	//! Delimiter to separate columns within each line
+	CSVOption<string> delimiter {","};
+	//! Quote used for columns that contain reserved characters, e.g '
+	CSVOption<char> quote = '\"';
+	//! Escape character to escape quote character
+	CSVOption<char> escape = '\0';
+	//! Comment character to skip a line
+	CSVOption<char> comment = '\0';
+	//! New Line separator
+	CSVOption<NewLineIdentifier> new_line = NewLineIdentifier::NOT_SET;
+	//! How Strict the parser should be
+	CSVOption<bool> strict_mode = true;
+
+	bool operator==(const CSVStateMachineOptions &other) const {
+		return delimiter == other.delimiter && quote == other.quote && escape == other.escape &&
+		       new_line == other.new_line && comment == other.comment && strict_mode == other.strict_mode;
+	}
+};
+} // namespace duckdb
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/multi_file/multi_file_options.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/hive_partitioning.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/column/partitioned_column_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/fixed_size_map.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/perfect_map_set.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct PerfectHash {
+	std::size_t operator()(const idx_t &h) const {
+		return h;
+	}
+};
+
+struct PerfectEquality {
+	bool operator()(const idx_t &a, const idx_t &b) const {
+		return a == b;
+	}
+};
+
+template <typename T>
+using perfect_map_t = unordered_map<idx_t, T, PerfectHash, PerfectEquality>;
+
+using perfect_set_t = unordered_set<idx_t, PerfectHash, PerfectEquality>;
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+template <class T, bool is_const>
+class fixed_size_map_iterator; // NOLINT: match stl case
+
+//! Alternative to perfect_map_t when min/max keys are integral, small, and known
+template <class T>
+class fixed_size_map_t { // NOLINT: match stl case
+	friend class fixed_size_map_iterator<T, false>;
+	friend class fixed_size_map_iterator<T, true>;
+
+public:
+	using key_type = idx_t;
+	using mapped_type = T;
+	using occupied_mask = TemplatedValidityMask<uint8_t>;
+	using iterator = fixed_size_map_iterator<mapped_type, false>;
+	using const_iterator = fixed_size_map_iterator<mapped_type, true>;
+
+public:
+	explicit fixed_size_map_t(idx_t capacity_p = 0) : capacity(capacity_p) {
+		resize(capacity);
+	}
+
+	idx_t size() const { // NOLINT: match stl case
+		return count;
+	}
+
+	void resize(idx_t capacity_p) { // NOLINT: match stl case
+		capacity = capacity_p;
+		occupied = occupied_mask(capacity);
+		values = make_unsafe_uniq_array_uninitialized<mapped_type>(capacity + 1);
+		clear();
+	}
+
+	void clear() { // NOLINT: match stl case
+		count = 0;
+		occupied.SetAllInvalid(capacity);
+	}
+
+	mapped_type &operator[](const key_type &key) {
+		D_ASSERT(key < capacity);
+		count += 1 - occupied.RowIsValidUnsafe(key);
+		occupied.SetValidUnsafe(key);
+		return values[key];
+	}
+
+	const mapped_type &operator[](const key_type &key) const {
+		D_ASSERT(key < capacity);
+		return values[key];
+	}
+
+	iterator begin() { // NOLINT: match stl case
+		iterator result(*this, 0);
+		if (!occupied_mask::RowIsValid(occupied.GetValidityEntryUnsafe(0), 0)) {
+			++result;
+		}
+		return result;
+	}
+
+	const_iterator begin() const { // NOLINT: match stl case
+		const_iterator result(*this, 0);
+		if (!occupied_mask::RowIsValid(occupied.GetValidityEntryUnsafe(0), 0)) {
+			++result;
+		}
+		return result;
+	}
+
+	iterator end() { // NOLINT: match stl case
+		return iterator(*this, capacity);
+	}
+
+	const_iterator end() const { // NOLINT: match stl case
+		return const_iterator(*this, capacity);
+	}
+
+	iterator find(const key_type &index) { // NOLINT: match stl case
+		return occupied.RowIsValidUnsafe(index) ? iterator(*this, index) : end();
+	}
+
+	const_iterator find(const key_type &index) const { // NOLINT: match stl case
+		return occupied.RowIsValidUnsafe(index) ? const_iterator(*this, index) : end();
+	}
+
+private:
+	idx_t capacity;
+	idx_t count;
+
+	occupied_mask occupied;
+	unsafe_unique_array<mapped_type> values;
+};
+
+template <class T, bool is_const>
+class fixed_size_map_iterator { // NOLINT: match stl case
+public:
+	using key_type = idx_t;
+	using mapped_type = T;
+	using fixed_size_map_type = fixed_size_map_t<mapped_type>;
+	using map_type = typename std::conditional<is_const, const fixed_size_map_type, fixed_size_map_type>::type;
+	using occupied_mask = typename fixed_size_map_t<mapped_type>::occupied_mask;
+
+public:
+	fixed_size_map_iterator(map_type &map_p, key_type index) : map(map_p) {
+		occupied_mask::GetEntryIndex(index, entry_idx, idx_in_entry);
+	}
+
+	fixed_size_map_iterator &operator++() {
+		// Prefix increment
+		if (++idx_in_entry == occupied_mask::BITS_PER_VALUE) {
+			NextEntry();
+		}
+		// Loop until we find an occupied index, or until the end
+		auto end = map.end();
+		while (*this < end) {
+			const auto &entry = map.occupied.GetValidityEntryUnsafe(entry_idx);
+			if (entry == static_cast<uint8_t>(~occupied_mask::ValidityBuffer::MAX_ENTRY)) {
+				// Entire entry is unoccupied, skip
+				if (entry_idx == end.entry_idx) {
+					// This is the last entry
+					idx_in_entry = end.idx_in_entry;
+					break;
+				}
+				NextEntry();
+			} else {
+				// One or more occupied in entry, loop over it
+				const auto idx_to = entry_idx == end.entry_idx ? end.idx_in_entry : occupied_mask::BITS_PER_VALUE;
+				for (; idx_in_entry < idx_to; idx_in_entry++) {
+					if (map.occupied.RowIsValid(entry, idx_in_entry)) {
+						// We found an occupied index
+						return *this;
+					}
+				}
+				// We did not find an occupied index
+				if (*this != end) {
+					NextEntry();
+				}
+			}
+		}
+		return *this;
+	}
+
+	fixed_size_map_iterator operator++(int) {
+		fixed_size_map_iterator tmp = *this;
+		++(*this);
+		return tmp;
+	}
+
+	key_type GetKey() const {
+		return entry_idx * occupied_mask::BITS_PER_VALUE + idx_in_entry;
+	}
+
+	mapped_type &GetValue() {
+		return map.values[GetKey()];
+	}
+
+	const mapped_type &GetValue() const {
+		return map.values[GetKey()];
+	}
+
+	friend bool operator==(const fixed_size_map_iterator &a, const fixed_size_map_iterator &b) {
+		return a.entry_idx == b.entry_idx && a.idx_in_entry == b.idx_in_entry;
+	}
+
+	friend bool operator!=(const fixed_size_map_iterator &a, const fixed_size_map_iterator &b) {
+		return !(a == b);
+	}
+
+	friend bool operator<(const fixed_size_map_iterator &a, const fixed_size_map_iterator &b) {
+		if (a.entry_idx < b.entry_idx) {
+			return true;
+		}
+		if (a.entry_idx == b.entry_idx) {
+			return a.idx_in_entry < b.idx_in_entry;
+		}
+		return false;
+	}
+
+private:
+	void NextEntry() {
+		entry_idx++;
+		idx_in_entry = 0;
+	}
+
+private:
+	map_type &map;
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+};
+
+//! A helper functor so we can template functions to use either a perfect map or a fixed size map
+
+// LCOV_EXCL_START
+template <class T, bool fixed>
+struct TemplatedMapGetter {
+private:
+	using key_type = idx_t;
+	using mapped_type = T;
+	using fixed_size_map_type = fixed_size_map_t<mapped_type>;
+	using perfect_map_type = perfect_map_t<mapped_type>;
+	using map_type = typename std::conditional<fixed, fixed_size_map_type, perfect_map_type>::type;
+	using iterator = typename map_type::iterator;
+	using const_iterator = typename map_type::const_iterator;
+
+public:
+	static key_type GetKey(const iterator &it) {
+		return GetKeyInternal(it);
+	}
+
+	static key_type GetKey(const const_iterator &it) {
+		return GetKeyInternal(it);
+	}
+
+	static mapped_type &GetValue(iterator &it) {
+		return GetValueInternal(it);
+	}
+
+	static const mapped_type &GetValue(const const_iterator &it) {
+		return GetValueInternal(it);
+	}
+
+private:
+	// Down here we overload instead of templating to circumvent this error:
+	// "Explicit specialization of struct 'Functor<fixed>' in non-namespace scope"
+	// Alternatively, we could define these outside of TemplatedMapGetter
+	// However, then we no longer have access to the MAPPED_TYPE template and the code becomes unreadable
+	static key_type GetKeyInternal(const typename perfect_map_type::iterator &it) {
+		return it->first;
+	}
+
+	static key_type GetKeyInternal(const typename perfect_map_type::const_iterator &it) {
+		return it->first;
+	}
+
+	static mapped_type &GetValueInternal(typename perfect_map_type::iterator &it) {
+		return it->second;
+	}
+
+	static const mapped_type &GetValueInternal(const typename perfect_map_type::const_iterator &it) {
+		return it->second;
+	}
+
+	static key_type GetKeyInternal(const typename fixed_size_map_type::iterator &it) {
+		return it.GetKey();
+	}
+
+	static key_type GetKeyInternal(const typename fixed_size_map_type::const_iterator &it) {
+		return it.GetKey();
+	}
+
+	static mapped_type &GetValueInternal(typename fixed_size_map_type::iterator &it) {
+		return it.GetValue();
+	}
+
+	static const mapped_type &GetValueInternal(const typename fixed_size_map_type::const_iterator &it) {
+		return it.GetValue();
+	}
+};
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/column/column_data_allocator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+struct ChunkMetaData;
+struct VectorMetaData;
+
+struct BlockMetaData {
+	//! The underlying block handle
+	shared_ptr<BlockHandle> handle;
+	//! How much space is currently used within the block
+	uint32_t size;
+	//! How much space is available in the block
+	uint32_t capacity;
+
+	uint32_t Capacity();
+};
+
+class ColumnDataAllocator {
+public:
+	explicit ColumnDataAllocator(Allocator &allocator);
+	explicit ColumnDataAllocator(BufferManager &buffer_manager);
+	ColumnDataAllocator(ClientContext &context, ColumnDataAllocatorType allocator_type);
+	ColumnDataAllocator(ColumnDataAllocator &allocator);
+	~ColumnDataAllocator();
+
+	//! Returns an allocator object to allocate with. This returns the allocator in IN_MEMORY_ALLOCATOR, and a buffer
+	//! allocator in case of BUFFER_MANAGER_ALLOCATOR.
+	Allocator &GetAllocator();
+	//! Returns the buffer manager, if this is not an in-memory allocation.
+	BufferManager &GetBufferManager();
+	//! Returns the allocator type
+	ColumnDataAllocatorType GetType() {
+		return type;
+	}
+	void MakeShared() {
+		shared = true;
+	}
+	bool IsShared() const {
+		return shared;
+	}
+	idx_t BlockCount() const {
+		return blocks.size();
+	}
+	idx_t SizeInBytes() const {
+		idx_t total_size = 0;
+		for (const auto &block : blocks) {
+			total_size += block.size;
+		}
+		return total_size;
+	}
+	idx_t AllocationSize() const {
+		return allocated_size;
+	}
+	//! Sets the partition index of this tuple data collection
+	void SetPartitionIndex(idx_t index) {
+		D_ASSERT(!partition_index.IsValid());
+		D_ASSERT(blocks.empty() && allocated_data.empty());
+		partition_index = index;
+	}
+
+public:
+	void AllocateData(idx_t size, uint32_t &block_id, uint32_t &offset, ChunkManagementState *chunk_state);
+
+	void Initialize(ColumnDataAllocator &other);
+	void InitializeChunkState(ChunkManagementState &state, ChunkMetaData &meta_data);
+	data_ptr_t GetDataPointer(ChunkManagementState &state, uint32_t block_id, uint32_t offset);
+	void UnswizzlePointers(ChunkManagementState &state, Vector &result, idx_t v_offset, uint16_t count,
+	                       uint32_t block_id, uint32_t offset);
+
+	//! Prevents the block with the given id from being added to the eviction queue
+	void SetDestroyBufferUponUnpin(uint32_t block_id);
+
+private:
+	void AllocateEmptyBlock(idx_t size);
+	BufferHandle AllocateBlock(idx_t size);
+	BufferHandle Pin(uint32_t block_id);
+
+	bool HasBlocks() const {
+		return !blocks.empty();
+	}
+
+private:
+	void AllocateBuffer(idx_t size, uint32_t &block_id, uint32_t &offset, ChunkManagementState *chunk_state);
+	void AllocateMemory(idx_t size, uint32_t &block_id, uint32_t &offset, ChunkManagementState *chunk_state);
+	void AssignPointer(uint32_t &block_id, uint32_t &offset, data_ptr_t pointer);
+
+private:
+	ColumnDataAllocatorType type;
+	union {
+		//! The allocator object (if this is a IN_MEMORY_ALLOCATOR)
+		Allocator *allocator;
+		//! The buffer manager (if this is a BUFFER_MANAGER_ALLOCATOR)
+		BufferManager *buffer_manager;
+	} alloc;
+	//! The set of blocks used by the column data collection
+	vector<BlockMetaData> blocks;
+	//! The set of allocated data
+	vector<AllocatedData> allocated_data;
+	//! Whether this ColumnDataAllocator is shared across ColumnDataCollections that allocate in parallel
+	bool shared = false;
+	//! Lock used in case this ColumnDataAllocator is shared across threads
+	mutex lock;
+	//! Total allocated size
+	idx_t allocated_size = 0;
+	//! Partition index (optional, if partitioned)
+	optional_idx partition_index;
+};
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//! Local state for parallel partitioning
+struct PartitionedColumnDataAppendState {
+public:
+	PartitionedColumnDataAppendState() : partition_indices(LogicalType::UBIGINT) {
+	}
+
+public:
+	Vector partition_indices;
+	SelectionVector partition_sel;
+
+	static constexpr idx_t MAP_THRESHOLD = 256;
+	perfect_map_t<list_entry_t> partition_entries;
+	fixed_size_map_t<list_entry_t> fixed_partition_entries;
+
+	DataChunk slice_chunk;
+
+	vector<unique_ptr<DataChunk>> partition_buffers;
+	vector<unique_ptr<ColumnDataAppendState>> partition_append_states;
+
+public:
+	template <bool fixed>
+	typename std::conditional<fixed, fixed_size_map_t<list_entry_t>, perfect_map_t<list_entry_t>>::type &GetMap() {
+		throw NotImplementedException("PartitionedColumnDataAppendState::GetMap for boolean value");
+	}
+
+	optional_idx GetPartitionIndexIfSinglePartition(const bool use_fixed_size_map) {
+		optional_idx result;
+		if (use_fixed_size_map) {
+			if (fixed_partition_entries.size() == 1) {
+				result = fixed_partition_entries.begin().GetKey();
+			}
+		} else {
+			if (partition_entries.size() == 1) {
+				result = partition_entries.begin()->first;
+			}
+		}
+		return result;
+	}
+};
+
+template <>
+inline perfect_map_t<list_entry_t> &PartitionedColumnDataAppendState::GetMap<false>() {
+	return partition_entries;
+}
+
+template <>
+inline fixed_size_map_t<list_entry_t> &PartitionedColumnDataAppendState::GetMap<true>() {
+	return fixed_partition_entries;
+}
+
+enum class PartitionedColumnDataType : uint8_t {
+	INVALID,
+	//! Radix partitioning on a hash column
+	RADIX,
+	//! Hive-style multi-field partitioning
+	HIVE
+};
+
+//! Shared allocators for parallel partitioning
+struct PartitionColumnDataAllocators {
+	mutex lock;
+	vector<shared_ptr<ColumnDataAllocator>> allocators;
+};
+
+//! PartitionedColumnData represents partitioned columnar data, which serves as an interface for different types of
+//! partitioning, e.g., radix, hive
+class PartitionedColumnData {
+public:
+	unique_ptr<PartitionedColumnData> CreateShared();
+	virtual ~PartitionedColumnData();
+
+public:
+	//! Initializes a local state for parallel partitioning that can be merged into this PartitionedColumnData
+	void InitializeAppendState(PartitionedColumnDataAppendState &state) const;
+	//! Appends a DataChunk to this PartitionedColumnData
+	void Append(PartitionedColumnDataAppendState &state, DataChunk &input);
+	//! Flushes any remaining data in the append state into this PartitionedColumnData
+	void FlushAppendState(PartitionedColumnDataAppendState &state);
+	//! Combine another PartitionedColumnData into this PartitionedColumnData
+	void Combine(PartitionedColumnData &other);
+	//! Get the partitions in this PartitionedColumnData
+	vector<unique_ptr<ColumnDataCollection>> &GetPartitions();
+
+protected:
+	//===--------------------------------------------------------------------===//
+	// Partitioning type implementation interface
+	//===--------------------------------------------------------------------===//
+	//! Size of the buffers in the append states for this type of partitioning (default 128)
+	virtual idx_t BufferSize() const {
+		return MinValue<idx_t>(128, STANDARD_VECTOR_SIZE);
+	}
+	//! Initialize a PartitionedColumnDataAppendState for this type of partitioning (optional)
+	virtual void InitializeAppendStateInternal(PartitionedColumnDataAppendState &state) const {
+	}
+	//! Compute the partition indices for this type of partitioning for the input DataChunk and store them in the
+	//! `partition_data` of the local state. If this type creates partitions on the fly (for, e.g., hive), this
+	//! function is also in charge of creating new partitions and mapping the input data to a partition index
+	virtual void ComputePartitionIndices(PartitionedColumnDataAppendState &state, DataChunk &input) {
+		throw NotImplementedException("ComputePartitionIndices for this type of PartitionedColumnData");
+	}
+	//!
+
+	//! Maximum partition index (optional)
+	virtual idx_t MaxPartitionIndex() const {
+		return DConstants::INVALID_INDEX;
+	}
+
+protected:
+	//! PartitionedColumnData can only be instantiated by derived classes
+	PartitionedColumnData(PartitionedColumnDataType type, ClientContext &context, vector<LogicalType> types);
+	PartitionedColumnData(const PartitionedColumnData &other);
+
+	//! If the buffer is half full, we append to the partition
+	inline idx_t HalfBufferSize() const {
+		D_ASSERT(IsPowerOfTwo(BufferSize()));
+		return BufferSize() / 2;
+	}
+	//! Create a new shared allocator
+	void CreateAllocator();
+	//! Whether to use fixed size map or regular map
+	bool UseFixedSizeMap() const;
+	//! Builds a selection vector in the Append state for the partitions
+	//! - returns true if everything belongs to the same partition - stores partition index in single_partition_idx
+	void BuildPartitionSel(PartitionedColumnDataAppendState &state, const idx_t append_count) const;
+	template <bool fixed>
+	static void BuildPartitionSel(PartitionedColumnDataAppendState &state, const idx_t append_count);
+	//! Appends a DataChunk to this PartitionedColumnData
+	template <bool fixed>
+	void AppendInternal(PartitionedColumnDataAppendState &state, DataChunk &input);
+	//! Create a collection for a specific a partition
+	unique_ptr<ColumnDataCollection> CreatePartitionCollection(idx_t partition_index) const {
+		return make_uniq<ColumnDataCollection>(allocators->allocators[partition_index], types);
+	}
+	//! Create a DataChunk used for buffering appends to the partition
+	unique_ptr<DataChunk> CreatePartitionBuffer() const;
+
+protected:
+	PartitionedColumnDataType type;
+	ClientContext &context;
+	vector<LogicalType> types;
+
+	mutex lock;
+	shared_ptr<PartitionColumnDataAllocators> allocators;
+	vector<unique_ptr<ColumnDataCollection>> partitions;
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/expression_executor.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+class Allocator;
+class ExecutionContext;
+
+//! ExpressionExecutor is responsible for executing a set of expressions and storing the result in a data chunk
+class ExpressionExecutor {
+	friend class BoundIndex;
+
+public:
+	DUCKDB_API explicit ExpressionExecutor(ClientContext &context);
+	DUCKDB_API ExpressionExecutor(ClientContext &context, const Expression *expression);
+	DUCKDB_API ExpressionExecutor(ClientContext &context, const Expression &expression);
+	DUCKDB_API ExpressionExecutor(ClientContext &context, const vector<unique_ptr<Expression>> &expressions);
+	ExpressionExecutor(ExpressionExecutor &&) = delete;
+
+	//! The expressions of the executor
+	vector<const Expression *> expressions;
+	//! The data chunk of the current physical operator, used to resolve
+	//! column references and determines the output cardinality
+	DataChunk *chunk = nullptr;
+
+public:
+	bool HasContext();
+	ClientContext &GetContext();
+	Allocator &GetAllocator();
+
+	//! Add an expression to the set of to-be-executed expressions of the executor
+	DUCKDB_API void AddExpression(const Expression &expr);
+	void ClearExpressions();
+
+	//! Execute the set of expressions with the given input chunk and store the result in the output chunk
+	DUCKDB_API void Execute(DataChunk *input, DataChunk &result);
+	inline void Execute(DataChunk &input, DataChunk &result) {
+		Execute(&input, result);
+	}
+	inline void Execute(DataChunk &result) {
+		Execute(nullptr, result);
+	}
+
+	//! Execute the ExpressionExecutor and put the result in the result vector; this should only be used for expression
+	//! executors with a single expression
+	DUCKDB_API void ExecuteExpression(DataChunk &input, Vector &result);
+	//! Execute the ExpressionExecutor and put the result in the result vector; this should only be used for expression
+	//! executors with a single expression
+	DUCKDB_API void ExecuteExpression(Vector &result);
+	//! Execute the ExpressionExecutor and generate a selection vector from all true values in the result; this should
+	//! only be used with a single boolean expression
+	DUCKDB_API idx_t SelectExpression(DataChunk &input, SelectionVector &sel);
+
+	DUCKDB_API idx_t SelectExpression(DataChunk &input, SelectionVector &result_sel,
+	                                  optional_ptr<SelectionVector> current_sel, idx_t current_count);
+
+	//! Execute the expression with index `expr_idx` and store the result in the result vector
+	DUCKDB_API void ExecuteExpression(idx_t expr_idx, Vector &result);
+	//! Evaluate a scalar expression and fold it into a single value
+	DUCKDB_API static Value EvaluateScalar(ClientContext &context, const Expression &expr,
+	                                       bool allow_unfoldable = false);
+	//! Try to evaluate a scalar expression and fold it into a single value, returns false if an exception is thrown
+	DUCKDB_API static bool TryEvaluateScalar(ClientContext &context, const Expression &expr, Value &result);
+
+	//! Initialize the state of a given expression
+	static unique_ptr<ExpressionState> InitializeState(const Expression &expr, ExpressionExecutorState &state);
+
+	inline void SetChunk(DataChunk *chunk) {
+		this->chunk = chunk;
+	}
+	inline void SetChunk(DataChunk &chunk) {
+		SetChunk(&chunk);
+	}
+
+	DUCKDB_API vector<unique_ptr<ExpressionExecutorState>> &GetStates();
+
+protected:
+	void Initialize(const Expression &expr, ExpressionExecutorState &state);
+
+	static unique_ptr<ExpressionState> InitializeState(const BoundReferenceExpression &expr,
+	                                                   ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundBetweenExpression &expr,
+	                                                   ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundCaseExpression &expr, ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundCastExpression &expr, ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundComparisonExpression &expr,
+	                                                   ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundConjunctionExpression &expr,
+	                                                   ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundConstantExpression &expr,
+	                                                   ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundFunctionExpression &expr,
+	                                                   ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundOperatorExpression &expr,
+	                                                   ExpressionExecutorState &state);
+	static unique_ptr<ExpressionState> InitializeState(const BoundParameterExpression &expr,
+	                                                   ExpressionExecutorState &state);
+
+	void Execute(const Expression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+
+	void Execute(const BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+	void Execute(const BoundCaseExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+	void Execute(const BoundCastExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+
+	void Execute(const BoundComparisonExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+	void Execute(const BoundConjunctionExpression &expr, ExpressionState *state, const SelectionVector *sel,
+	             idx_t count, Vector &result);
+	void Execute(const BoundConstantExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+	void Execute(const BoundFunctionExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+	void Execute(const BoundOperatorExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+	void Execute(const BoundParameterExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+	void Execute(const BoundReferenceExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             Vector &result);
+
+	//! Execute the (boolean-returning) expression and generate a selection vector with all entries that are "true" in
+	//! the result
+	idx_t Select(const Expression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             SelectionVector *true_sel, SelectionVector *false_sel);
+	idx_t DefaultSelect(const Expression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	                    SelectionVector *true_sel, SelectionVector *false_sel);
+
+	idx_t Select(const BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             SelectionVector *true_sel, SelectionVector *false_sel);
+	idx_t Select(const BoundComparisonExpression &expr, ExpressionState *state, const SelectionVector *sel, idx_t count,
+	             SelectionVector *true_sel, SelectionVector *false_sel);
+	idx_t Select(const BoundConjunctionExpression &expr, ExpressionState *state, const SelectionVector *sel,
+	             idx_t count, SelectionVector *true_sel, SelectionVector *false_sel);
+
+	//! Verify that the output of a step in the ExpressionExecutor is correct
+	void Verify(const Expression &expr, Vector &result, idx_t count);
+
+	void FillSwitch(Vector &vector, Vector &result, const SelectionVector &sel, sel_t count);
+
+private:
+	//! Client context
+	optional_ptr<ClientContext> context;
+	//! The states of the expression executor; this holds any intermediates and temporary states of expressions
+	vector<unique_ptr<ExpressionExecutorState>> states;
+	//! The vector verification (debug setting)
+	DebugVectorVerification debug_vector_verification = DebugVectorVerification::NONE;
+
+private:
+	// it is possible to create an expression executor without a ClientContext - but it should be avoided
+	DUCKDB_API ExpressionExecutor();
+	DUCKDB_API explicit ExpressionExecutor(const vector<unique_ptr<Expression>> &exprs);
+};
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/filter_combiner.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/filter/constant_filter.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+class ConstantFilter : public TableFilter {
+public:
+	static constexpr const TableFilterType TYPE = TableFilterType::CONSTANT_COMPARISON;
+
+public:
+	ConstantFilter(ExpressionType comparison_type, Value constant);
+
+	//! The comparison type (e.g. COMPARE_EQUAL, COMPARE_GREATERTHAN, COMPARE_LESSTHAN, ...)
+	ExpressionType comparison_type;
+	//! The constant value to filter on
+	Value constant;
+
+public:
+	bool Compare(const Value &value) const;
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
+	string ToString(const string &column_name) const override;
+	bool Equals(const TableFilter &other) const override;
+	unique_ptr<TableFilter> Copy() const override;
+	unique_ptr<Expression> ToExpression(const Expression &column) const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<TableFilter> Deserialize(Deserializer &deserializer);
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/data_table.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/index_constraint_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Index Constraint Types
+//===--------------------------------------------------------------------===//
+enum class IndexConstraintType : uint8_t {
+	NONE = 0,    // index is an index don't built to any constraint
+	UNIQUE = 1,  // index is an index built to enforce a UNIQUE constraint
+	PRIMARY = 2, // index is an index built to enforce a PRIMARY KEY constraint
+	FOREIGN = 3  // index is an index built to enforce a FOREIGN KEY constraint
+};
+
+//===--------------------------------------------------------------------===//
+// Index Types
+//===--------------------------------------------------------------------===//
+// NOTE: deprecated. Still necessary to read older duckdb files.
+enum class DeprecatedIndexType : uint8_t {
+	INVALID = 0,    // invalid index type
+	ART = 1,        // Adaptive Radix Tree
+	EXTENSION = 100 // Extension index
+};
+
+} // namespace duckdb
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/index.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class Index;
+
+class ConflictInfo {
+public:
+	explicit ConflictInfo(const unordered_set<column_t> &column_ids, bool only_check_unique = true)
+	    : column_ids(column_ids), only_check_unique(only_check_unique) {
+	}
+	const unordered_set<column_t> &column_ids;
+
+public:
+	bool ConflictTargetMatches(Index &index) const;
+
+public:
+	bool only_check_unique = true;
+};
+
+} // namespace duckdb
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table_storage_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/index_storage_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//! Information to serialize a FixedSizeAllocator, which holds the index data
+struct FixedSizeAllocatorInfo {
+	idx_t segment_size;
+	vector<idx_t> buffer_ids;
+	vector<BlockPointer> block_pointers;
+	vector<idx_t> segment_counts;
+	vector<idx_t> allocation_sizes;
+	vector<idx_t> buffers_with_free_space;
+
+	void Serialize(Serializer &serializer) const;
+	static FixedSizeAllocatorInfo Deserialize(Deserializer &deserializer);
+};
+
+//! Information to serialize an index buffer to the WAL
+struct IndexBufferInfo {
+	IndexBufferInfo(data_ptr_t buffer_ptr, const idx_t allocation_size)
+	    : buffer_ptr(buffer_ptr), allocation_size(allocation_size) {
+	}
+
+	data_ptr_t buffer_ptr;
+	idx_t allocation_size;
+};
+
+//! Index (de)serialization information.
+struct IndexStorageInfo {
+	IndexStorageInfo() {};
+	explicit IndexStorageInfo(const string &name) : name(name) {};
+
+	//! The name.
+	string name;
+	//! The storage root.
+	idx_t root;
+	//! Any index specialization can provide additional key-Value settings via this map.
+	case_insensitive_map_t<Value> options;
+	//! Serialization information for fixed-size allocator memory.
+	vector<FixedSizeAllocatorInfo> allocator_infos;
+
+	//! Contains all buffer pointers and their allocation size for serializing to the WAL.
+	//! First dimension: All fixed-size allocators.
+	//! Second dimension: The buffers of each fixed-size allocator.
+	vector<vector<IndexBufferInfo>> buffers;
+
+	//! The root block pointer of the index. Necessary to support older storage files.
+	BlockPointer root_block_ptr;
+
+	//! Returns true, if IndexStorageInfo holds information to deserialize an index.
+	//! Note that the name can be misleading - any index that is empty (no nodes, etc.) might
+	//! also have neither a root_block_ptr nor allocator_infos.
+	//! Ensure that your index constructor initializes an empty index correctly without the
+	//! need for these fields.
+	bool IsValid() const {
+		return root_block_ptr.IsValid() || !allocator_infos.empty();
+	}
+
+	void Serialize(Serializer &serializer) const;
+	static IndexStorageInfo Deserialize(Deserializer &deserializer);
+};
+
+//! Additional index information for tables
+struct IndexInfo {
+	bool is_unique;
+	bool is_primary;
+	bool is_foreign;
+	unordered_set<column_t> column_set;
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//! Column segment information
+struct ColumnSegmentInfo {
+	idx_t row_group_index;
+	idx_t column_id;
+	string column_path;
+	idx_t segment_idx;
+	string segment_type;
+	idx_t segment_start;
+	idx_t segment_count;
+	string compression_type;
+	string segment_stats;
+	bool has_updates;
+	bool persistent;
+	block_id_t block_id;
+	vector<block_id_t> additional_blocks;
+	idx_t block_offset;
+	string segment_info;
+};
+
+//! Table storage information
+class TableStorageInfo {
+public:
+	//! The (estimated) cardinality of the table
+	optional_idx cardinality;
+	//! Info of the indexes of a table
+	vector<IndexInfo> index_info;
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class ClientContext;
+class TableIOManager;
+class Transaction;
+class ConflictManager;
+
+struct IndexLock;
+struct IndexScanState;
+
+//! The index is an abstract base class that serves as the basis for indexes
+class Index {
+protected:
+	Index(const vector<column_t> &column_ids, TableIOManager &table_io_manager, AttachedDatabase &db);
+
+	//! The logical column ids of the indexed table
+	vector<column_t> column_ids;
+	//! Unordered set of column_ids used by the index
+	unordered_set<column_t> column_id_set;
+
+public:
+	//! Associated table io manager
+	TableIOManager &table_io_manager;
+	//! Attached database instance
+	AttachedDatabase &db;
+
+public:
+	virtual ~Index() = default;
+
+	//! Returns true if the index is a bound index, and false otherwise
+	virtual bool IsBound() const = 0;
+
+	//! The index type (ART, B+-tree, Skip-List, ...)
+	virtual const string &GetIndexType() const = 0;
+
+	//! The name of the index
+	virtual const string &GetIndexName() const = 0;
+
+	//! The index constraint type
+	virtual IndexConstraintType GetConstraintType() const = 0;
+
+	//! Returns unique flag
+	bool IsUnique() const {
+		auto type = GetConstraintType();
+		return type == IndexConstraintType::UNIQUE || type == IndexConstraintType::PRIMARY;
+	}
+
+	//! Returns primary key flag
+	bool IsPrimary() const {
+		auto index_constraint_type = GetConstraintType();
+		return (index_constraint_type == IndexConstraintType::PRIMARY);
+	}
+
+	//! Returns foreign key flag
+	bool IsForeign() const {
+		auto index_constraint_type = GetConstraintType();
+		return (index_constraint_type == IndexConstraintType::FOREIGN);
+	}
+
+	const vector<column_t> &GetColumnIds() const {
+		return column_ids;
+	}
+
+	const unordered_set<column_t> &GetColumnIdSet() const {
+		return column_id_set;
+	}
+
+	// All indexes can be dropped, even if they are unbound
+	virtual void CommitDrop() = 0;
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/statistics/column_statistics.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/statistics/distinct_statistics.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/hyperloglog.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/bit_utils.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct CountZeros {};
+
+template <>
+struct CountZeros<uint64_t> {
+	// see here: https://en.wikipedia.org/wiki/De_Bruijn_sequence
+	inline static idx_t Leading(const uint64_t value_in) {
+		if (!value_in) {
+			return 64;
+		}
+
+		uint64_t value = value_in;
+
+		constexpr uint64_t index64msb[] = {0,  47, 1,  56, 48, 27, 2,  60, 57, 49, 41, 37, 28, 16, 3,  61,
+		                                   54, 58, 35, 52, 50, 42, 21, 44, 38, 32, 29, 23, 17, 11, 4,  62,
+		                                   46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43, 31, 22, 10, 45,
+		                                   25, 39, 14, 33, 19, 30, 9,  24, 13, 18, 8,  12, 7,  6,  5,  63};
+
+		constexpr uint64_t debruijn64msb = 0X03F79D71B4CB0A89;
+
+		value |= value >> 1;
+		value |= value >> 2;
+		value |= value >> 4;
+		value |= value >> 8;
+		value |= value >> 16;
+		value |= value >> 32;
+		auto result = 63 - index64msb[(value * debruijn64msb) >> 58];
+#ifdef __clang__
+		D_ASSERT(result == static_cast<uint64_t>(__builtin_clzl(value_in)));
+#endif
+		return result;
+	}
+	inline static idx_t Trailing(uint64_t value_in) {
+		if (!value_in) {
+			return 64;
+		}
+		uint64_t value = value_in;
+
+		constexpr uint64_t index64lsb[] = {63, 0,  58, 1,  59, 47, 53, 2,  60, 39, 48, 27, 54, 33, 42, 3,
+		                                   61, 51, 37, 40, 49, 18, 28, 20, 55, 30, 34, 11, 43, 14, 22, 4,
+		                                   62, 57, 46, 52, 38, 26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21,
+		                                   56, 45, 25, 31, 35, 16, 9,  12, 44, 24, 15, 8,  23, 7,  6,  5};
+		constexpr uint64_t debruijn64lsb = 0x07EDD5E59A4E28C2ULL;
+		auto result = index64lsb[((value & -value) * debruijn64lsb) >> 58];
+#ifdef __clang__
+		D_ASSERT(result == static_cast<uint64_t>(__builtin_ctzl(value_in)));
+#endif
+		return result;
+	}
+};
+
+template <>
+struct CountZeros<uint32_t> {
+	inline static idx_t Leading(uint32_t value) {
+		return CountZeros<uint64_t>::Leading(static_cast<uint64_t>(value)) - 32;
+	}
+	inline static idx_t Trailing(uint32_t value) {
+		return CountZeros<uint64_t>::Trailing(static_cast<uint64_t>(value));
+	}
+};
+
+template <>
+struct CountZeros<hugeint_t> {
+	inline static idx_t Leading(hugeint_t value) {
+		const uint64_t upper = static_cast<uint64_t>(value.upper);
+		const uint64_t lower = value.lower;
+
+		if (upper) {
+			return CountZeros<uint64_t>::Leading(upper);
+		} else if (lower) {
+			return 64 + CountZeros<uint64_t>::Leading(lower);
+		} else {
+			return 128;
+		}
+	}
+
+	inline static idx_t Trailing(hugeint_t value) {
+		const uint64_t upper = static_cast<uint64_t>(value.upper);
+		const uint64_t lower = value.lower;
+
+		if (lower) {
+			return CountZeros<uint64_t>::Trailing(lower);
+		} else if (upper) {
+			return 64 + CountZeros<uint64_t>::Trailing(upper);
+		} else {
+			return 128;
+		}
+	}
+};
+
+template <>
+struct CountZeros<uhugeint_t> {
+	inline static idx_t Leading(uhugeint_t value) {
+		const uint64_t upper = static_cast<uint64_t>(value.upper);
+		const uint64_t lower = value.lower;
+
+		if (upper) {
+			return CountZeros<uint64_t>::Leading(upper);
+		} else if (lower) {
+			return 64 + CountZeros<uint64_t>::Leading(lower);
+		} else {
+			return 128;
+		}
+	}
+
+	inline static idx_t Trailing(uhugeint_t value) {
+		const uint64_t upper = static_cast<uint64_t>(value.upper);
+		const uint64_t lower = value.lower;
+
+		if (lower) {
+			return CountZeros<uint64_t>::Trailing(lower);
+		} else if (upper) {
+			return 64 + CountZeros<uint64_t>::Trailing(upper);
+		} else {
+			return 128;
+		}
+	}
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/algorithm.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+#include <algorithm>
+#include <cmath>
+
+
+namespace duckdb {
+
+enum class HLLStorageType : uint8_t {
+	HLL_V1 = 1, //! Redis HLL
+	HLL_V2 = 2, //! Our own implementation
+};
+
+class Serializer;
+class Deserializer;
+
+//! Algorithms from
+//! "New cardinality estimation algorithms for HyperLogLog sketches"
+//! Otmar Ertl, arXiv:1702.01284
+class HyperLogLog {
+public:
+	static constexpr idx_t P = 6;
+	static constexpr idx_t Q = 64 - P;
+	static constexpr idx_t M = 1 << P;
+	static constexpr double ALPHA = 0.721347520444481703680; // 1 / (2 log(2))
+
+	static double GetErrorRate() {
+		return std::sqrt(PI / 2.0) / sqrt(M);
+	}
+
+public:
+	HyperLogLog() {
+		memset(k, 0, sizeof(k));
+	}
+
+	//! Algorithm 1
+	inline void InsertElement(hash_t h) {
+		const auto i = h & ((1 << P) - 1);
+		h >>= P;
+		h |= hash_t(1) << Q;
+		const uint8_t z = UnsafeNumericCast<uint8_t>(CountZeros<hash_t>::Trailing(h) + 1);
+		Update(i, z);
+	}
+
+	inline void Update(const idx_t &i, const uint8_t &z) {
+		k[i] = MaxValue<uint8_t>(k[i], z);
+	}
+
+	inline uint8_t GetRegister(const idx_t &i) const {
+		return k[i];
+	}
+
+	idx_t Count() const;
+
+	//! Algorithm 2
+	void Merge(const HyperLogLog &other);
+
+public:
+	//! Add data to this HLL
+	void Update(Vector &input, Vector &hashes, idx_t count);
+	//! Get copy of the HLL
+	unique_ptr<HyperLogLog> Copy() const;
+
+	void Serialize(Serializer &serializer) const;
+	static unique_ptr<HyperLogLog> Deserialize(Deserializer &deserializer);
+
+	//! Algorithm 4
+	void ExtractCounts(uint32_t *c) const;
+	//! Algorithm 6
+	static int64_t EstimateCardinality(uint32_t *c);
+
+private:
+	uint8_t k[M];
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class Vector;
+class Serializer;
+class Deserializer;
+
+class DistinctStatistics {
+public:
+	DistinctStatistics();
+	explicit DistinctStatistics(unique_ptr<HyperLogLog> log, idx_t sample_count, idx_t total_count);
+
+	//! The HLL of the table
+	unique_ptr<HyperLogLog> log;
+	//! How many values have been sampled into the HLL
+	atomic<idx_t> sample_count;
+	//! How many values have been inserted (before sampling)
+	atomic<idx_t> total_count;
+
+public:
+	void Merge(const DistinctStatistics &other);
+
+	unique_ptr<DistinctStatistics> Copy() const;
+
+	void UpdateSample(Vector &new_data, idx_t count, Vector &hashes);
+	void Update(Vector &new_data, idx_t count, Vector &hashes);
+
+	string ToString() const;
+	idx_t GetCount() const;
+
+	static bool TypeIsSupported(const LogicalType &type);
+
+	void Serialize(Serializer &serializer) const;
+	static unique_ptr<DistinctStatistics> Deserialize(Deserializer &deserializer);
+
+private:
+	void UpdateInternal(Vector &update, idx_t count, Vector &hashes);
+
+private:
+	//! For distinct statistics we sample the input to speed up insertions
+	static constexpr double BASE_SAMPLE_RATE = 0.1;
+	//! For integers, we sample more: likely to be join keys (and hashing is cheaper than, e.g., strings)
+	static constexpr double INTEGRAL_SAMPLE_RATE = 0.3;
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class Serializer;
+
+class ColumnStatistics {
+public:
+	explicit ColumnStatistics(BaseStatistics stats_p);
+	ColumnStatistics(BaseStatistics stats_p, unique_ptr<DistinctStatistics> distinct_stats_p);
+
+public:
+	static shared_ptr<ColumnStatistics> CreateEmptyStats(const LogicalType &type);
+
+	void Merge(ColumnStatistics &other);
+
+	void UpdateDistinctStatistics(Vector &v, idx_t count, Vector &hashes);
+
+	BaseStatistics &Statistics();
+
+	bool HasDistinctStats();
+	DistinctStatistics &DistinctStats();
+	void SetDistinct(unique_ptr<DistinctStatistics> distinct_stats);
+
+	shared_ptr<ColumnStatistics> Copy() const;
+
+	void Serialize(Serializer &serializer) const;
+	static shared_ptr<ColumnStatistics> Deserialize(Deserializer &source);
+
+private:
+	BaseStatistics stats;
+	//! The approximate count distinct stats of the column
+	unique_ptr<DistinctStatistics> distinct_stats;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/column_segment.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/scan_vector_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+enum class ScanVectorType { SCAN_ENTIRE_VECTOR, SCAN_FLAT_VECTOR };
+
+enum class ScanVectorMode { REGULAR_SCAN, SCAN_COMMITTED, SCAN_COMMITTED_NO_UPDATES };
+
+} // namespace duckdb
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/compression_function.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+class DatabaseInstance;
+class ColumnData;
+struct ColumnDataCheckpointData;
+class ColumnSegment;
+class SegmentStatistics;
+class TableFilter;
+struct TableFilterState;
+struct ColumnSegmentState;
+
+struct ColumnFetchState;
+struct ColumnScanState;
+struct PrefetchState;
+struct SegmentScanState;
+
+class CompressionInfo {
+public:
+	explicit CompressionInfo(BlockManager &block_manager) : block_manager(block_manager) {
+	}
+
+public:
+	//! The size below which the segment is compacted on flushing.
+	idx_t GetCompactionFlushLimit() const {
+		return block_manager.GetBlockSize() / 5 * 4;
+	}
+	//! The block size for blocks using this compression.
+	idx_t GetBlockSize() const {
+		return block_manager.GetBlockSize();
+	}
+
+	//! The block header size for blocks using this compression.
+	idx_t GetBlockHeaderSize() const {
+		return block_manager.GetBlockHeaderSize();
+	}
+
+	BlockManager &GetBlockManager() const {
+		return block_manager;
+	}
+
+private:
+	BlockManager &block_manager;
+};
+
+struct AnalyzeState {
+	explicit AnalyzeState(const CompressionInfo &info) : info(info) {};
+	virtual ~AnalyzeState() {
+	}
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+	CompressionInfo info;
+};
+
+struct CompressionState {
+	explicit CompressionState(const CompressionInfo &info) : info(info) {};
+	virtual ~CompressionState() {
+	}
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+	CompressionInfo info;
+};
+
+struct CompressedSegmentState {
+	virtual ~CompressedSegmentState() {
+	}
+
+	//! Display info for PRAGMA storage_info
+	virtual string GetSegmentInfo() const { // LCOV_EXCL_START
+		return "";
+	} // LCOV_EXCL_STOP
+
+	//! Get the block ids of additional pages created by the segment
+	virtual vector<block_id_t> GetAdditionalBlocks() const { // LCOV_EXCL_START
+		return vector<block_id_t>();
+	} // LCOV_EXCL_STOP
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+struct CompressionAppendState {
+	explicit CompressionAppendState(BufferHandle handle_p) : handle(std::move(handle_p)) {
+	}
+	virtual ~CompressionAppendState() {
+	}
+
+	BufferHandle handle;
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Analyze
+//===--------------------------------------------------------------------===//
+//! The analyze functions are used to determine whether or not to use this compression method
+//! The system first determines the potential compression methods to use based on the physical type of the column
+//! After that the following steps are taken:
+//! 1. The init_analyze is called to initialize the analyze state of every candidate compression method
+//! 2. The analyze method is called with all of the input data in the order in which it must be stored.
+//!    analyze can return "false". In that case, the compression method is taken out of consideration early.
+//! 3. The final_analyze method is called, which should return a score for the compression method
+
+//! The system then decides which compression function to use based on the analyzed score (returned from final_analyze)
+typedef unique_ptr<AnalyzeState> (*compression_init_analyze_t)(ColumnData &col_data, PhysicalType type);
+typedef bool (*compression_analyze_t)(AnalyzeState &state, Vector &input, idx_t count);
+typedef idx_t (*compression_final_analyze_t)(AnalyzeState &state);
+
+//===--------------------------------------------------------------------===//
+// Compress
+//===--------------------------------------------------------------------===//
+typedef unique_ptr<CompressionState> (*compression_init_compression_t)(ColumnDataCheckpointData &checkpoint_data,
+                                                                       unique_ptr<AnalyzeState> state);
+typedef void (*compression_compress_data_t)(CompressionState &state, Vector &scan_vector, idx_t count);
+typedef void (*compression_compress_finalize_t)(CompressionState &state);
+
+//===--------------------------------------------------------------------===//
+// Uncompress / Scan
+//===--------------------------------------------------------------------===//
+typedef void (*compression_init_prefetch_t)(ColumnSegment &segment, PrefetchState &prefetch_state);
+typedef unique_ptr<SegmentScanState> (*compression_init_segment_scan_t)(ColumnSegment &segment);
+
+//! Function prototype used for reading an entire vector (STANDARD_VECTOR_SIZE)
+typedef void (*compression_scan_vector_t)(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count,
+                                          Vector &result);
+//! Function prototype used for reading an arbitrary ('scan_count') number of values
+typedef void (*compression_scan_partial_t)(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count,
+                                           Vector &result, idx_t result_offset);
+//! Function prototype used for reading a subset of the values of a vector indicated by a selection vector
+typedef void (*compression_select_t)(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
+                                     const SelectionVector &sel, idx_t sel_count);
+//! Function prototype used for applying a filter to a vector while scanning that vector
+typedef void (*compression_filter_t)(ColumnSegment &segment, ColumnScanState &state, idx_t vector_count, Vector &result,
+                                     SelectionVector &sel, idx_t &sel_count, const TableFilter &filter,
+                                     TableFilterState &filter_state);
+//! Function prototype used for reading a single value
+typedef void (*compression_fetch_row_t)(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
+                                        idx_t result_idx);
+//! Function prototype used for skipping 'skip_count' values, non-trivial if random-access is not supported for the
+//! compressed data.
+typedef void (*compression_skip_t)(ColumnSegment &segment, ColumnScanState &state, idx_t skip_count);
+
+//===--------------------------------------------------------------------===//
+// Append (optional)
+//===--------------------------------------------------------------------===//
+typedef unique_ptr<CompressedSegmentState> (*compression_init_segment_t)(
+    ColumnSegment &segment, block_id_t block_id, optional_ptr<ColumnSegmentState> segment_state);
+typedef unique_ptr<CompressionAppendState> (*compression_init_append_t)(ColumnSegment &segment);
+typedef idx_t (*compression_append_t)(CompressionAppendState &append_state, ColumnSegment &segment,
+                                      SegmentStatistics &stats, UnifiedVectorFormat &data, idx_t offset, idx_t count);
+typedef idx_t (*compression_finalize_append_t)(ColumnSegment &segment, SegmentStatistics &stats);
+typedef void (*compression_revert_append_t)(ColumnSegment &segment, idx_t start_row);
+
+//===--------------------------------------------------------------------===//
+// Serialization (optional)
+//===--------------------------------------------------------------------===//
+//! Function prototype for serializing the segment state
+typedef unique_ptr<ColumnSegmentState> (*compression_serialize_state_t)(ColumnSegment &segment);
+//! Function prototype for deserializing the segment state
+typedef unique_ptr<ColumnSegmentState> (*compression_deserialize_state_t)(Deserializer &deserializer);
+//! Function prototype for cleaning up the segment state when the column data is dropped
+typedef void (*compression_cleanup_state_t)(ColumnSegment &segment);
+
+//===--------------------------------------------------------------------===//
+// GetSegmentInfo (optional)
+//===--------------------------------------------------------------------===//
+//! Function prototype for retrieving segment information straight from the column segment
+typedef InsertionOrderPreservingMap<string> (*compression_get_segment_info_t)(ColumnSegment &segment);
+
+enum class CompressionValidity : uint8_t { REQUIRES_VALIDITY, NO_VALIDITY_REQUIRED };
+
+class CompressionFunction {
+public:
+	CompressionFunction(CompressionType type, PhysicalType data_type, compression_init_analyze_t init_analyze,
+	                    compression_analyze_t analyze, compression_final_analyze_t final_analyze,
+	                    compression_init_compression_t init_compression, compression_compress_data_t compress,
+	                    compression_compress_finalize_t compress_finalize, compression_init_segment_scan_t init_scan,
+	                    compression_scan_vector_t scan_vector, compression_scan_partial_t scan_partial,
+	                    compression_fetch_row_t fetch_row, compression_skip_t skip,
+	                    compression_init_segment_t init_segment = nullptr,
+	                    compression_init_append_t init_append = nullptr, compression_append_t append = nullptr,
+	                    compression_finalize_append_t finalize_append = nullptr,
+	                    compression_revert_append_t revert_append = nullptr,
+	                    compression_serialize_state_t serialize_state = nullptr,
+	                    compression_deserialize_state_t deserialize_state = nullptr,
+	                    compression_cleanup_state_t cleanup_state = nullptr,
+	                    compression_init_prefetch_t init_prefetch = nullptr, compression_select_t select = nullptr,
+	                    compression_filter_t filter = nullptr)
+	    : type(type), data_type(data_type), init_analyze(init_analyze), analyze(analyze), final_analyze(final_analyze),
+	      init_compression(init_compression), compress(compress), compress_finalize(compress_finalize),
+	      init_prefetch(init_prefetch), init_scan(init_scan), scan_vector(scan_vector), scan_partial(scan_partial),
+	      select(select), filter(filter), fetch_row(fetch_row), skip(skip), init_segment(init_segment),
+	      init_append(init_append), append(append), finalize_append(finalize_append), revert_append(revert_append),
+	      serialize_state(serialize_state), deserialize_state(deserialize_state), cleanup_state(cleanup_state) {
+	}
+
+	//! Compression type
+	CompressionType type;
+	//! The data type this function can compress
+	PhysicalType data_type;
+
+	//! Analyze step: determine which compression function is the most effective
+	//! init_analyze is called once to set up the analyze state
+	compression_init_analyze_t init_analyze;
+	//! analyze is called several times (once per vector in the row group)
+	//! analyze should return true, unless compression is no longer possible with this compression method
+	//! in that case false should be returned
+	compression_analyze_t analyze;
+	//! final_analyze should return the score of the compression function
+	//! ideally this is the exact number of bytes required to store the data
+	//! this is not required/enforced: it can be an estimate as well
+	//! also this function can return DConstants::INVALID_INDEX to skip this compression method
+	compression_final_analyze_t final_analyze;
+
+	//! Compression step: actually compress the data
+	//! init_compression is called once to set up the comperssion state
+	compression_init_compression_t init_compression;
+	//! compress is called several times (once per vector in the row group)
+	compression_compress_data_t compress;
+	//! compress_finalize is called after
+	compression_compress_finalize_t compress_finalize;
+
+	//! Initialize prefetch state with required I/O data to scan this segment
+	compression_init_prefetch_t init_prefetch;
+	//! init_scan is called to set up the scan state
+	compression_init_segment_scan_t init_scan;
+	//! scan_vector scans an entire vector using the scan state
+	compression_scan_vector_t scan_vector;
+	//! scan_partial scans a subset of a vector
+	//! this can request > vector_size as well
+	//! this is used if a vector crosses segment boundaries, or for child columns of lists
+	compression_scan_partial_t scan_partial;
+	//! scan a subset of a vector
+	compression_select_t select;
+	//! Scan and apply a filter to a vector while scanning
+	compression_filter_t filter;
+	//! fetch an individual row from the compressed vector
+	//! used for index lookups
+	compression_fetch_row_t fetch_row;
+	//! Skip forward in the compressed segment
+	compression_skip_t skip;
+
+	// Append functions
+	//! This only really needs to be defined for uncompressed segments
+
+	//! Initialize a compressed segment (optional)
+	compression_init_segment_t init_segment;
+	//! Initialize the append state (optional)
+	compression_init_append_t init_append;
+	//! Append to the compressed segment (optional)
+	compression_append_t append;
+	//! Finalize an append to the segment
+	compression_finalize_append_t finalize_append;
+	//! Revert append (optional)
+	compression_revert_append_t revert_append;
+
+	// State serialize functions
+	//! This is only necessary if the segment state has information that must be written to disk in the metadata
+
+	//! Serialize the segment state to the metadata (optional)
+	compression_serialize_state_t serialize_state;
+	//! Deserialize the segment state to the metadata (optional)
+	compression_deserialize_state_t deserialize_state;
+	//! Cleanup the segment state (optional)
+	compression_cleanup_state_t cleanup_state;
+
+	// Get Segment Info
+	//! This is only necessary if you want to convey more information about the segment in the 'pragma_storage_info'
+	//! result
+
+	//! Get stringified segment information directly from reading the column segment
+	compression_get_segment_info_t get_segment_info = nullptr;
+
+	//! Whether the validity mask should be separately compressed
+	//! or this compression function can also be used to decompress the validity
+	CompressionValidity validity = CompressionValidity::REQUIRES_VALIDITY;
+};
+
+//! The set of compression functions
+struct CompressionFunctionSet {
+	mutex lock;
+	map<CompressionType, map<PhysicalType, CompressionFunction>> functions;
+};
+
+} // namespace duckdb
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/storage_lock.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+namespace duckdb {
+struct StorageLockInternals;
+
+enum class StorageLockType { SHARED = 0, EXCLUSIVE = 1 };
+
+class StorageLockKey {
+public:
+	StorageLockKey(shared_ptr<StorageLockInternals> internals, StorageLockType type);
+	~StorageLockKey();
+
+	StorageLockType GetType() const {
+		return type;
+	}
+
+private:
+	shared_ptr<StorageLockInternals> internals;
+	StorageLockType type;
+};
+
+class StorageLock {
+public:
+	StorageLock();
+	~StorageLock();
+
+	//! Get an exclusive lock
+	unique_ptr<StorageLockKey> GetExclusiveLock();
+	//! Get a shared lock
+	unique_ptr<StorageLockKey> GetSharedLock();
+	//! Try to get an exclusive lock - if we cannot get it immediately we return `nullptr`
+	unique_ptr<StorageLockKey> TryGetExclusiveLock();
+	//! This is a special method that only exists for checkpointing
+	//! This method takes a shared lock, and returns an exclusive lock if the parameter is the only active shared lock
+	//! If this method succeeds, we have **both** a shared and exclusive lock active (which normally is not allowed)
+	//! But this behavior is required for checkpointing
+	unique_ptr<StorageLockKey> TryUpgradeCheckpointLock(StorageLockKey &lock);
+
+private:
+	shared_ptr<StorageLockInternals> internals;
+};
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+class ColumnSegment;
+class BlockManager;
+class ColumnData;
+class DatabaseInstance;
+class Transaction;
+class BaseStatistics;
+class UpdateSegment;
+class TableFilter;
+struct TableFilterState;
+struct ColumnFetchState;
+struct ColumnScanState;
+struct ColumnAppendState;
+struct PrefetchState;
+
+enum class ColumnSegmentType : uint8_t { TRANSIENT, PERSISTENT };
+//! TableFilter represents a filter pushed down into the table scan.
+
+class ColumnSegment : public SegmentBase<ColumnSegment> {
+public:
+	//! Construct a column segment.
+	ColumnSegment(DatabaseInstance &db, shared_ptr<BlockHandle> block, const LogicalType &type,
+	              const ColumnSegmentType segment_type, const idx_t start, const idx_t count,
+	              CompressionFunction &function_p, BaseStatistics statistics, const block_id_t block_id_p,
+	              const idx_t offset, const idx_t segment_size_p,
+	              unique_ptr<ColumnSegmentState> segment_state_p = nullptr);
+	//! Construct a column segment from another column segment.
+	//! The other column segment becomes invalid (std::move).
+	ColumnSegment(ColumnSegment &other, const idx_t start);
+	~ColumnSegment();
+
+public:
+	static unique_ptr<ColumnSegment> CreatePersistentSegment(DatabaseInstance &db, BlockManager &block_manager,
+	                                                         block_id_t id, idx_t offset, const LogicalType &type_p,
+	                                                         idx_t start, idx_t count, CompressionType compression_type,
+	                                                         BaseStatistics statistics,
+	                                                         unique_ptr<ColumnSegmentState> segment_state);
+	static unique_ptr<ColumnSegment> CreateTransientSegment(DatabaseInstance &db, CompressionFunction &function,
+	                                                        const LogicalType &type, const idx_t start,
+	                                                        const idx_t segment_size, BlockManager &block_manager);
+
+public:
+	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state);
+	void InitializeScan(ColumnScanState &state);
+	//! Scan one vector from this segment
+	void Scan(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset, ScanVectorType scan_type);
+	//! Scan a subset of a vector (defined by the selection vector)
+	void Select(ColumnScanState &state, idx_t scan_count, Vector &result, const SelectionVector &sel, idx_t sel_count);
+	//! Scan one vector while applying a filter to the vector, returning only the matching elements
+	void Filter(ColumnScanState &state, idx_t scan_count, Vector &result, SelectionVector &sel, idx_t &sel_count,
+	            const TableFilter &filter, TableFilterState &filter_state);
+	//! Fetch a value of the specific row id and append it to the result
+	void FetchRow(ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx);
+
+	static idx_t FilterSelection(SelectionVector &sel, Vector &vector, UnifiedVectorFormat &vdata,
+	                             const TableFilter &filter, TableFilterState &filter_state, idx_t scan_count,
+	                             idx_t &approved_tuple_count);
+
+	//! Skip a scan forward to the row_index specified in the scan state
+	void Skip(ColumnScanState &state);
+
+	// The maximum size of the buffer (in bytes)
+	idx_t SegmentSize() const;
+	//! Resize the block
+	void Resize(idx_t segment_size);
+	const CompressionFunction &GetCompressionFunction();
+
+	//! Initialize an append of this segment. Appends are only supported on transient segments.
+	void InitializeAppend(ColumnAppendState &state);
+	//! Appends a (part of) vector to the segment, returns the amount of entries successfully appended
+	idx_t Append(ColumnAppendState &state, UnifiedVectorFormat &data, idx_t offset, idx_t count);
+	//! Finalize the segment for appending - no more appends can follow on this segment
+	//! The segment should be compacted as much as possible
+	//! Returns the number of bytes occupied within the segment
+	idx_t FinalizeAppend(ColumnAppendState &state);
+	//! Revert an append made to this segment
+	void RevertAppend(idx_t start_row);
+
+	//! Convert a transient in-memory segment into a persistent segment blocked by an on-disk block.
+	//! Only used during checkpointing.
+	void ConvertToPersistent(optional_ptr<BlockManager> block_manager, block_id_t block_id);
+	//! Updates pointers to refer to the given block and offset. This is only used
+	//! when sharing a block among segments. This is invoked only AFTER the block is written.
+	void MarkAsPersistent(shared_ptr<BlockHandle> block, uint32_t offset_in_block);
+	//! Gets a data pointer from a persistent column segment
+	DataPointer GetDataPointer();
+
+	block_id_t GetBlockId() {
+		D_ASSERT(segment_type == ColumnSegmentType::PERSISTENT);
+		return block_id;
+	}
+
+	//! Returns the block manager handling this segment. For transient segments, this might be the temporary block
+	//! manager. Later, we possibly convert this (transient) segment to a persistent segment. In that case, there
+	//! exists another block manager handling the ColumnData, of which this segment is a part.
+	BlockManager &GetBlockManager() const {
+		return block->block_manager;
+	}
+
+	idx_t GetBlockOffset() {
+		D_ASSERT(segment_type == ColumnSegmentType::PERSISTENT || offset == 0);
+		return offset;
+	}
+
+	idx_t GetRelativeIndex(idx_t row_index) {
+		D_ASSERT(row_index >= this->start);
+		D_ASSERT(row_index <= this->start + this->count);
+		return row_index - this->start;
+	}
+
+	optional_ptr<CompressedSegmentState> GetSegmentState() {
+		return segment_state.get();
+	}
+
+	void CommitDropSegment();
+
+private:
+	void Scan(ColumnScanState &state, idx_t scan_count, Vector &result);
+	void ScanPartial(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset);
+
+public:
+	//! The database instance
+	DatabaseInstance &db;
+	//! The type stored in the column
+	LogicalType type;
+	//! The size of the type
+	idx_t type_size;
+	//! The column segment type (transient or persistent)
+	ColumnSegmentType segment_type;
+	//! The statistics for the segment
+	SegmentStatistics stats;
+	//! The block that this segment relates to
+	shared_ptr<BlockHandle> block;
+
+private:
+	//! The compression function
+	reference<CompressionFunction> function;
+	//! The block id that this segment relates to (persistent segment only)
+	block_id_t block_id;
+	//! The offset into the block (persistent segment only)
+	idx_t offset;
+	//! The allocated segment size, which is bounded by Storage::BLOCK_SIZE
+	idx_t segment_size;
+	//! Storage associated with the compressed segment
+	unique_ptr<CompressedSegmentState> segment_state;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/data_table_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/table_index_list.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/index/bound_index.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class ClientContext;
+class TableIOManager;
+class Transaction;
+class ConflictManager;
+
+struct IndexLock;
+struct IndexScanState;
+
+enum class IndexAppendMode : uint8_t { DEFAULT = 0, IGNORE_DUPLICATES = 1, INSERT_DUPLICATES = 2 };
+
+class IndexAppendInfo {
+public:
+	IndexAppendInfo() : append_mode(IndexAppendMode::DEFAULT), delete_index(nullptr) {};
+	IndexAppendInfo(const IndexAppendMode append_mode, const optional_ptr<BoundIndex> delete_index)
+	    : append_mode(append_mode), delete_index(delete_index) {};
+
+public:
+	IndexAppendMode append_mode;
+	optional_ptr<BoundIndex> delete_index;
+};
+
+//! The index is an abstract base class that serves as the basis for indexes
+class BoundIndex : public Index {
+public:
+	BoundIndex(const string &name, const string &index_type, IndexConstraintType index_constraint_type,
+	           const vector<column_t> &column_ids, TableIOManager &table_io_manager,
+	           const vector<unique_ptr<Expression>> &unbound_expressions, AttachedDatabase &db);
+
+	//! The physical types stored in the index
+	vector<PhysicalType> types;
+	//! The logical types of the expressions
+	vector<LogicalType> logical_types;
+
+	//! The name of the index
+	string name;
+	//! The index type (ART, B+-tree, Skip-List, ...)
+	string index_type;
+	//! The index constraint type
+	IndexConstraintType index_constraint_type;
+
+public:
+	bool IsBound() const override {
+		return true;
+	}
+
+	const string &GetIndexType() const override {
+		return index_type;
+	}
+
+	const string &GetIndexName() const override {
+		return name;
+	}
+
+	IndexConstraintType GetConstraintType() const override {
+		return index_constraint_type;
+	}
+
+public:
+	//! Obtains a lock on the index.
+	void InitializeLock(IndexLock &state);
+	//! Appends data to the locked index.
+	virtual ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) = 0;
+	//! Obtains a lock and calls Append while holding that lock.
+	ErrorData Append(DataChunk &chunk, Vector &row_ids);
+	//! Appends data to the locked index and verifies constraint violations.
+	virtual ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info);
+	//! Obtains a lock and calls Append while holding that lock.
+	ErrorData Append(DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info);
+
+	//! Verify that data can be appended to the index without a constraint violation.
+	virtual void VerifyAppend(DataChunk &chunk, IndexAppendInfo &info, optional_ptr<ConflictManager> manager);
+	//! Verifies the constraint for a chunk of data.
+	virtual void VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictManager &manager);
+
+	//! Deletes all data from the index. The lock obtained from InitializeLock must be held
+	virtual void CommitDrop(IndexLock &index_lock) = 0;
+	//! Deletes all data from the index
+	void CommitDrop() override;
+	//! Delete a chunk of entries from the index. The lock obtained from InitializeLock must be held
+	virtual void Delete(IndexLock &state, DataChunk &entries, Vector &row_identifiers) = 0;
+	//! Obtains a lock and calls Delete while holding that lock
+	void Delete(DataChunk &entries, Vector &row_identifiers);
+
+	//! Insert a chunk.
+	virtual ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids) = 0;
+	//! Insert a chunk and verifies constraint violations.
+	virtual ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info);
+
+	//! Merge another index into this index. The lock obtained from InitializeLock must be held, and the other
+	//! index must also be locked during the merge
+	virtual bool MergeIndexes(IndexLock &state, BoundIndex &other_index) = 0;
+	//! Obtains a lock and calls MergeIndexes while holding that lock
+	bool MergeIndexes(BoundIndex &other_index);
+
+	//! Performs a full traversal of the ART while vacuuming the qualifying nodes.
+	//! The lock obtained from InitializeLock must be held.
+	virtual void Vacuum(IndexLock &l) = 0;
+	//! Obtains a lock and calls Vacuum while holding that lock.
+	void Vacuum();
+
+	//! Returns the in-memory usage of the index. The lock obtained from InitializeLock must be held
+	virtual idx_t GetInMemorySize(IndexLock &state) = 0;
+	//! Returns the in-memory usage of the index
+	idx_t GetInMemorySize();
+
+	//! Returns the string representation of an index, or only traverses and verifies the index.
+	virtual string VerifyAndToString(IndexLock &l, const bool only_verify) = 0;
+	//! Obtains a lock and calls VerifyAndToString.
+	string VerifyAndToString(const bool only_verify);
+
+	//! Ensures that the node allocation counts match the node counts.
+	virtual void VerifyAllocations(IndexLock &l) = 0;
+	//! Obtains a lock and calls VerifyAllocations.
+	void VerifyAllocations();
+
+	//! Verify the index buffers.
+	virtual void VerifyBuffers(IndexLock &l);
+	//! Obtains a lock and calls VerifyBuffers.
+	void VerifyBuffers();
+
+	//! Returns true if the index is affected by updates on the specified column IDs, and false otherwise
+	bool IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const;
+
+	//! Returns index storage serialization information.
+	virtual IndexStorageInfo GetStorageInfo(const case_insensitive_map_t<Value> &options, const bool to_wal);
+
+	//! Execute the index expressions on an input chunk
+	void ExecuteExpressions(DataChunk &input, DataChunk &result);
+	static string AppendRowError(DataChunk &input, idx_t index);
+
+	//! Throw a constraint violation exception
+	virtual string GetConstraintViolationMessage(VerifyExistenceType verify_type, idx_t failed_index,
+	                                             DataChunk &input) = 0;
+
+	vector<unique_ptr<Expression>> unbound_expressions;
+
+protected:
+	//! Lock used for any changes to the index
+	mutex lock;
+
+	//! Bound expressions used during expression execution
+	vector<unique_ptr<Expression>> bound_expressions;
+
+private:
+	//! Expression executor to execute the index expressions
+	ExpressionExecutor executor;
+
+	//! Bind the unbound expressions of the index
+	unique_ptr<Expression> BindExpression(unique_ptr<Expression> expr);
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class ConflictManager;
+class LocalTableStorage;
+struct IndexStorageInfo;
+struct DataTableInfo;
+
+class TableIndexList {
+public:
+	//! Scan the indexes, invoking the callback method for every entry.
+	template <class T>
+	void Scan(T &&callback) {
+		lock_guard<mutex> lock(indexes_lock);
+		for (auto &index : indexes) {
+			if (callback(*index)) {
+				break;
+			}
+		}
+	}
+
+	//! Scan the indexes, invoking the callback method for every bound entry of type T.
+	template <class T, class FUNC>
+	void ScanBound(FUNC &&callback) {
+		lock_guard<mutex> lock(indexes_lock);
+		for (auto &index : indexes) {
+			if (index->IsBound() && T::TYPE_NAME == index->GetIndexType()) {
+				if (callback(index->Cast<T>())) {
+					break;
+				}
+			}
+		}
+	}
+
+	// Bind any unbound indexes of type T and invoke the callback method.
+	template <class T, class FUNC>
+	void BindAndScan(ClientContext &context, DataTableInfo &table_info, FUNC &&callback) {
+		// FIXME: optimize this by only looping through the indexes once without re-acquiring the lock.
+		InitializeIndexes(context, table_info, T::TYPE_NAME);
+		ScanBound<T>(callback);
+	}
+
+	//! Returns a reference to the indexes.
+	const vector<unique_ptr<Index>> &Indexes() const {
+		return indexes;
+	}
+	//! Adds an index to the list of indexes.
+	void AddIndex(unique_ptr<Index> index);
+	//! Removes an index from the list of indexes.
+	void RemoveIndex(const string &name);
+	//! Removes all remaining memory of an index after dropping the catalog entry.
+	void CommitDrop(const string &name);
+	//! Returns true, if the index name does not exist.
+	bool NameIsUnique(const string &name);
+	//! Returns an optional pointer to the index matching the name.
+	optional_ptr<BoundIndex> Find(const string &name);
+	//! Initializes unknown indexes that are possibly present after an extension load, optionally throwing an exception
+	//! on failure.
+	void InitializeIndexes(ClientContext &context, DataTableInfo &table_info, const char *index_type = nullptr);
+	//! Returns true, if there are no indexes in this list.
+	bool Empty();
+	//! Returns the number of indexes in this list.
+	idx_t Count();
+	//! Overwrite this list with the other list.
+	void Move(TableIndexList &other);
+	//! Find the foreign key matching the keys.
+	optional_ptr<Index> FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, const ForeignKeyType fk_type);
+	//! Verify a foreign key constraint.
+	void VerifyForeignKey(optional_ptr<LocalTableStorage> storage, const vector<PhysicalIndex> &fk_keys,
+	                      DataChunk &chunk, ConflictManager &conflict_manager);
+	//! Get the combined column ids of the indexes in this list.
+	unordered_set<column_t> GetRequiredColumns();
+	//! Serialize all indexes of this table.
+	vector<IndexStorageInfo> GetStorageInfos(const case_insensitive_map_t<Value> &options);
+
+private:
+	//! A lock to prevent any concurrent changes to the indexes.
+	mutex indexes_lock;
+	//! Indexes associated with the table.
+	vector<unique_ptr<Index>> indexes;
+};
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+class DatabaseInstance;
+class TableIOManager;
+
+struct DataTableInfo {
+	friend class DataTable;
+
+public:
+	DataTableInfo(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager_p, string schema, string table);
+
+	//! Initialize any unknown indexes whose types might now be present after an extension load, optionally throwing an
+	//! exception if an index can't be initialized
+	void InitializeIndexes(ClientContext &context, const char *index_type = nullptr);
+
+	//! Whether or not the table is temporary
+	bool IsTemporary() const;
+
+	AttachedDatabase &GetDB() {
+		return db;
+	}
+
+	TableIOManager &GetIOManager() {
+		return *table_io_manager;
+	}
+
+	TableIndexList &GetIndexes() {
+		return indexes;
+	}
+	const vector<IndexStorageInfo> &GetIndexStorageInfo() const {
+		return index_storage_infos;
+	}
+	unique_ptr<StorageLockKey> GetSharedLock() {
+		return checkpoint_lock.GetSharedLock();
+	}
+
+	string GetSchemaName();
+	string GetTableName();
+	void SetTableName(string name);
+
+private:
+	//! The database instance of the table
+	AttachedDatabase &db;
+	//! The table IO manager
+	shared_ptr<TableIOManager> table_io_manager;
+	//! Lock for modifying the name
+	mutex name_lock;
+	//! The schema of the table
+	string schema;
+	//! The name of the table
+	string table;
+	//! The physical list of indexes of this table
+	TableIndexList indexes;
+	//! Index storage information of the indexes created by this table
+	vector<IndexStorageInfo> index_storage_infos;
+	//! Lock held while checkpointing
+	StorageLock checkpoint_lock;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/persistent_table_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/table_statistics.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/reservoir_sample.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/random_engine.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+#include <random>
+
+namespace duckdb {
+class ClientContext;
+struct RandomState;
+
+class RandomEngine {
+public:
+	explicit RandomEngine(int64_t seed = -1);
+	~RandomEngine();
+
+	//! Generate a random number between min and max
+	double NextRandom(double min, double max);
+
+	//! Generate a random number between 0 and 1
+	double NextRandom();
+	//! Generate a random number between 0 and 1, using 32-bits as a base
+	double NextRandom32();
+	double NextRandom32(double min, double max);
+	uint32_t NextRandomInteger32(uint32_t min, uint32_t max);
+	uint32_t NextRandomInteger();
+	uint32_t NextRandomInteger(uint32_t min, uint32_t max);
+	uint64_t NextRandomInteger64();
+
+	void SetSeed(uint64_t seed);
+
+	static RandomEngine &Get(ClientContext &context);
+
+	mutex lock;
+
+private:
+	unique_ptr<RandomState> random_state;
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/windows_undefs.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+// Do not add a header inclusion guard to this file. Otherwise these Win32 macros
+// may get defined and stomp on DuckDB symbols
+
+#ifdef WIN32
+
+#ifdef min
+#undef min
+#endif
+
+#ifdef max
+#undef max
+#endif
+
+#ifdef ERROR
+#undef ERROR
+#endif
+
+#ifdef small
+#undef small
+#endif
+
+#ifdef CreateDirectory
+#undef CreateDirectory
+#endif
+
+#ifdef MoveFile
+#undef MoveFile
+#endif
+
+#ifdef RemoveDirectory
+#undef RemoveDirectory
+#endif
+
+#ifdef UUID
+#undef UUID
+#endif
+
+#ifdef interface
+#undef interface
+#endif
+
+#endif
+
+
+
+
+// Originally intended to be the vector size, but in order to run on
+// vector size = 2, we had to change it.
+#define FIXED_SAMPLE_SIZE 2048
+
+namespace duckdb {
+
+enum class SampleType : uint8_t { BLOCKING_SAMPLE = 0, RESERVOIR_SAMPLE = 1, RESERVOIR_PERCENTAGE_SAMPLE = 2 };
+
+enum class SamplingState : uint8_t { RANDOM = 0, RESERVOIR = 1 };
+
+class ReservoirRNG : public RandomEngine {
+public:
+	// return type must be called result type to be a valid URNG
+	typedef uint32_t result_type;
+
+	explicit ReservoirRNG(int64_t seed) : RandomEngine(seed) {};
+
+	result_type operator()() {
+		return NextRandomInteger();
+	};
+
+	static constexpr result_type min() {
+		return NumericLimits<result_type>::Minimum();
+	};
+	static constexpr result_type max() {
+		return NumericLimits<result_type>::Maximum();
+	};
+};
+
+//! Resevoir sampling is based on the 2005 paper "Weighted Random Sampling" by Efraimidis and Spirakis
+class BaseReservoirSampling {
+public:
+	explicit BaseReservoirSampling(int64_t seed);
+	BaseReservoirSampling();
+
+	void InitializeReservoirWeights(idx_t cur_size, idx_t sample_size);
+
+	void SetNextEntry();
+
+	void ReplaceElementWithIndex(idx_t entry_index, double with_weight, bool pop = true);
+	void ReplaceElement(double with_weight = -1);
+
+	void UpdateMinWeightThreshold();
+
+	//! Go from the naive sampling to the reservoir sampling
+	//! Naive samping will not collect weights, but when we serialize
+	//! we need to serialize weights again.
+	void FillWeights(SelectionVector &sel, idx_t &sel_size);
+
+	unique_ptr<BaseReservoirSampling> Copy();
+
+	//! The random generator
+	ReservoirRNG random;
+
+	//! The next element to sample
+	idx_t next_index_to_sample;
+	//! The reservoir threshold of the current min entry
+	double min_weight_threshold;
+	//! The reservoir index of the current min entry
+	idx_t min_weighted_entry_index;
+	//! The current count towards next index (i.e. we will replace an entry in next_index - current_count tuples)
+	//! The number of entries "seen" before choosing one that will go in our reservoir sample.
+	idx_t num_entries_to_skip_b4_next_sample;
+	//! when collecting a sample in parallel, we want to know how many values each thread has seen
+	//! so we can collect the samples from the thread local states in a uniform manner
+	idx_t num_entries_seen_total;
+	//! Priority queue of [random element, index] for each of the elements in the sample
+	std::priority_queue<std::pair<double, idx_t>> reservoir_weights;
+
+	void Serialize(Serializer &serializer) const;
+	static unique_ptr<BaseReservoirSampling> Deserialize(Deserializer &deserializer);
+
+	static double GetMinWeightFromTuplesSeen(idx_t rows_seen_total);
+	// static unordered_map<idx_t, double> tuples_to_min_weight_map;
+	// Blocking sample is a virtual class. It should be allowed to see the weights and
+	// of tuples in the sample. The blocking sample can then easily maintain statisitcal properties
+	// from the sample point of view.
+	friend class BlockingSample;
+};
+
+class BlockingSample {
+public:
+	static constexpr const SampleType TYPE = SampleType::BLOCKING_SAMPLE;
+
+	unique_ptr<BaseReservoirSampling> base_reservoir_sample;
+	//! The sample type
+	SampleType type;
+	//! has the sample been destroyed due to updates to the referenced table
+	bool destroyed;
+
+public:
+	explicit BlockingSample(int64_t seed = -1)
+	    : base_reservoir_sample(make_uniq<BaseReservoirSampling>(seed)), type(SampleType::BLOCKING_SAMPLE),
+	      destroyed(false) {
+	}
+	virtual ~BlockingSample() {
+	}
+
+	//! Add a chunk of data to the sample
+	virtual void AddToReservoir(DataChunk &input) = 0;
+	virtual unique_ptr<BlockingSample> Copy() const = 0;
+	virtual void Finalize() = 0;
+	virtual void Destroy();
+
+	//! Fetches a chunk from the sample. destroy = true should only be used when
+	//! querying from a sample defined in a query and not a duckdb_table_sample.
+	virtual unique_ptr<DataChunk> GetChunk() = 0;
+
+	virtual void Serialize(Serializer &serializer) const;
+	static unique_ptr<BlockingSample> Deserialize(Deserializer &deserializer);
+
+	//! Helper functions needed to merge two reservoirs while respecting weights of sampled rows
+	std::pair<double, idx_t> PopFromWeightQueue();
+	double GetMinWeightThreshold();
+	idx_t GetPriorityQueueSize();
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		if (type != TARGET::TYPE && TARGET::TYPE != SampleType::BLOCKING_SAMPLE) {
+			throw InternalException("Failed to cast sample to type - sample type mismatch");
+		}
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		if (type != TARGET::TYPE && TARGET::TYPE != SampleType::BLOCKING_SAMPLE) {
+			throw InternalException("Failed to cast sample to type - sample type mismatch");
+		}
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+class ReservoirChunk {
+public:
+	ReservoirChunk() {
+	}
+
+	DataChunk chunk;
+	void Serialize(Serializer &serializer) const;
+	static unique_ptr<ReservoirChunk> Deserialize(Deserializer &deserializer);
+
+	unique_ptr<ReservoirChunk> Copy() const;
+};
+
+struct SelectionVectorHelper {
+	SelectionVector sel;
+	uint32_t size;
+};
+
+class ReservoirSample : public BlockingSample {
+public:
+	static constexpr const SampleType TYPE = SampleType::RESERVOIR_SAMPLE;
+
+	constexpr static idx_t FIXED_SAMPLE_SIZE_MULTIPLIER = 10;
+	// size is small enough, then the threshold to switch
+	// MinValue between std vec size and fixed sample size.
+	// During 'fast' sampling, we want every new vector to have the potential
+	// to add to the sample. If the threshold is too far below the standard vector size, then
+	// samples in the sample have a higher weight than new samples coming in.
+	// i.e during vector_size=2, 2 new samples will not be significant compared 2048 samples from 204800 tuples.
+	constexpr static idx_t FAST_TO_SLOW_THRESHOLD = MinValue<idx_t>(STANDARD_VECTOR_SIZE, 60);
+
+	// If the table has less than 204800 rows, this is the percentage
+	// of values we save when serializing/returning a sample.
+	constexpr static double SAVE_PERCENTAGE = 0.01;
+
+	ReservoirSample(Allocator &allocator, idx_t sample_count, int64_t seed = 1);
+	explicit ReservoirSample(idx_t sample_count, unique_ptr<ReservoirChunk> = nullptr);
+
+	//! methods used to help with serializing and deserializing
+	void EvictOverBudgetSamples();
+	void ExpandSerializedSample();
+
+	SamplingState GetSamplingState() const;
+
+	//! Vacuum the Reservoir Sample so it throws away tuples that are not in the
+	//! reservoir weights or in the selection vector
+	void Vacuum();
+
+	//! Transform To sample based on reservoir sampling paper
+	void ConvertToReservoirSample();
+
+	//! Get the capactiy of the data chunk reserved for storing samples
+	template <typename T>
+	T GetReservoirChunkCapacity() const;
+
+	//! If for_serialization=true then the sample_chunk is not padded with extra spaces for
+	//! future sampling values
+	unique_ptr<BlockingSample> Copy() const override;
+
+	//! create the first chunk called by AddToReservoir()
+	idx_t FillReservoir(DataChunk &chunk);
+	//! Add a chunk of data to the sample
+	void AddToReservoir(DataChunk &input) override;
+	//! Merge two Reservoir Samples. Other must be a reservoir sample
+	void Merge(unique_ptr<BlockingSample> other);
+
+	void ShuffleSel(SelectionVector &sel, idx_t range, idx_t size) const;
+
+	//! Update the sample by pushing new sample rows to the end of the sample_chunk.
+	//! The new sample rows are the tuples rows resulting from applying sel to other
+	void UpdateSampleAppend(DataChunk &this_, DataChunk &other, SelectionVector &other_sel, idx_t append_count) const;
+
+	idx_t GetTuplesSeen() const;
+	idx_t NumSamplesCollected() const;
+	idx_t GetActiveSampleCount() const;
+	static bool ValidSampleType(const LogicalType &type);
+
+	// get the chunk from Reservoir chunk
+	DataChunk &Chunk();
+
+	//! Fetches a chunk from the sample. Note that this method is destructive and should only be used after the
+	//! sample is completely built.
+	// unique_ptr<DataChunk> GetChunkAndDestroy() override;
+	unique_ptr<DataChunk> GetChunk() override;
+	void Destroy() override;
+	void Finalize() override;
+	void Verify();
+
+	idx_t GetSampleCount();
+
+	// map is [index in input chunk] -> [index in sample chunk]. Both are zero-based
+	// [index in sample chunk] is incremented by 1
+	// index in input chunk have random values, however, they are increasing.
+	// The base_reservoir_sampling gets updated however, so the indexes point to (sample_chunk_offset +
+	// index_in_sample_chunk) this data is used to make a selection vector to copy samples from the input chunk to the
+	// sample chunk
+	//! Get indexes from current sample that can be replaced.
+	SelectionVectorHelper GetReplacementIndexes(idx_t sample_chunk_offset, idx_t theoretical_chunk_length);
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<BlockingSample> Deserialize(Deserializer &deserializer);
+
+private:
+	// when we serialize, we may have collected too many samples since we fill a standard vector size, then
+	// truncate if the table is still <=204800 values. The problem is, in our weights, we store indexes into
+	// the selection vector. If throw away values at selection vector index i = 5 , we need to update all indexes
+	// i > 5. Otherwise we will have indexes in the weights that are greater than the length of our sample.
+	void NormalizeWeights();
+
+	SelectionVectorHelper GetReplacementIndexesSlow(const idx_t sample_chunk_offset, const idx_t chunk_length);
+	SelectionVectorHelper GetReplacementIndexesFast(const idx_t sample_chunk_offset, const idx_t chunk_length);
+	void SimpleMerge(ReservoirSample &other);
+	void WeightedMerge(ReservoirSample &other_sample);
+
+	// Helper methods for Shrink().
+	// Shrink has different logic depending on if the Reservoir sample is still in
+	// "Random" mode or in "reservoir" mode. This function creates a new sample chunk
+	// to copy the old sample chunk into
+	unique_ptr<ReservoirChunk> CreateNewSampleChunk(vector<LogicalType> &types, idx_t size) const;
+
+	// Get a vector where each index is a random int in the range 0, size.
+	// This is used to shuffle selection vector indexes
+	vector<uint32_t> GetRandomizedVector(uint32_t range, uint32_t size) const;
+
+	idx_t sample_count;
+	Allocator &allocator;
+	unique_ptr<ReservoirChunk> reservoir_chunk;
+	bool stats_sample;
+	SelectionVector sel;
+	idx_t sel_size;
+};
+
+//! The reservoir sample sample_size class maintains a streaming sample of variable size
+class ReservoirSamplePercentage : public BlockingSample {
+	constexpr static idx_t RESERVOIR_THRESHOLD = 100000;
+
+public:
+	static constexpr const SampleType TYPE = SampleType::RESERVOIR_PERCENTAGE_SAMPLE;
+
+	ReservoirSamplePercentage(Allocator &allocator, double percentage, int64_t seed = -1);
+	ReservoirSamplePercentage(double percentage, int64_t seed, idx_t reservoir_sample_size);
+	explicit ReservoirSamplePercentage(double percentage, int64_t seed = -1);
+
+	//! Add a chunk of data to the sample
+	void AddToReservoir(DataChunk &input) override;
+
+	unique_ptr<BlockingSample> Copy() const override;
+
+	//! Fetches a chunk from the sample. If destory = true this method is descructive
+	unique_ptr<DataChunk> GetChunk() override;
+	void Finalize() override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<BlockingSample> Deserialize(Deserializer &deserializer);
+
+private:
+	Allocator &allocator;
+	//! The sample_size to sample
+	double sample_percentage;
+	//! The fixed sample size of the sub-reservoirs
+	idx_t reservoir_sample_size;
+
+	//! The current sample
+	unique_ptr<ReservoirSample> current_sample;
+
+	//! The set of finished samples of the reservoir sample
+	vector<unique_ptr<ReservoirSample>> finished_samples;
+
+	//! The amount of tuples that have been processed so far (not put in the reservoir, just processed)
+	idx_t current_count = 0;
+	//! Whether or not the stream is finalized. The stream is automatically finalized on the first call to
+	//! GetChunkAndShrink();
+	bool is_finalized;
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+class ColumnList;
+class PersistentTableData;
+class Serializer;
+class Deserializer;
+
+class TableStatisticsLock {
+public:
+	explicit TableStatisticsLock(mutex &l) : guard(l) {
+	}
+
+	lock_guard<mutex> guard;
+};
+
+class TableStatistics {
+public:
+	void Initialize(const vector<LogicalType> &types, PersistentTableData &data);
+	void InitializeEmpty(const vector<LogicalType> &types);
+
+	void InitializeAddColumn(TableStatistics &parent, const LogicalType &new_column_type);
+	void InitializeRemoveColumn(TableStatistics &parent, idx_t removed_column);
+	void InitializeAlterType(TableStatistics &parent, idx_t changed_idx, const LogicalType &new_type);
+	void InitializeAddConstraint(TableStatistics &parent);
+
+	void MergeStats(TableStatistics &other);
+	void MergeStats(idx_t i, BaseStatistics &stats);
+	void MergeStats(TableStatisticsLock &lock, idx_t i, BaseStatistics &stats);
+
+	void CopyStats(TableStatistics &other);
+	void CopyStats(TableStatisticsLock &lock, TableStatistics &other);
+	unique_ptr<BaseStatistics> CopyStats(idx_t i);
+	//! Get a reference to the stats - this requires us to hold the lock.
+	//! The reference can only be safely accessed while the lock is held
+	ColumnStatistics &GetStats(TableStatisticsLock &lock, idx_t i);
+	//! Get a reference to the table sample - this requires us to hold the lock.
+	// BlockingSample &GetTableSampleRef(TableStatisticsLock &lock);
+	//! Take ownership of the sample, needed for merging. Requires the lock
+	unique_ptr<BlockingSample> GetTableSample(TableStatisticsLock &lock);
+	void SetTableSample(TableStatisticsLock &lock, unique_ptr<BlockingSample> sample);
+
+	void DestroyTableSample(TableStatisticsLock &lock) const;
+	void AppendToTableSample(TableStatisticsLock &lock, unique_ptr<BlockingSample> sample);
+
+	bool Empty();
+
+	unique_ptr<TableStatisticsLock> GetLock();
+
+	void Serialize(Serializer &serializer) const;
+	void Deserialize(Deserializer &deserializer, ColumnList &columns);
+
+private:
+	//! The statistics lock
+	shared_ptr<mutex> stats_lock;
+	//! Column statistics
+	vector<shared_ptr<ColumnStatistics>> column_stats;
+	//! The table sample
+	unique_ptr<BlockingSample> table_sample;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/metadata/metadata_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+class DatabaseInstance;
+struct MetadataBlockInfo;
+
+struct MetadataBlock {
+	shared_ptr<BlockHandle> block;
+	block_id_t block_id;
+	vector<uint8_t> free_blocks;
+
+	void Write(WriteStream &sink);
+	static MetadataBlock Read(ReadStream &source);
+
+	idx_t FreeBlocksToInteger();
+	void FreeBlocksFromInteger(idx_t blocks);
+};
+
+struct MetadataPointer {
+	idx_t block_index : 56;
+	uint8_t index : 8;
+};
+
+struct MetadataHandle {
+	MetadataPointer pointer;
+	BufferHandle handle;
+};
+
+class MetadataManager {
+public:
+	//! The amount of metadata blocks per storage block
+	static constexpr const idx_t METADATA_BLOCK_COUNT = 64;
+
+public:
+	MetadataManager(BlockManager &block_manager, BufferManager &buffer_manager);
+	~MetadataManager();
+
+	MetadataHandle AllocateHandle();
+	MetadataHandle Pin(const MetadataPointer &pointer);
+
+	MetaBlockPointer GetDiskPointer(const MetadataPointer &pointer, uint32_t offset = 0);
+	MetadataPointer FromDiskPointer(MetaBlockPointer pointer);
+	MetadataPointer RegisterDiskPointer(MetaBlockPointer pointer);
+
+	static BlockPointer ToBlockPointer(MetaBlockPointer meta_pointer, const idx_t metadata_block_size);
+	static MetaBlockPointer FromBlockPointer(BlockPointer block_pointer, const idx_t metadata_block_size);
+
+	//! Flush all blocks to disk
+	void Flush();
+
+	void MarkBlocksAsModified();
+	void ClearModifiedBlocks(const vector<MetaBlockPointer> &pointers);
+
+	vector<MetadataBlockInfo> GetMetadataInfo() const;
+	vector<shared_ptr<BlockHandle>> GetBlocks() const;
+	idx_t BlockCount();
+
+	void Write(WriteStream &sink);
+	void Read(ReadStream &source);
+
+	idx_t GetMetadataBlockSize() const;
+
+protected:
+	BlockManager &block_manager;
+	BufferManager &buffer_manager;
+	unordered_map<block_id_t, MetadataBlock> blocks;
+	unordered_map<block_id_t, idx_t> modified_blocks;
+
+protected:
+	block_id_t AllocateNewBlock();
+	block_id_t PeekNextBlockId();
+	block_id_t GetNextBlockId();
+
+	void AddBlock(MetadataBlock new_block, bool if_exists = false);
+	void AddAndRegisterBlock(MetadataBlock block);
+	void ConvertToTransient(MetadataBlock &block);
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class BaseStatistics;
+
+class PersistentTableData {
+public:
+	explicit PersistentTableData(idx_t column_count);
+	~PersistentTableData();
+
+	TableStatistics table_stats;
+	idx_t total_rows;
+	idx_t row_group_count;
+	MetaBlockPointer block_pointer;
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/row_group_collection.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/segment_tree.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/segment_lock.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+struct SegmentLock {
+public:
+	SegmentLock() {
+	}
+	explicit SegmentLock(mutex &lock) : lock(lock) {
+	}
+	// disable copy constructors
+	SegmentLock(const SegmentLock &other) = delete;
+	SegmentLock &operator=(const SegmentLock &) = delete;
+	//! enable move constructors
+	SegmentLock(SegmentLock &&other) noexcept {
+		std::swap(lock, other.lock);
+	}
+	SegmentLock &operator=(SegmentLock &&other) noexcept {
+		std::swap(lock, other.lock);
+		return *this;
+	}
+
+private:
+	unique_lock<mutex> lock;
+};
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct SegmentNode {
+	idx_t row_start;
+	unique_ptr<T> node;
+};
+
+//! The SegmentTree maintains a list of all segments of a specific column in a table, and allows searching for a segment
+//! by row number
+template <class T, bool SUPPORTS_LAZY_LOADING = false>
+class SegmentTree {
+private:
+	class SegmentIterationHelper;
+
+public:
+	explicit SegmentTree() : finished_loading(true) {
+	}
+	virtual ~SegmentTree() {
+	}
+
+	//! Locks the segment tree. All methods to the segment tree either lock the segment tree, or take an already
+	//! obtained lock.
+	SegmentLock Lock() {
+		return SegmentLock(node_lock);
+	}
+
+	bool IsEmpty(SegmentLock &l) {
+		return GetRootSegment(l) == nullptr;
+	}
+
+	//! Gets a pointer to the first segment. Useful for scans.
+	T *GetRootSegment() {
+		auto l = Lock();
+		return GetRootSegment(l);
+	}
+
+	T *GetRootSegment(SegmentLock &l) {
+		if (nodes.empty()) {
+			LoadNextSegment(l);
+		}
+		return GetRootSegmentInternal();
+	}
+	//! Obtains ownership of the data of the segment tree
+	vector<SegmentNode<T>> MoveSegments(SegmentLock &l) {
+		LoadAllSegments(l);
+		return std::move(nodes);
+	}
+	vector<SegmentNode<T>> MoveSegments() {
+		auto l = Lock();
+		return MoveSegments(l);
+	}
+
+	const vector<SegmentNode<T>> &ReferenceSegments(SegmentLock &l) {
+		LoadAllSegments(l);
+		return nodes;
+	}
+	const vector<SegmentNode<T>> &ReferenceSegments() {
+		auto l = Lock();
+		return ReferenceSegments(l);
+	}
+
+	idx_t GetSegmentCount() {
+		auto l = Lock();
+		return GetSegmentCount(l);
+	}
+	idx_t GetSegmentCount(SegmentLock &l) {
+		return nodes.size();
+	}
+	//! Gets a pointer to the nth segment. Negative numbers start from the back.
+	T *GetSegmentByIndex(int64_t index) {
+		auto l = Lock();
+		return GetSegmentByIndex(l, index);
+	}
+	T *GetSegmentByIndex(SegmentLock &l, int64_t index) {
+		if (index < 0) {
+			// load all segments
+			LoadAllSegments(l);
+			index += nodes.size();
+			if (index < 0) {
+				return nullptr;
+			}
+			return nodes[UnsafeNumericCast<idx_t>(index)].node.get();
+		} else {
+			// lazily load segments until we reach the specific segment
+			while (idx_t(index) >= nodes.size() && LoadNextSegment(l)) {
+			}
+			if (idx_t(index) >= nodes.size()) {
+				return nullptr;
+			}
+			return nodes[UnsafeNumericCast<idx_t>(index)].node.get();
+		}
+	}
+	//! Gets the next segment
+	T *GetNextSegment(T *segment) {
+		if (!SUPPORTS_LAZY_LOADING) {
+			return segment->Next();
+		}
+		if (finished_loading) {
+			return segment->Next();
+		}
+		auto l = Lock();
+		return GetNextSegment(l, segment);
+	}
+	T *GetNextSegment(SegmentLock &l, T *segment) {
+		if (!segment) {
+			return nullptr;
+		}
+#ifdef DEBUG
+		D_ASSERT(nodes[segment->index].node.get() == segment);
+#endif
+		return GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment->index + 1));
+	}
+
+	//! Gets a pointer to the last segment. Useful for appends.
+	T *GetLastSegment(SegmentLock &l) {
+		LoadAllSegments(l);
+		if (nodes.empty()) {
+			return nullptr;
+		}
+		return nodes.back().node.get();
+	}
+	//! Gets a pointer to a specific column segment for the given row
+	T *GetSegment(idx_t row_number) {
+		auto l = Lock();
+		return GetSegment(l, row_number);
+	}
+	T *GetSegment(SegmentLock &l, idx_t row_number) {
+		return nodes[GetSegmentIndex(l, row_number)].node.get();
+	}
+
+	//! Append a column segment to the tree
+	void AppendSegmentInternal(SegmentLock &l, unique_ptr<T> segment) {
+		D_ASSERT(segment);
+		// add the node to the list of nodes
+		if (!nodes.empty()) {
+			nodes.back().node->next = segment.get();
+		}
+		SegmentNode<T> node;
+		segment->index = nodes.size();
+		segment->next = nullptr;
+		node.row_start = segment->start;
+		node.node = std::move(segment);
+		nodes.push_back(std::move(node));
+	}
+	void AppendSegment(unique_ptr<T> segment) {
+		auto l = Lock();
+		AppendSegment(l, std::move(segment));
+	}
+	void AppendSegment(SegmentLock &l, unique_ptr<T> segment) {
+		LoadAllSegments(l);
+		AppendSegmentInternal(l, std::move(segment));
+	}
+	//! Debug method, check whether the segment is in the segment tree
+	bool HasSegment(T *segment) {
+		auto l = Lock();
+		return HasSegment(l, segment);
+	}
+	bool HasSegment(SegmentLock &, T *segment) {
+		return segment->index < nodes.size() && nodes[segment->index].node.get() == segment;
+	}
+
+	//! Erase all segments after a specific segment
+	void EraseSegments(SegmentLock &l, idx_t segment_start) {
+		LoadAllSegments(l);
+		if (segment_start >= nodes.size() - 1) {
+			return;
+		}
+		nodes.erase(nodes.begin() + UnsafeNumericCast<int64_t>(segment_start) + 1, nodes.end());
+	}
+
+	//! Get the segment index of the column segment for the given row
+	idx_t GetSegmentIndex(SegmentLock &l, idx_t row_number) {
+		idx_t segment_index;
+		if (TryGetSegmentIndex(l, row_number, segment_index)) {
+			return segment_index;
+		}
+		string error;
+		error = StringUtil::Format("Attempting to find row number \"%lld\" in %lld nodes\n", row_number, nodes.size());
+		for (idx_t i = 0; i < nodes.size(); i++) {
+			error += StringUtil::Format("Node %lld: Start %lld, Count %lld", i, nodes[i].row_start,
+			                            nodes[i].node->count.load());
+		}
+		throw InternalException("Could not find node in column segment tree!\n%s%s", error, Exception::GetStackTrace());
+	}
+
+	bool TryGetSegmentIndex(SegmentLock &l, idx_t row_number, idx_t &result) {
+		// load segments until the row number is within bounds
+		while (nodes.empty() || (row_number >= (nodes.back().row_start + nodes.back().node->count))) {
+			if (!LoadNextSegment(l)) {
+				break;
+			}
+		}
+		if (nodes.empty()) {
+			return false;
+		}
+		idx_t lower = 0;
+		idx_t upper = nodes.size() - 1;
+		// binary search to find the node
+		while (lower <= upper) {
+			idx_t index = (lower + upper) / 2;
+			D_ASSERT(index < nodes.size());
+			auto &entry = nodes[index];
+			D_ASSERT(entry.row_start == entry.node->start);
+			if (row_number < entry.row_start) {
+				upper = index - 1;
+			} else if (row_number >= entry.row_start + entry.node->count) {
+				lower = index + 1;
+			} else {
+				result = index;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	void Verify(SegmentLock &) {
+#ifdef DEBUG
+		idx_t base_start = nodes.empty() ? 0 : nodes[0].node->start;
+		for (idx_t i = 0; i < nodes.size(); i++) {
+			D_ASSERT(nodes[i].row_start == nodes[i].node->start);
+			D_ASSERT(nodes[i].node->start == base_start);
+			base_start += nodes[i].node->count;
+		}
+#endif
+	}
+	void Verify() {
+#ifdef DEBUG
+		auto l = Lock();
+		Verify(l);
+#endif
+	}
+
+	SegmentIterationHelper Segments() {
+		return SegmentIterationHelper(*this);
+	}
+
+	void Reinitialize() {
+		if (nodes.empty()) {
+			return;
+		}
+		idx_t offset = nodes[0].node->start;
+		for (auto &entry : nodes) {
+			if (entry.node->start != offset) {
+				throw InternalException("In SegmentTree::Reinitialize - gap found between nodes!");
+			}
+			entry.row_start = offset;
+			offset += entry.node->count;
+		}
+	}
+
+protected:
+	atomic<bool> finished_loading;
+
+	//! Load the next segment - only used when lazily loading
+	virtual unique_ptr<T> LoadSegment() {
+		return nullptr;
+	}
+
+private:
+	//! The nodes in the tree, can be binary searched
+	vector<SegmentNode<T>> nodes;
+	//! Lock to access or modify the nodes
+	mutex node_lock;
+
+private:
+	T *GetRootSegmentInternal() {
+		return nodes.empty() ? nullptr : nodes[0].node.get();
+	}
+
+	class SegmentIterationHelper {
+	public:
+		explicit SegmentIterationHelper(SegmentTree &tree) : tree(tree) {
+		}
+
+	private:
+		SegmentTree &tree;
+
+	private:
+		class SegmentIterator {
+		public:
+			SegmentIterator(SegmentTree &tree_p, T *current_p) : tree(tree_p), current(current_p) {
+			}
+
+			SegmentTree &tree;
+			T *current;
+
+		public:
+			void Next() {
+				current = tree.GetNextSegment(current);
+			}
+
+			SegmentIterator &operator++() {
+				Next();
+				return *this;
+			}
+			bool operator!=(const SegmentIterator &other) const {
+				return current != other.current;
+			}
+			T &operator*() const {
+				D_ASSERT(current);
+				return *current;
+			}
+		};
+
+	public:
+		SegmentIterator begin() { // NOLINT: match stl API
+			return SegmentIterator(tree, tree.GetRootSegment());
+		}
+		SegmentIterator end() { // NOLINT: match stl API
+			return SegmentIterator(tree, nullptr);
+		}
+	};
+
+	//! Load the next segment, if there are any left to load
+	bool LoadNextSegment(SegmentLock &l) {
+		if (!SUPPORTS_LAZY_LOADING) {
+			return false;
+		}
+		if (finished_loading) {
+			return false;
+		}
+		auto result = LoadSegment();
+		if (result) {
+			AppendSegmentInternal(l, std::move(result));
+			return true;
+		}
+		return false;
+	}
+
+	//! Load all segments, if there are any left to load
+	void LoadAllSegments(SegmentLock &l) {
+		if (!SUPPORTS_LAZY_LOADING) {
+			return;
+		}
+		while (LoadNextSegment(l)) {
+		}
+	}
+};
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct ParallelTableScanState;
+struct ParallelCollectionScanState;
+class CreateIndexScanState;
+class CollectionScanState;
+class PersistentTableData;
+class TableDataWriter;
+class TableIndexList;
+class TableStatistics;
+struct TableAppendState;
+class DuckTransaction;
+class BoundConstraint;
+class RowGroupSegmentTree;
+class StorageCommitState;
+struct ColumnSegmentInfo;
+class MetadataManager;
+struct VacuumState;
+struct CollectionCheckpointState;
+struct PersistentCollectionData;
+class CheckpointTask;
+class TableIOManager;
+
+class RowGroupCollection {
+public:
+	RowGroupCollection(shared_ptr<DataTableInfo> info, TableIOManager &io_manager, vector<LogicalType> types,
+	                   idx_t row_start, idx_t total_rows = 0);
+	RowGroupCollection(shared_ptr<DataTableInfo> info, BlockManager &block_manager, vector<LogicalType> types,
+	                   idx_t row_start, idx_t total_rows, idx_t row_group_size);
+
+public:
+	idx_t GetTotalRows() const;
+	Allocator &GetAllocator() const;
+
+	void Initialize(PersistentCollectionData &data);
+	void Initialize(PersistentTableData &data);
+	void InitializeEmpty();
+
+	bool IsEmpty() const;
+
+	void AppendRowGroup(SegmentLock &l, idx_t start_row);
+	//! Get the nth row-group, negative numbers start from the back (so -1 is the last row group, etc)
+	RowGroup *GetRowGroup(int64_t index);
+	void Verify();
+
+	void InitializeScan(CollectionScanState &state, const vector<StorageIndex> &column_ids,
+	                    optional_ptr<TableFilterSet> table_filters);
+	void InitializeCreateIndexScan(CreateIndexScanState &state);
+	void InitializeScanWithOffset(CollectionScanState &state, const vector<StorageIndex> &column_ids, idx_t start_row,
+	                              idx_t end_row);
+	static bool InitializeScanInRowGroup(CollectionScanState &state, RowGroupCollection &collection,
+	                                     RowGroup &row_group, idx_t vector_index, idx_t max_row);
+	void InitializeParallelScan(ParallelCollectionScanState &state);
+	bool NextParallelScan(ClientContext &context, ParallelCollectionScanState &state, CollectionScanState &scan_state);
+
+	bool Scan(DuckTransaction &transaction, const vector<StorageIndex> &column_ids,
+	          const std::function<bool(DataChunk &chunk)> &fun);
+	bool Scan(DuckTransaction &transaction, const std::function<bool(DataChunk &chunk)> &fun);
+
+	void Fetch(TransactionData transaction, DataChunk &result, const vector<StorageIndex> &column_ids,
+	           const Vector &row_identifiers, idx_t fetch_count, ColumnFetchState &state);
+
+	//! Initialize an append of a variable number of rows. FinalizeAppend must be called after appending is done.
+	void InitializeAppend(TableAppendState &state);
+	//! Initialize an append with a variable number of rows. FinalizeAppend should not be called after appending is
+	//! done.
+	void InitializeAppend(TransactionData transaction, TableAppendState &state);
+	//! Appends to the row group collection. Returns true if a new row group has been created to append to
+	bool Append(DataChunk &chunk, TableAppendState &state);
+	//! FinalizeAppend flushes an append with a variable number of rows.
+	void FinalizeAppend(TransactionData transaction, TableAppendState &state);
+	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
+	void RevertAppendInternal(idx_t start_row);
+	void CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count);
+
+	void MergeStorage(RowGroupCollection &data, optional_ptr<DataTable> table,
+	                  optional_ptr<StorageCommitState> commit_state);
+	bool IsPersistent() const;
+
+	void RemoveFromIndexes(TableIndexList &indexes, Vector &row_identifiers, idx_t count);
+
+	idx_t Delete(TransactionData transaction, DataTable &table, row_t *ids, idx_t count);
+	void Update(TransactionData transaction, row_t *ids, const vector<PhysicalIndex> &column_ids, DataChunk &updates);
+	void UpdateColumn(TransactionData transaction, Vector &row_ids, const vector<column_t> &column_path,
+	                  DataChunk &updates);
+
+	void Checkpoint(TableDataWriter &writer, TableStatistics &global_stats);
+
+	void InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
+	                           vector<SegmentNode<RowGroup>> &segments);
+	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx,
+	                         bool schedule_vacuum);
+	unique_ptr<CheckpointTask> GetCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);
+
+	void CommitDropColumn(const idx_t column_index);
+	void CommitDropTable();
+
+	vector<PartitionStatistics> GetPartitionStats() const;
+	vector<ColumnSegmentInfo> GetColumnSegmentInfo();
+	const vector<LogicalType> &GetTypes() const;
+
+	shared_ptr<RowGroupCollection> AddColumn(ClientContext &context, ColumnDefinition &new_column,
+	                                         ExpressionExecutor &default_executor);
+	shared_ptr<RowGroupCollection> RemoveColumn(idx_t col_idx);
+	shared_ptr<RowGroupCollection> AlterType(ClientContext &context, idx_t changed_idx, const LogicalType &target_type,
+	                                         vector<StorageIndex> bound_columns, Expression &cast_expr);
+	void VerifyNewConstraint(DataTable &parent, const BoundConstraint &constraint);
+
+	void CopyStats(TableStatistics &stats);
+	unique_ptr<BaseStatistics> CopyStats(column_t column_id);
+	unique_ptr<BlockingSample> GetSample();
+	void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
+
+	AttachedDatabase &GetAttached();
+	BlockManager &GetBlockManager() {
+		return block_manager;
+	}
+	MetadataManager &GetMetadataManager();
+	DataTableInfo &GetTableInfo() {
+		return *info;
+	}
+
+	idx_t GetAllocationSize() const {
+		return allocation_size;
+	}
+
+	idx_t GetRowGroupSize() const {
+		return row_group_size;
+	}
+
+private:
+	bool IsEmpty(SegmentLock &) const;
+
+private:
+	//! BlockManager
+	BlockManager &block_manager;
+	//! The row group size of the row group collection
+	const idx_t row_group_size;
+	//! The number of rows in the table
+	atomic<idx_t> total_rows;
+	//! The data table info
+	shared_ptr<DataTableInfo> info;
+	//! The column types of the row group collection
+	vector<LogicalType> types;
+	idx_t row_start;
+	//! The segment trees holding the various row_groups of the table
+	shared_ptr<RowGroupSegmentTree> row_groups;
+	//! Table statistics
+	TableStatistics stats;
+	//! Allocation size, only tracked for appends
+	idx_t allocation_size;
+};
+
+} // namespace duckdb
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/transaction/local_storage.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/optimistic_data_writer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+class PartialBlockManager;
+
+class OptimisticDataWriter {
+public:
+	explicit OptimisticDataWriter(DataTable &table);
+	OptimisticDataWriter(DataTable &table, OptimisticDataWriter &parent);
+	~OptimisticDataWriter();
+
+	//! Write a new row group to disk (if possible)
+	void WriteNewRowGroup(RowGroupCollection &row_groups);
+	//! Write the last row group of a collection to disk
+	void WriteLastRowGroup(RowGroupCollection &row_groups);
+	//! Final flush of the optimistic writer - fully flushes the partial block manager
+	void FinalFlush();
+	//! Flushes a specific row group to disk
+	void FlushToDisk(RowGroup &row_group);
+	//! Merge the partially written blocks from one optimistic writer into another
+	void Merge(OptimisticDataWriter &other);
+	//! Rollback
+	void Rollback();
+
+private:
+	//! Prepare a write to disk
+	bool PrepareWrite();
+
+private:
+	//! The table
+	DataTable &table;
+	//! The partial block manager, if any was created.
+	unique_ptr<PartialBlockManager> partial_manager;
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+class AttachedDatabase;
+class Catalog;
+class DataTable;
+class StorageCommitState;
+class Transaction;
+class WriteAheadLog;
+struct LocalAppendState;
+struct TableAppendState;
+
+class LocalTableStorage : public enable_shared_from_this<LocalTableStorage> {
+public:
+	// Create a new LocalTableStorage
+	explicit LocalTableStorage(ClientContext &context, DataTable &table);
+	//! Create a LocalTableStorage from an ALTER TYPE.
+	LocalTableStorage(ClientContext &context, DataTable &new_data_table, LocalTableStorage &parent,
+	                  const idx_t alter_column_index, const LogicalType &target_type,
+	                  const vector<StorageIndex> &bound_columns, Expression &cast_expr);
+	//! Create a LocalTableStorage from a DROP COLUMN.
+	LocalTableStorage(DataTable &new_data_table, LocalTableStorage &parent, const idx_t drop_column_index);
+	// Create a LocalTableStorage from an ADD COLUMN
+	LocalTableStorage(ClientContext &context, DataTable &table, LocalTableStorage &parent, ColumnDefinition &new_column,
+	                  ExpressionExecutor &default_executor);
+	~LocalTableStorage();
+
+	reference<DataTable> table_ref;
+
+	Allocator &allocator;
+	//! The main row group collection.
+	shared_ptr<RowGroupCollection> row_groups;
+	//! The set of unique append indexes.
+	TableIndexList append_indexes;
+	//! The set of delete indexes.
+	TableIndexList delete_indexes;
+	//! Set to INSERT_DUPLICATES, if we are skipping constraint checking during, e.g., WAL replay.
+	IndexAppendMode index_append_mode = IndexAppendMode::DEFAULT;
+	//! The number of deleted rows
+	idx_t deleted_rows;
+
+	//! The optimistic row group collections associated with this table.
+	vector<unique_ptr<RowGroupCollection>> optimistic_collections;
+	//! The main optimistic data writer associated with this table.
+	OptimisticDataWriter optimistic_writer;
+
+	//! Whether or not storage was merged
+	bool merged_storage = false;
+	//! Whether or not the storage was dropped
+	bool is_dropped = false;
+
+public:
+	void InitializeScan(CollectionScanState &state, optional_ptr<TableFilterSet> table_filters = nullptr);
+	//! Write a new row group to disk (if possible)
+	void WriteNewRowGroup();
+	void FlushBlocks();
+	void Rollback();
+	idx_t EstimatedSize();
+
+	void AppendToIndexes(DuckTransaction &transaction, TableAppendState &append_state, bool append_to_table);
+	ErrorData AppendToIndexes(DuckTransaction &transaction, RowGroupCollection &source, TableIndexList &index_list,
+	                          const vector<LogicalType> &table_types, row_t &start_row);
+	void AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete_chunk);
+
+	//! Create an optimistic row group collection for this table.
+	//! Returns the index into the optimistic_collections vector for newly created collection.
+	PhysicalIndex CreateOptimisticCollection(unique_ptr<RowGroupCollection> collection);
+	//! Returns the optimistic row group collection corresponding to the index.
+	RowGroupCollection &GetOptimisticCollection(const PhysicalIndex collection_index);
+	//! Resets the optimistic row group collection corresponding to the index.
+	void ResetOptimisticCollection(const PhysicalIndex collection_index);
+	//! Returns the optimistic writer.
+	OptimisticDataWriter &GetOptimisticWriter();
+
+private:
+	mutex collections_lock;
+};
+
+class LocalTableManager {
+public:
+	shared_ptr<LocalTableStorage> MoveEntry(DataTable &table);
+	reference_map_t<DataTable, shared_ptr<LocalTableStorage>> MoveEntries();
+	optional_ptr<LocalTableStorage> GetStorage(DataTable &table) const;
+	LocalTableStorage &GetOrCreateStorage(ClientContext &context, DataTable &table);
+	idx_t EstimatedSize() const;
+	bool IsEmpty() const;
+	void InsertEntry(DataTable &table, shared_ptr<LocalTableStorage> entry);
+
+private:
+	mutable mutex table_storage_lock;
+	reference_map_t<DataTable, shared_ptr<LocalTableStorage>> table_storage;
+};
+
+//! The LocalStorage class holds appends that have not been committed yet
+class LocalStorage {
+public:
+	struct CommitState {
+		CommitState();
+		~CommitState();
+
+		reference_map_t<DataTable, unique_ptr<TableAppendState>> append_states;
+	};
+
+public:
+	explicit LocalStorage(ClientContext &context, DuckTransaction &transaction);
+
+	static LocalStorage &Get(DuckTransaction &transaction);
+	static LocalStorage &Get(ClientContext &context, AttachedDatabase &db);
+	static LocalStorage &Get(ClientContext &context, Catalog &catalog);
+
+	//! Initialize a scan of the local storage
+	void InitializeScan(DataTable &table, CollectionScanState &state, optional_ptr<TableFilterSet> table_filters);
+	//! Scan
+	void Scan(CollectionScanState &state, const vector<StorageIndex> &column_ids, DataChunk &result);
+
+	void InitializeParallelScan(DataTable &table, ParallelCollectionScanState &state);
+	bool NextParallelScan(ClientContext &context, DataTable &table, ParallelCollectionScanState &state,
+	                      CollectionScanState &scan_state);
+
+	//! Begin appending to the local storage
+	void InitializeAppend(LocalAppendState &state, DataTable &table);
+	//! Initialize the storage and its indexes, but no row groups.
+	void InitializeStorage(LocalAppendState &state, DataTable &table);
+	//! Append a chunk to the local storage
+	static void Append(LocalAppendState &state, DataChunk &chunk);
+	//! Finish appending to the local storage
+	static void FinalizeAppend(LocalAppendState &state);
+	//! Merge a row group collection into the transaction-local storage
+	void LocalMerge(DataTable &table, RowGroupCollection &collection);
+	//! Create an optimistic row group collection for this table.
+	//! Returns the index into the optimistic_collections vector for newly created collection.
+	PhysicalIndex CreateOptimisticCollection(DataTable &table, unique_ptr<RowGroupCollection> collection);
+	//! Returns the optimistic row group collection corresponding to the index.
+	RowGroupCollection &GetOptimisticCollection(DataTable &table, const PhysicalIndex collection_index);
+	//! Resets the optimistic row group collection corresponding to the index.
+	void ResetOptimisticCollection(DataTable &table, const PhysicalIndex collection_index);
+	//! Returns the optimistic writer.
+	OptimisticDataWriter &GetOptimisticWriter(DataTable &table);
+
+	//! Delete a set of rows from the local storage
+	idx_t Delete(DataTable &table, Vector &row_ids, idx_t count);
+	//! Update a set of rows in the local storage
+	void Update(DataTable &table, Vector &row_ids, const vector<PhysicalIndex> &column_ids, DataChunk &data);
+
+	//! Commits the local storage, writing it to the WAL and completing the commit
+	void Commit(optional_ptr<StorageCommitState> commit_state);
+	//! Rollback the local storage
+	void Rollback();
+
+	bool ChangesMade() noexcept;
+	idx_t EstimatedSize();
+
+	void DropTable(DataTable &table);
+	bool Find(DataTable &table);
+
+	idx_t AddedRows(DataTable &table);
+	vector<PartitionStatistics> GetPartitionStats(DataTable &table) const;
+
+	void AddColumn(DataTable &old_dt, DataTable &new_dt, ColumnDefinition &new_column,
+	               ExpressionExecutor &default_executor);
+	void DropColumn(DataTable &old_dt, DataTable &new_dt, const idx_t drop_column_index);
+	void ChangeType(DataTable &old_dt, DataTable &new_dt, idx_t changed_idx, const LogicalType &target_type,
+	                const vector<StorageIndex> &bound_columns, Expression &cast_expr);
+
+	void MoveStorage(DataTable &old_dt, DataTable &new_dt);
+	void FetchChunk(DataTable &table, Vector &row_ids, idx_t count, const vector<StorageIndex> &col_ids,
+	                DataChunk &chunk, ColumnFetchState &fetch_state);
+	TableIndexList &GetIndexes(ClientContext &context, DataTable &table);
+	optional_ptr<LocalTableStorage> GetStorage(DataTable &table);
+
+	void VerifyNewConstraint(DataTable &parent, const BoundConstraint &constraint);
+
+private:
+	ClientContext &context;
+	DuckTransaction &transaction;
+	LocalTableManager table_manager;
+
+private:
+	void Flush(DataTable &table, LocalTableStorage &storage, optional_ptr<StorageCommitState> commit_state);
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class BoundForeignKeyConstraint;
+class ClientContext;
+class ColumnDataCollection;
+class ColumnDefinition;
+class DataTable;
+class DuckTransaction;
+class RowGroup;
+class StorageManager;
+class TableCatalogEntry;
+class TableIOManager;
+class Transaction;
+class WriteAheadLog;
+class TableDataWriter;
+class ConflictManager;
+class TableScanState;
+struct TableDeleteState;
+struct ConstraintState;
+struct TableUpdateState;
+enum class VerifyExistenceType : uint8_t;
+
+enum class DataTableVersion {
+	MAIN_TABLE, // this is the newest version of the table - it has not been altered or dropped
+	ALTERED,    // this table has been altered
+	DROPPED     // this table has been dropped
+};
+
+//! DataTable represents a physical table on disk
+class DataTable : public enable_shared_from_this<DataTable> {
+public:
+	//! Constructs a new data table from an (optional) set of persistent segments
+	DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager, const string &schema,
+	          const string &table, vector<ColumnDefinition> column_definitions_p,
+	          unique_ptr<PersistentTableData> data = nullptr);
+	//! Constructs a DataTable as a delta on an existing data table with a newly added column
+	DataTable(ClientContext &context, DataTable &parent, ColumnDefinition &new_column, Expression &default_value);
+	//! Constructs a DataTable as a delta on an existing data table but with one column removed
+	DataTable(ClientContext &context, DataTable &parent, idx_t removed_column);
+	//! Constructs a DataTable as a delta on an existing data table but with one column changed type
+	DataTable(ClientContext &context, DataTable &parent, idx_t changed_idx, const LogicalType &target_type,
+	          const vector<StorageIndex> &bound_columns, Expression &cast_expr);
+	//! Constructs a DataTable as a delta on an existing data table but with one column added new constraint
+	DataTable(ClientContext &context, DataTable &parent, BoundConstraint &constraint);
+
+	//! A reference to the database instance
+	AttachedDatabase &db;
+
+public:
+	AttachedDatabase &GetAttached();
+	TableIOManager &GetTableIOManager();
+
+	bool IsTemporary() const;
+
+	//! Returns a list of types of the table
+	vector<LogicalType> GetTypes();
+	const vector<ColumnDefinition> &Columns() const;
+
+	void InitializeScan(ClientContext &context, DuckTransaction &transaction, TableScanState &state,
+	                    const vector<StorageIndex> &column_ids, optional_ptr<TableFilterSet> table_filters = nullptr);
+
+	//! Returns the maximum amount of threads that should be assigned to scan this data table
+	idx_t MaxThreads(ClientContext &context) const;
+	void InitializeParallelScan(ClientContext &context, ParallelTableScanState &state);
+	bool NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state);
+
+	//! Scans up to STANDARD_VECTOR_SIZE elements from the table starting
+	//! from offset and store them in result. Offset is incremented with how many
+	//! elements were returned.
+	//! Returns true if all pushed down filters were executed during data fetching
+	void Scan(DuckTransaction &transaction, DataChunk &result, TableScanState &state);
+
+	//! Fetch data from the specific row identifiers from the base table
+	void Fetch(DuckTransaction &transaction, DataChunk &result, const vector<StorageIndex> &column_ids,
+	           const Vector &row_ids, idx_t fetch_count, ColumnFetchState &state);
+
+	//! Initializes appending to transaction-local storage
+	void InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+	                           const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Initializes only the delete-indexes of the transaction-local storage
+	void InitializeLocalStorage(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+	                            const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Append a DataChunk to the transaction-local storage of the table.
+	void LocalAppend(LocalAppendState &state, ClientContext &context, DataChunk &chunk, bool unsafe);
+	//! Finalizes a transaction-local append
+	void FinalizeLocalAppend(LocalAppendState &state);
+	//! Append a chunk to the transaction-local storage of this table and update the delete indexes.
+	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints, Vector &row_ids,
+	                 DataChunk &delete_chunk);
+	//! Appends to the transaction-local storage of this table
+	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Append a chunk to the transaction-local storage of this table.
+	void LocalWALAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	                    const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Append a column data collection with default values to the transaction-local storage of this table.
+	void LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection,
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints,
+	                 optional_ptr<const vector<LogicalIndex>> column_ids);
+	//! Merge a row group collection into the transaction-local storage
+	void LocalMerge(ClientContext &context, RowGroupCollection &collection);
+	//! Create an optimistic row group collection for this table. Used for optimistically writing parallel appends.
+	//! Returns the index into the optimistic_collections vector for newly created collection.
+	PhysicalIndex CreateOptimisticCollection(ClientContext &context, unique_ptr<RowGroupCollection> collection);
+	//! Returns the optimistic row group collection corresponding to the index.
+	RowGroupCollection &GetOptimisticCollection(ClientContext &context, const PhysicalIndex collection_index);
+	//! Resets the optimistic row group collection corresponding to the index.
+	void ResetOptimisticCollection(ClientContext &context, const PhysicalIndex collection_index);
+	//! Returns the optimistic writer of the corresponding local table.
+	OptimisticDataWriter &GetOptimisticWriter(ClientContext &context);
+
+	unique_ptr<TableDeleteState> InitializeDelete(TableCatalogEntry &table, ClientContext &context,
+	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Delete the entries with the specified row identifier from the table
+	idx_t Delete(TableDeleteState &state, ClientContext &context, Vector &row_ids, idx_t count);
+
+	unique_ptr<TableUpdateState> InitializeUpdate(TableCatalogEntry &table, ClientContext &context,
+	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Update the entries with the specified row identifier from the table
+	void Update(TableUpdateState &state, ClientContext &context, Vector &row_ids,
+	            const vector<PhysicalIndex> &column_ids, DataChunk &data);
+	//! Update a single (sub-)column along a column path
+	//! The column_path vector is a *path* towards a column within the table
+	//! i.e. if we have a table with a single column S STRUCT(A INT, B INT)
+	//! and we update the validity mask of "S.B"
+	//! the column path is:
+	//! 0 (first column of table)
+	//! -> 1 (second subcolumn of struct)
+	//! -> 0 (first subcolumn of INT)
+	//! This method should only be used from the WAL replay. It does not verify update constraints.
+	void UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
+	                  const vector<column_t> &column_path, DataChunk &updates);
+
+	//! Fetches an append lock
+	void AppendLock(TableAppendState &state);
+	//! Begin appending structs to this table, obtaining necessary locks, etc
+	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state);
+	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
+	void Append(DataChunk &chunk, TableAppendState &state);
+	//! Finalize an append
+	void FinalizeAppend(DuckTransaction &transaction, TableAppendState &state);
+	//! Commit the append
+	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
+	//! Write a segment of the table to the WAL
+	void WriteToLog(DuckTransaction &transaction, WriteAheadLog &log, idx_t row_start, idx_t count,
+	                optional_ptr<StorageCommitState> commit_state);
+	//! Revert a set of appends made by the given AppendState, used to revert appends in the event of an error during
+	//! commit (e.g. because of an I/O exception)
+	void RevertAppend(DuckTransaction &transaction, idx_t start_row, idx_t count);
+	void RevertAppendInternal(idx_t start_row);
+
+	void ScanTableSegment(DuckTransaction &transaction, idx_t start_row, idx_t count,
+	                      const std::function<void(DataChunk &chunk)> &function);
+
+	//! Merge a row group collection directly into this table - appending it to the end of the table without copying
+	void MergeStorage(RowGroupCollection &data, TableIndexList &indexes, optional_ptr<StorageCommitState> commit_state);
+
+	//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table.
+	//! Returns empty ErrorData, if the append was successful.
+	ErrorData AppendToIndexes(optional_ptr<TableIndexList> delete_indexes, DataChunk &chunk, row_t row_start,
+	                          const IndexAppendMode index_append_mode);
+	static ErrorData AppendToIndexes(TableIndexList &indexes, optional_ptr<TableIndexList> delete_indexes,
+	                                 DataChunk &chunk, row_t row_start, const IndexAppendMode index_append_mode);
+	//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
+	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start);
+	//! Remove the chunk with the specified set of row identifiers from all indexes of the table
+	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, Vector &row_identifiers);
+	//! Remove the row identifiers from all the indexes of the table
+	void RemoveFromIndexes(Vector &row_identifiers, idx_t count);
+
+	void SetAsMainTable() {
+		this->version = DataTableVersion::MAIN_TABLE;
+	}
+
+	void SetAsDropped() {
+		this->version = DataTableVersion::DROPPED;
+	}
+
+	bool IsMainTable() const {
+		return this->version == DataTableVersion::MAIN_TABLE;
+	}
+	bool IsRoot() const {
+		return IsMainTable();
+	}
+	string TableModification() const;
+
+	//! Get statistics of a physical column within the table
+	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id);
+
+	//! Get table sample
+	unique_ptr<BlockingSample> GetSample();
+	//! Sets statistics of a physical column within the table
+	void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
+
+	//! Obtains a shared lock to prevent checkpointing while operations are running
+	unique_ptr<StorageLockKey> GetSharedCheckpointLock();
+	//! Obtains a lock during a checkpoint operation that prevents other threads from reading this table
+	unique_ptr<StorageLockKey> GetCheckpointLock();
+	//! Checkpoint the table to the specified table data writer
+	void Checkpoint(TableDataWriter &writer, Serializer &serializer);
+	void CommitDropTable();
+	void CommitDropColumn(const idx_t column_index);
+
+	idx_t ColumnCount() const;
+	idx_t GetTotalRows() const;
+
+	vector<ColumnSegmentInfo> GetColumnSegmentInfo();
+
+	//! Scans the next chunk for the CREATE INDEX operator
+	bool CreateIndexScan(TableScanState &state, DataChunk &result, TableScanType type);
+	//! Returns true, if the index name is unique (i.e., no PK, UNIQUE, FK constraint has the same name)
+	//! FIXME: This is only necessary until we treat all indexes as catalog entries, allowing to alter constraints
+	bool IndexNameIsUnique(const string &name);
+
+	//! Initialize constraint verification state
+	unique_ptr<ConstraintState> InitializeConstraintState(TableCatalogEntry &table,
+	                                                      const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Verify constraints with a chunk from the Append containing all columns of the table
+	void VerifyAppendConstraints(ConstraintState &constraint_state, ClientContext &context, DataChunk &chunk,
+	                             optional_ptr<LocalTableStorage> local_storage, optional_ptr<ConflictManager> manager);
+
+	shared_ptr<DataTableInfo> &GetDataTableInfo();
+
+	void InitializeIndexes(ClientContext &context);
+	bool HasIndexes() const;
+	bool HasUniqueIndexes() const;
+	bool HasForeignKeyIndex(const vector<PhysicalIndex> &keys, ForeignKeyType type);
+	void SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info);
+	void VacuumIndexes();
+	void VerifyIndexBuffers();
+	void CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count);
+
+	string GetTableName() const;
+	void SetTableName(string new_name);
+
+	TableStorageInfo GetStorageInfo();
+
+	idx_t GetRowGroupSize() const;
+
+	static void VerifyUniqueIndexes(TableIndexList &indexes, optional_ptr<LocalTableStorage> storage, DataChunk &chunk,
+	                                optional_ptr<ConflictManager> manager);
+
+	//! AddIndex initializes an index and adds it to the table's index list.
+	//! It is either empty, or initialized via its index storage information.
+	void AddIndex(const ColumnList &columns, const vector<LogicalIndex> &column_indexes, const IndexConstraintType type,
+	              const IndexStorageInfo &info);
+	//! AddIndex moves an index to this table's index list.
+	void AddIndex(unique_ptr<Index> index);
+
+	//! Returns a list of the partition stats
+	vector<PartitionStatistics> GetPartitionStats(ClientContext &context);
+
+private:
+	//! Verify the new added constraints against current persistent&local data
+	void VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint);
+
+	//! Verify constraints with a chunk from the Update containing only the specified column_ids
+	void VerifyUpdateConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
+	                             const vector<PhysicalIndex> &column_ids);
+	//! Verify constraints with a chunk from the Delete containing all columns of the table
+	void VerifyDeleteConstraints(optional_ptr<LocalTableStorage> storage, TableDeleteState &state,
+	                             ClientContext &context, DataChunk &chunk);
+
+	void InitializeScanWithOffset(DuckTransaction &transaction, TableScanState &state,
+	                              const vector<StorageIndex> &column_ids, idx_t start_row, idx_t end_row);
+
+	void VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+	                                const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	                                DataChunk &chunk, VerifyExistenceType type);
+	void VerifyAppendForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+	                                      const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	                                      DataChunk &chunk);
+	void VerifyDeleteForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+	                                      const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	                                      DataChunk &chunk);
+
+private:
+	//! The table info
+	shared_ptr<DataTableInfo> info;
+	//! The set of physical columns stored by this DataTable
+	vector<ColumnDefinition> column_definitions;
+	//! Lock for appending entries to the table
+	mutex append_lock;
+	//! The row groups of the table
+	shared_ptr<RowGroupCollection> row_groups;
+	//! The version of the data table
+	atomic<DataTableVersion> version;
+};
+} // namespace duckdb
+
+#include <functional>
+#include <map>
+
+namespace duckdb {
+class Optimizer;
+
+enum class ValueComparisonResult { PRUNE_LEFT, PRUNE_RIGHT, UNSATISFIABLE_CONDITION, PRUNE_NOTHING };
+enum class FilterResult { UNSATISFIABLE, SUCCESS, UNSUPPORTED };
+enum class FilterPushdownResult { NO_PUSHDOWN, PUSHED_DOWN_PARTIALLY, PUSHED_DOWN_FULLY };
+
+//! The FilterCombiner combines several filters and generates a logically equivalent set that is more efficient
+//! Amongst others:
+//! (1) it prunes obsolete filter conditions: i.e. [X > 5 and X > 7] => [X > 7]
+//! (2) it generates new filters for expressions in the same equivalence set: i.e. [X = Y and X = 500] => [Y = 500]
+//! (3) it prunes branches that have unsatisfiable filters: i.e. [X = 5 AND X > 6] => FALSE, prune branch
+class FilterCombiner {
+public:
+	explicit FilterCombiner(ClientContext &context);
+	explicit FilterCombiner(Optimizer &optimizer);
+
+	ClientContext &context;
+
+public:
+	struct ExpressionValueInformation {
+		Value constant;
+		ExpressionType comparison_type;
+	};
+
+	FilterResult AddFilter(unique_ptr<Expression> expr);
+
+	//! Returns whether or not a set of integral values is a dense range (i.e. 1, 2, 3, 4, 5)
+	//! If this returns true - this sorts "in_list" as a side-effect
+	static bool IsDenseRange(vector<Value> &in_list);
+	static bool ContainsNull(vector<Value> &in_list);
+
+	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
+	bool HasFilters();
+	TableFilterSet GenerateTableScanFilters(const vector<ColumnIndex> &column_ids,
+	                                        vector<FilterPushdownResult> &pushdown_results);
+
+	FilterPushdownResult TryPushdownGenericExpression(LogicalGet &get, Expression &expr);
+
+private:
+	FilterResult AddFilter(Expression &expr);
+	FilterResult AddBoundComparisonFilter(Expression &expr);
+	FilterResult AddTransitiveFilters(BoundComparisonExpression &comparison, bool is_root = true);
+	unique_ptr<Expression> FindTransitiveFilter(Expression &expr);
+	Expression &GetNode(Expression &expr);
+	idx_t GetEquivalenceSet(Expression &expr);
+	FilterResult AddConstantComparison(vector<ExpressionValueInformation> &info_list, ExpressionValueInformation info);
+
+	FilterPushdownResult TryPushdownConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                               column_t column_id, vector<ExpressionValueInformation> &info_list);
+	FilterPushdownResult TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                           Expression &expr);
+	FilterPushdownResult TryPushdownPrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                             Expression &expr);
+	FilterPushdownResult TryPushdownLikeFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                           Expression &expr);
+	FilterPushdownResult TryPushdownInFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                         Expression &expr);
+	FilterPushdownResult TryPushdownOrClause(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                         Expression &expr);
+
+private:
+	vector<unique_ptr<Expression>> remaining_filters;
+
+	expression_map_t<unique_ptr<Expression>> stored_expressions;
+	expression_map_t<idx_t> equivalence_set_map;
+	map<idx_t, vector<ExpressionValueInformation>> constant_values;
+	map<idx_t, vector<reference<Expression>>> equivalence_map;
+	idx_t set_index = 0;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/statistics_propagator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class Optimizer;
+class ClientContext;
+class LogicalOperator;
+class TableFilter;
+struct BoundOrderByNode;
+
+class StatisticsPropagator {
+public:
+	StatisticsPropagator(Optimizer &optimizer, LogicalOperator &root);
+
+	unique_ptr<NodeStatistics> PropagateStatistics(unique_ptr<LogicalOperator> &node_ptr);
+
+	column_binding_map_t<unique_ptr<BaseStatistics>> GetStatisticsMap() {
+		return std::move(statistics_map);
+	}
+
+	//! Whether or not we can propagate a cast between two types
+	static bool CanPropagateCast(const LogicalType &source, const LogicalType &target);
+	static unique_ptr<BaseStatistics> TryPropagateCast(BaseStatistics &stats, const LogicalType &source,
+	                                                   const LogicalType &target);
+
+private:
+	//! Propagate statistics through an operator
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalOperator &node, unique_ptr<LogicalOperator> &node_ptr);
+
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalFilter &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalGet &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalJoin &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalPositionalJoin &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalProjection &op, unique_ptr<LogicalOperator> &node_ptr);
+	void PropagateStatistics(LogicalComparisonJoin &op, unique_ptr<LogicalOperator> &node_ptr);
+	void PropagateStatistics(LogicalAnyJoin &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalSetOperation &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalAggregate &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalCrossProduct &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalLimit &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalOrder &op, unique_ptr<LogicalOperator> &node_ptr);
+	unique_ptr<NodeStatistics> PropagateStatistics(LogicalWindow &op, unique_ptr<LogicalOperator> &node_ptr);
+
+	unique_ptr<NodeStatistics> PropagateChildren(LogicalOperator &node, unique_ptr<LogicalOperator> &node_ptr);
+
+	//! Return statistics from a constant value
+	unique_ptr<BaseStatistics> StatisticsFromValue(const Value &input);
+	//! Run a comparison with two sets of statistics, returns if the comparison will always returns true/false or not
+	FilterPropagateResult PropagateComparison(BaseStatistics &left, BaseStatistics &right, ExpressionType comparison);
+
+	//! Update filter statistics from a filter with a constant
+	void UpdateFilterStatistics(BaseStatistics &input, ExpressionType comparison_type, const Value &constant);
+	//! Update statistics from a filter between two stats
+	void UpdateFilterStatistics(BaseStatistics &lstats, BaseStatistics &rstats, ExpressionType comparison_type);
+	//! Update filter statistics from a generic comparison
+	void UpdateFilterStatistics(Expression &left, Expression &right, ExpressionType comparison_type);
+	//! Update filter statistics from an expression
+	void UpdateFilterStatistics(Expression &condition);
+	//! Set the statistics of a specific column binding to not contain null values
+	void SetStatisticsNotNull(ColumnBinding binding);
+	//! Propagate a filter condition
+	FilterPropagateResult HandleFilter(unique_ptr<Expression> &condition);
+
+	//! Run a comparison between the statistics and the table filter; returns the prune result
+	FilterPropagateResult PropagateTableFilter(ColumnBinding stats_binding, BaseStatistics &stats, TableFilter &filter);
+	//! Update filter statistics from a TableFilter
+	void UpdateFilterStatistics(BaseStatistics &input, TableFilter &filter);
+
+	//! Add cardinalities together (i.e. new max is stats.max + new_stats.max): used for union
+	void AddCardinalities(unique_ptr<NodeStatistics> &stats, NodeStatistics &new_stats);
+	//! Multiply the cardinalities together (i.e. new max cardinality is stats.max * new_stats.max): used for
+	//! joins/cross products
+	void MultiplyCardinalities(unique_ptr<NodeStatistics> &stats, NodeStatistics &new_stats);
+	//! Creates and pushes down a filter based on join statistics
+	void CreateFilterFromJoinStats(unique_ptr<LogicalOperator> &child, unique_ptr<Expression> &expr,
+	                               const BaseStatistics &stats_before, const BaseStatistics &stats_after);
+
+	unique_ptr<BaseStatistics> PropagateExpression(unique_ptr<Expression> &expr);
+	unique_ptr<BaseStatistics> PropagateExpression(Expression &expr, unique_ptr<Expression> &expr_ptr);
+	//! Run a comparison between the statistics and the table filter; returns the prune result
+	unique_ptr<BaseStatistics> PropagateExpression(BoundAggregateExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundBetweenExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundCaseExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundCastExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundConjunctionExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundFunctionExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundComparisonExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundConstantExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundColumnRefExpression &expr, unique_ptr<Expression> &expr_ptr);
+	unique_ptr<BaseStatistics> PropagateExpression(BoundOperatorExpression &expr, unique_ptr<Expression> &expr_ptr);
+
+	//! Try to execute aggregates using only the statistics if possible
+	void TryExecuteAggregates(LogicalAggregate &op, unique_ptr<LogicalOperator> &node_ptr);
+	void ReplaceWithEmptyResult(unique_ptr<LogicalOperator> &node);
+
+	bool ExpressionIsConstant(Expression &expr, const Value &val);
+	bool ExpressionIsConstantOrNull(Expression &expr, const Value &val);
+
+private:
+	Optimizer &optimizer;
+	ClientContext &context;
+	//! The root of the query plan
+	optional_ptr<LogicalOperator> root;
+	//! The map of ColumnBinding -> statistics for the various nodes
+	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
+	//! Node stats for the current node
+	unique_ptr<NodeStatistics> node_stats;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression_iterator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+#include <functional>
+
+namespace duckdb {
+class BoundQueryNode;
+class BoundTableRef;
+
+class ExpressionIterator {
+public:
+	static void EnumerateChildren(const Expression &expression,
+	                              const std::function<void(const Expression &child)> &callback);
+	static void EnumerateChildren(Expression &expression, const std::function<void(Expression &child)> &callback);
+	static void EnumerateChildren(Expression &expression,
+	                              const std::function<void(unique_ptr<Expression> &child)> &callback);
+
+	static void EnumerateExpression(unique_ptr<Expression> &expr,
+	                                const std::function<void(Expression &child)> &callback);
+};
+
+class BoundNodeVisitor {
+public:
+	virtual ~BoundNodeVisitor() = default;
+
+	virtual void VisitBoundQueryNode(BoundQueryNode &op);
+	virtual void VisitBoundTableRef(BoundTableRef &ref);
+	virtual void VisitExpression(unique_ptr<Expression> &expression);
+
+protected:
+	// The VisitExpressionChildren method is called at the end of every call to VisitExpression to recursively visit all
+	// expressions in an expression tree. It can be overloaded to prevent automatically visiting the entire tree.
+	virtual void VisitExpressionChildren(Expression &expression);
+};
+
+} // namespace duckdb
+
+
+
+
+
+#include <iostream>
+
+namespace duckdb {
+struct MultiFilePushdownInfo;
+
+struct HivePartitioningFilterInfo {
+	unordered_map<string, column_t> column_map;
+	bool hive_enabled;
+	bool filename_enabled;
+};
+
+class HivePartitioning {
+public:
+	//! Parse a filename that follows the hive partitioning scheme
+	DUCKDB_API static std::map<string, string> Parse(const string &filename);
+	//! Prunes a list of filenames based on a set of filters, can be used by TableFunctions in the
+	//! pushdown_complex_filter function to skip files with filename-based filters. Also removes the filters that always
+	//! evaluate to true.
+	DUCKDB_API static void ApplyFiltersToFileList(ClientContext &context, vector<OpenFileInfo> &files,
+	                                              vector<unique_ptr<Expression>> &filters,
+	                                              const HivePartitioningFilterInfo &filter_info,
+	                                              MultiFilePushdownInfo &info);
+
+	DUCKDB_API static Value GetValue(ClientContext &context, const string &key, const string &value,
+	                                 const LogicalType &type);
+	//! Escape a hive partition key or value using URL encoding
+	DUCKDB_API static string Escape(const string &input);
+	//! Unescape a hive partition key or value encoded using URL encoding
+	DUCKDB_API static string Unescape(const string &input);
+};
+
+struct HivePartitionKey {
+	//! Columns by which we want to partition
+	vector<Value> values;
+	//! Precomputed hash of values
+	hash_t hash;
+
+	struct Hash {
+		std::size_t operator()(const HivePartitionKey &k) const {
+			return k.hash;
+		}
+	};
+
+	struct Equality {
+		bool operator()(const HivePartitionKey &a, const HivePartitionKey &b) const {
+			if (a.values.size() != b.values.size()) {
+				return false;
+			}
+			for (idx_t i = 0; i < a.values.size(); i++) {
+				if (!Value::NotDistinctFrom(a.values[i], b.values[i])) {
+					return false;
+				}
+			}
+			return true;
+		}
+	};
+};
+
+//! Maps hive partitions to partition_ids
+typedef unordered_map<HivePartitionKey, idx_t, HivePartitionKey::Hash, HivePartitionKey::Equality> hive_partition_map_t;
+
+//! class shared between HivePartitionColumnData classes that synchronizes partition discovery between threads.
+//! each HivePartitionedColumnData will hold a local copy of the key->partition map
+class GlobalHivePartitionState {
+public:
+	mutex lock;
+	hive_partition_map_t partition_map;
+};
+
+class HivePartitionedColumnData : public PartitionedColumnData {
+public:
+	HivePartitionedColumnData(ClientContext &context, vector<LogicalType> types, vector<idx_t> partition_by_cols,
+	                          shared_ptr<GlobalHivePartitionState> global_state = nullptr);
+	void ComputePartitionIndices(PartitionedColumnDataAppendState &state, DataChunk &input) override;
+
+	//! Reverse lookup map to reconstruct keys from a partition id
+	std::map<idx_t, const HivePartitionKey *> GetReverseMap();
+
+protected:
+	//! Register a newly discovered partition
+	idx_t RegisterNewPartition(HivePartitionKey key, PartitionedColumnDataAppendState &state);
+	//! Add a new partition with the given partition id
+	void AddNewPartition(HivePartitionKey key, idx_t partition_id, PartitionedColumnDataAppendState &state);
+
+private:
+	void InitializeKeys();
+
+protected:
+	//! Shared HivePartitionedColumnData should always have a global state to allow parallel key discovery
+	shared_ptr<GlobalHivePartitionState> global_state;
+	//! Thread-local copy of the partition map
+	hive_partition_map_t local_partition_map;
+	//! The columns that make up the key
+	vector<idx_t> group_by_columns;
+	//! Thread-local pre-allocated vector for hashes
+	Vector hashes_v;
+	//! Thread-local pre-allocated HivePartitionKeys
+	vector<HivePartitionKey> keys;
+};
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+struct BindInfo;
+class MultiFileList;
+
+enum class MultiFileColumnMappingMode : uint8_t { BY_NAME, BY_FIELD_ID };
+
+struct MultiFileOptions {
+	bool filename = false;
+	bool hive_partitioning = false;
+	bool auto_detect_hive_partitioning = true;
+	bool union_by_name = false;
+	bool hive_types_autocast = true;
+	MultiFileColumnMappingMode mapping = MultiFileColumnMappingMode::BY_NAME;
+
+	case_insensitive_map_t<LogicalType> hive_types_schema;
+
+	// Default/configurable name of the column containing the file names
+	static constexpr const char *DEFAULT_FILENAME_COLUMN = "filename";
+	string filename_column = DEFAULT_FILENAME_COLUMN;
+	// These are used to pass options through custom multifilereaders
+	case_insensitive_map_t<Value> custom_options;
+
+	DUCKDB_API void Serialize(Serializer &serializer) const;
+	DUCKDB_API static MultiFileOptions Deserialize(Deserializer &source);
+	DUCKDB_API void AddBatchInfo(BindInfo &bind_info) const;
+	DUCKDB_API void AutoDetectHivePartitioning(MultiFileList &files, ClientContext &context);
+	DUCKDB_API static bool AutoDetectHivePartitioningInternal(MultiFileList &files, ClientContext &context);
+	DUCKDB_API void AutoDetectHiveTypesInternal(MultiFileList &files, ClientContext &context);
+	DUCKDB_API void VerifyHiveTypesArePartitions(const std::map<string, string> &partitions) const;
+	DUCKDB_API LogicalType GetHiveLogicalType(const string &hive_partition_column) const;
+	DUCKDB_API Value GetHivePartitionValue(const string &base, const string &entry, ClientContext &context) const;
+	DUCKDB_API bool AnySet() const;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/set_columns.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+namespace duckdb {
+//! This represents the data related to columns that have been set by the user
+//! e.g., from a copy command
+struct SetColumns {
+	SetColumns(const vector<LogicalType> *types_p, const vector<string> *names_p);
+	SetColumns();
+	//! Return Types that were detected
+	const vector<LogicalType> *types = nullptr;
+	//! Column Names that were detected
+	const vector<string> *names = nullptr;
+	//! If columns are set
+	bool IsSet() const;
+	//! How many columns
+	idx_t Size() const;
+	//! Helper function that checks if candidate is acceptable based on the number of columns it produces
+	bool IsCandidateUnacceptable(const idx_t num_cols, bool null_padding, bool ignore_errors,
+	                             bool last_value_always_empty) const;
+
+	string ToString() const;
+};
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+struct DialectOptions {
+	CSVStateMachineOptions state_machine_options;
+	//! Expected number of columns
+	idx_t num_cols = 0;
+	//! Whether the file has a header line
+	CSVOption<bool> header = false;
+	//! The date format to use (if any is specified)
+	map<LogicalTypeId, CSVOption<StrpTimeFormat>> date_format = {{LogicalTypeId::DATE, {}},
+	                                                             {LogicalTypeId::TIMESTAMP, {}}};
+	//! How many leading rows to skip
+	CSVOption<idx_t> skip_rows = 0;
+	idx_t rows_until_header = 0;
+};
+
+struct CSVReaderOptions {
+	CSVReaderOptions() {
+	}
+	CSVReaderOptions(CSVOption<char> single_byte_delimiter, const CSVOption<string> &multi_byte_delimiter);
+	//===--------------------------------------------------------------------===//
+	// CommonCSVOptions
+	//===--------------------------------------------------------------------===//
+	//! See struct above.
+	DialectOptions dialect_options;
+	//! Whether we should ignore InvalidInput errors
+	CSVOption<bool> ignore_errors = false;
+	//! Whether we store CSV Errors in the rejects table or not
+	CSVOption<bool> store_rejects = false;
+	//! Rejects table name (Name of the table the store rejects errors)
+	CSVOption<string> rejects_table_name = {"reject_errors"};
+	//! Rejects Scan name  (Name of the table the store rejects scans)
+	CSVOption<string> rejects_scan_name = {"reject_scans"};
+	//! Rejects table entry limit (0 = no limit)
+	idx_t rejects_limit = 0;
+	//! Number of samples to buffer
+	idx_t buffer_sample_size = static_cast<idx_t>(STANDARD_VECTOR_SIZE * 50);
+	//! Specifies the strings that represents a null value
+	vector<string> null_str = {""};
+	//! Whether file is compressed or not, and if so which compression type
+	//! AUTO_DETECT (default; infer from file extension)
+	FileCompressionType compression = FileCompressionType::AUTO_DETECT;
+	//! Option to convert quoted values to NULL values
+	bool allow_quoted_nulls = true;
+	char comment = '\0';
+
+	//! Thousands separator option (to be able to accept "100,000.220" as a double or decimal.
+	char thousands_separator = '\0';
+
+	//===--------------------------------------------------------------------===//
+	// CSVAutoOptions
+	//===--------------------------------------------------------------------===//
+	//! SQL Type list mapping of name to SQL type index in sql_type_list
+	case_insensitive_map_t<idx_t> sql_types_per_column;
+	//! User-defined SQL type list
+	vector<LogicalType> sql_type_list;
+	//! User-defined name list
+	vector<string> name_list;
+	//! If the names and types were set by the columns parameter
+	bool columns_set = false;
+	//! Types considered as candidates for auto-detection ordered by descending specificity (~ from high to low)
+	vector<LogicalType> auto_type_candidates = {
+	    LogicalType::VARCHAR,      LogicalType::DOUBLE,    LogicalType::BIGINT,
+	    LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP, LogicalType::DATE,
+	    LogicalType::TIME,         LogicalType::BOOLEAN,   LogicalType::SQLNULL};
+	//! In case the sniffer found a mismatch error from user defined types or dialect
+	string sniffer_user_mismatch_error;
+	//! In case the sniffer found a mismatch error from user defined types or dialect
+	vector<bool> was_type_manually_set;
+	//===--------------------------------------------------------------------===//
+	// ReadCSVOptions
+	//===--------------------------------------------------------------------===//
+	//! Maximum CSV line size: specified because if we reach this amount, we likely have wrong delimiters (default: 2MB)
+	//! note that this is the guaranteed line length that will succeed, longer lines may be accepted if slightly above
+	static constexpr idx_t max_line_size_default = 2000000;
+	CSVOption<idx_t> maximum_line_size = max_line_size_default;
+	//! Whether header names shall be normalized
+	bool normalize_names = false;
+	//! True, if column with that index must skip null check
+	unordered_set<string> force_not_null_names;
+	//! True, if column with that index must skip null check
+	vector<bool> force_not_null;
+	//! Result size of sniffing phases
+	static constexpr idx_t sniff_size = 2048;
+
+	//! In case this is a glob or list of multiple files, how many shall be used to sniff.
+	//! -1 means all
+	int64_t files_to_sniff = 10;
+
+	//! Number of sample chunks used in auto-detection
+	idx_t sample_size_chunks = 20480 / sniff_size;
+	//! Consider all columns to be of type varchar
+	bool all_varchar = false;
+	//! Whether to automatically detect dialect and datatypes
+	bool auto_detect = true;
+	//! The file path of the CSV file to read
+	string file_path;
+	//! Buffer Size (Parallel Scan)
+	CSVOption<idx_t> buffer_size_option = CSVBuffer::ROWS_PER_BUFFER * max_line_size_default;
+	//! Decimal separator when reading as numeric
+	string decimal_separator = ".";
+	//! Whether  to pad rows that do not have enough columns with NULL values
+	bool null_padding = false;
+	//! If we should attempt to run parallel scanning over one file
+	bool parallel = true;
+
+	//! By default, our encoding is always UTF-8
+	string encoding = "utf-8";
+	//! User defined parameters
+	map<string, string> user_defined_parameters;
+
+	//! Returns a list of user-defined parameters in string format
+	string GetUserDefinedParameters() const;
+
+	//===--------------------------------------------------------------------===//
+	// WriteCSVOptions
+	//===--------------------------------------------------------------------===//
+	//! True, if column with that index must be quoted
+	vector<bool> force_quote;
+	//! Prefix/suffix/custom newline the entire file once (enables writing of files as JSON arrays)
+	string prefix;
+	string suffix;
+	string write_newline;
+
+	//! The date format to use for writing (if any is specified)
+	map<LogicalTypeId, Value> write_date_format = {{LogicalTypeId::DATE, Value()}, {LogicalTypeId::TIMESTAMP, Value()}};
+	//! Whether  a type format is specified
+	map<LogicalTypeId, bool> has_format = {{LogicalTypeId::DATE, false}, {LogicalTypeId::TIMESTAMP, false}};
+	//! If this reader is a multifile reader
+	bool multi_file_reader = false;
+
+	void SetCompression(const string &compression);
+
+	bool GetHeader() const;
+	void SetHeader(bool has_header);
+
+	string GetEscape() const;
+	void SetEscape(const string &escape);
+
+	idx_t GetSkipRows() const;
+	void SetSkipRows(int64_t rows);
+
+	void SetQuote(const string &quote);
+	string GetQuote() const;
+	void SetComment(const string &comment);
+	string GetComment() const;
+	void SetDelimiter(const string &delimiter);
+	string GetDelimiter() const;
+
+	//! If we can safely ignore errors (i.e., they are being ignored and not being stored in a rejects table)
+	bool IgnoreErrors() const;
+
+	string GetNewline() const;
+	void SetNewline(const string &input);
+
+	bool GetRFC4180() const;
+	void SetRFC4180(bool rfc4180);
+
+	CSVOption<char> GetSingleByteDelimiter() const;
+	CSVOption<string> GetMultiByteDelimiter() const;
+
+	//! Set an option that is supported by both reading and writing functions, called by
+	//! the SetReadOption and SetWriteOption methods
+	bool SetBaseOption(const string &loption, const Value &value, bool write_option = false);
+
+	//! loption - lowercase string
+	//! set - argument(s) to the option
+	//! expected_names - names expected if the option is "columns"
+	void SetReadOption(const string &loption, const Value &value, vector<string> &expected_names);
+	void SetWriteOption(const string &loption, const Value &value);
+	void SetDateFormat(LogicalTypeId type, const string &format, bool read_format);
+	void ToNamedParameters(named_parameter_map_t &out) const;
+	void FromNamedParameters(const named_parameter_map_t &in, ClientContext &context, MultiFileOptions &file_options);
+	void ParseOption(ClientContext &context, const string &key, const Value &val);
+	//! Verify options are not conflicting
+	void Verify(MultiFileOptions &file_options);
+
+	string ToString(const string &current_file_path) const;
+	//! If the type for column with idx i was manually set
+	bool WasTypeManuallySet(idx_t i) const;
+
+	string NewLineIdentifierToString() const {
+		switch (dialect_options.state_machine_options.new_line.GetValue()) {
+		case NewLineIdentifier::SINGLE_N:
+			return "\\n";
+		case NewLineIdentifier::SINGLE_R:
+			return "\\r";
+		case NewLineIdentifier::CARRY_ON:
+			return "\\r\\n";
+		default:
+			return "";
+		}
+	}
+};
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class Deserializer {
+protected:
+	bool deserialize_enum_from_string = false;
+	SerializationData data;
+
+public:
+	virtual ~Deserializer() {
+	}
+
+	class List {
+		friend Deserializer;
+
+	private:
+		Deserializer &deserializer;
+		explicit List(Deserializer &deserializer) : deserializer(deserializer) {
+		}
+
+	public:
+		// Deserialize an element
+		template <class T>
+		T ReadElement();
+
+		//! Deserialize bytes
+		template <class T>
+		void ReadElement(data_ptr_t &ptr, idx_t size);
+
+		// Deserialize an object
+		template <class FUNC>
+		void ReadObject(FUNC f);
+	};
+
+public:
+	// Read into an existing value
+	template <typename T>
+	inline void ReadProperty(const field_id_t field_id, const char *tag, T &ret) {
+		OnPropertyBegin(field_id, tag);
+		ret = Read<T>();
+		OnPropertyEnd();
+	}
+
+	// Read and return a value
+	template <typename T>
+	inline T ReadProperty(const field_id_t field_id, const char *tag) {
+		OnPropertyBegin(field_id, tag);
+		auto ret = Read<T>();
+		OnPropertyEnd();
+		return ret;
+	}
+
+	// Default Value return
+	template <typename T>
+	inline T ReadPropertyWithDefault(const field_id_t field_id, const char *tag) {
+		if (!OnOptionalPropertyBegin(field_id, tag)) {
+			OnOptionalPropertyEnd(false);
+			return std::forward<T>(SerializationDefaultValue::GetDefault<T>());
+		}
+		auto ret = Read<T>();
+		OnOptionalPropertyEnd(true);
+		return ret;
+	}
+
+	template <typename T>
+	inline T ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, T default_value) {
+		if (!OnOptionalPropertyBegin(field_id, tag)) {
+			OnOptionalPropertyEnd(false);
+			return std::forward<T>(default_value);
+		}
+		auto ret = Read<T>();
+		OnOptionalPropertyEnd(true);
+		return ret;
+	}
+
+	// Default value in place
+	template <typename T>
+	inline void ReadPropertyWithDefault(const field_id_t field_id, const char *tag, T &ret) {
+		if (!OnOptionalPropertyBegin(field_id, tag)) {
+			ret = std::forward<T>(SerializationDefaultValue::GetDefault<T>());
+			OnOptionalPropertyEnd(false);
+			return;
+		}
+		ret = Read<T>();
+		OnOptionalPropertyEnd(true);
+	}
+
+	template <typename T>
+	inline void ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, T &ret, T default_value) {
+		if (!OnOptionalPropertyBegin(field_id, tag)) {
+			ret = std::forward<T>(default_value);
+			OnOptionalPropertyEnd(false);
+			return;
+		}
+		ret = Read<T>();
+		OnOptionalPropertyEnd(true);
+	}
+
+	template <typename T>
+	inline void ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, CSVOption<T> &ret,
+	                                            T default_value) {
+		if (!OnOptionalPropertyBegin(field_id, tag)) {
+			ret = std::forward<T>(default_value);
+			OnOptionalPropertyEnd(false);
+			return;
+		}
+		ret = Read<T>();
+		OnOptionalPropertyEnd(true);
+	}
+
+	// Special case:
+	// Read into an existing data_ptr_t
+	inline void ReadProperty(const field_id_t field_id, const char *tag, data_ptr_t ret, idx_t count) {
+		OnPropertyBegin(field_id, tag);
+		ReadDataPtr(ret, count);
+		OnPropertyEnd();
+	}
+
+	// Try to read a property, if it is not present, continue, otherwise read and discard the value
+	template <typename T>
+	inline void ReadDeletedProperty(const field_id_t field_id, const char *tag) {
+		// Try to read the property. If not present, great!
+		if (!OnOptionalPropertyBegin(field_id, tag)) {
+			OnOptionalPropertyEnd(false);
+			return;
+		}
+		// Otherwise read and discard the value
+		(void)Read<T>();
+		OnOptionalPropertyEnd(true);
+	}
+
+	//! Set a serialization property
+	template <class T>
+	void Set(T entry) {
+		return data.Set<T>(entry);
+	}
+
+	//! Retrieve the last set serialization property of this type
+	template <class T>
+	T Get() {
+		return data.Get<T>();
+	}
+
+	template <class T>
+	optional_ptr<T> TryGet() {
+		return data.TryGet<T>();
+	}
+
+	//! Unset a serialization property
+	template <class T>
+	void Unset() {
+		return data.Unset<T>();
+	}
+
+	SerializationData &GetSerializationData() {
+		return data;
+	}
+
+	void SetSerializationData(const SerializationData &other) {
+		data = other;
+	}
+
+	template <class FUNC>
+	void ReadList(const field_id_t field_id, const char *tag, FUNC func) {
+		OnPropertyBegin(field_id, tag);
+		auto size = OnListBegin();
+		List list {*this};
+		for (idx_t i = 0; i < size; i++) {
+			func(list, i);
+		}
+		OnListEnd();
+		OnPropertyEnd();
+	}
+
+	template <class FUNC>
+	void ReadObject(const field_id_t field_id, const char *tag, FUNC func) {
+		OnPropertyBegin(field_id, tag);
+		OnObjectBegin();
+		func(*this);
+		OnObjectEnd();
+		OnPropertyEnd();
+	}
+
+private:
+	// Deserialize anything implementing a Deserialize method
+	template <typename T = void>
+	inline typename std::enable_if<has_deserialize<T>::value, T>::type Read() {
+		OnObjectBegin();
+		auto val = T::Deserialize(*this);
+		OnObjectEnd();
+		return val;
+	}
+
+	// Deserialize a optionally_owned_ptr
+	template <class T, typename ELEMENT_TYPE = typename is_optionally_owned_ptr<T>::ELEMENT_TYPE>
+	inline typename std::enable_if<is_optionally_owned_ptr<T>::value, T>::type Read() {
+		return optionally_owned_ptr<ELEMENT_TYPE>(Read<unique_ptr<ELEMENT_TYPE>>());
+	}
+
+	// Deserialize unique_ptr if the element type has a Deserialize method
+	template <class T, typename ELEMENT_TYPE = typename is_unique_ptr<T>::ELEMENT_TYPE>
+	inline typename std::enable_if<is_unique_ptr<T>::value && has_deserialize<ELEMENT_TYPE>::value, T>::type Read() {
+		unique_ptr<ELEMENT_TYPE> ptr = nullptr;
+		auto is_present = OnNullableBegin();
+		if (is_present) {
+			OnObjectBegin();
+			ptr = ELEMENT_TYPE::Deserialize(*this);
+			OnObjectEnd();
+		}
+		OnNullableEnd();
+		return ptr;
+	}
+
+	// Deserialize a unique_ptr if the element type does not have a Deserialize method
+	template <class T, typename ELEMENT_TYPE = typename is_unique_ptr<T>::ELEMENT_TYPE>
+	inline typename std::enable_if<is_unique_ptr<T>::value && !has_deserialize<ELEMENT_TYPE>::value, T>::type Read() {
+		unique_ptr<ELEMENT_TYPE> ptr = nullptr;
+		auto is_present = OnNullableBegin();
+		if (is_present) {
+			OnObjectBegin();
+			ptr = make_uniq<ELEMENT_TYPE>(Read<ELEMENT_TYPE>());
+			OnObjectEnd();
+		}
+		OnNullableEnd();
+		return ptr;
+	}
+
+	// Deserialize shared_ptr
+	template <typename T = void>
+	inline typename std::enable_if<is_shared_ptr<T>::value, T>::type Read() {
+		using ELEMENT_TYPE = typename is_shared_ptr<T>::ELEMENT_TYPE;
+		shared_ptr<ELEMENT_TYPE> ptr = nullptr;
+		auto is_present = OnNullableBegin();
+		if (is_present) {
+			OnObjectBegin();
+			ptr = ELEMENT_TYPE::Deserialize(*this);
+			OnObjectEnd();
+		}
+		OnNullableEnd();
+		return ptr;
+	}
+
+	// Deserialize a vector
+	template <typename T = void>
+	inline typename std::enable_if<is_vector<T>::value, T>::type Read() {
+		using ELEMENT_TYPE = typename is_vector<T>::ELEMENT_TYPE;
+		T vec;
+		auto size = OnListBegin();
+		for (idx_t i = 0; i < size; i++) {
+			vec.push_back(Read<ELEMENT_TYPE>());
+		}
+		OnListEnd();
+		return vec;
+	}
+
+	template <typename T = void>
+	inline typename std::enable_if<is_unsafe_vector<T>::value, T>::type Read() {
+		using ELEMENT_TYPE = typename is_unsafe_vector<T>::ELEMENT_TYPE;
+		T vec;
+		auto size = OnListBegin();
+		for (idx_t i = 0; i < size; i++) {
+			vec.push_back(Read<ELEMENT_TYPE>());
+		}
+		OnListEnd();
+
+		return vec;
+	}
+
+	// Deserialize a map
+	template <typename T = void>
+	inline typename std::enable_if<is_unordered_map<T>::value, T>::type Read() {
+		using KEY_TYPE = typename is_unordered_map<T>::KEY_TYPE;
+		using VALUE_TYPE = typename is_unordered_map<T>::VALUE_TYPE;
+
+		T map;
+		auto size = OnListBegin();
+		for (idx_t i = 0; i < size; i++) {
+			OnObjectBegin();
+			auto key = ReadProperty<KEY_TYPE>(0, "key");
+			auto value = ReadProperty<VALUE_TYPE>(1, "value");
+			OnObjectEnd();
+			map[std::move(key)] = std::move(value);
+		}
+		OnListEnd();
+		return map;
+	}
+
+	template <typename T = void>
+	inline typename std::enable_if<is_map<T>::value, T>::type Read() {
+		using KEY_TYPE = typename is_map<T>::KEY_TYPE;
+		using VALUE_TYPE = typename is_map<T>::VALUE_TYPE;
+
+		T map;
+		auto size = OnListBegin();
+		for (idx_t i = 0; i < size; i++) {
+			OnObjectBegin();
+			auto key = ReadProperty<KEY_TYPE>(0, "key");
+			auto value = ReadProperty<VALUE_TYPE>(1, "value");
+			OnObjectEnd();
+			map[std::move(key)] = std::move(value);
+		}
+		OnListEnd();
+		return map;
+	}
+
+	template <typename T = void>
+	inline typename std::enable_if<is_insertion_preserving_map<T>::value, T>::type Read() {
+		using VALUE_TYPE = typename is_insertion_preserving_map<T>::VALUE_TYPE;
+
+		T map;
+		auto size = OnListBegin();
+		for (idx_t i = 0; i < size; i++) {
+			OnObjectBegin();
+			auto key = ReadProperty<string>(0, "key");
+			auto value = ReadProperty<VALUE_TYPE>(1, "value");
+			OnObjectEnd();
+			map[key] = std::move(value);
+		}
+		OnListEnd();
+		return map;
+	}
+
+	// Deserialize an unordered set
+	template <typename T = void>
+	inline typename std::enable_if<is_unordered_set<T>::value, T>::type Read() {
+		using ELEMENT_TYPE = typename is_unordered_set<T>::ELEMENT_TYPE;
+		auto size = OnListBegin();
+		T set;
+		for (idx_t i = 0; i < size; i++) {
+			set.insert(Read<ELEMENT_TYPE>());
+		}
+		OnListEnd();
+		return set;
+	}
+
+	// Deserialize a set
+	template <typename T = void>
+	inline typename std::enable_if<is_set<T>::value, T>::type Read() {
+		using ELEMENT_TYPE = typename is_set<T>::ELEMENT_TYPE;
+		auto size = OnListBegin();
+		T set;
+		for (idx_t i = 0; i < size; i++) {
+			set.insert(Read<ELEMENT_TYPE>());
+		}
+		OnListEnd();
+		return set;
+	}
+
+	// Deserialize a pair
+	template <typename T = void>
+	inline typename std::enable_if<is_pair<T>::value, T>::type Read() {
+		using FIRST_TYPE = typename is_pair<T>::FIRST_TYPE;
+		using SECOND_TYPE = typename is_pair<T>::SECOND_TYPE;
+		OnObjectBegin();
+		auto first = ReadProperty<FIRST_TYPE>(0, "first");
+		auto second = ReadProperty<SECOND_TYPE>(1, "second");
+		OnObjectEnd();
+		return std::make_pair(first, second);
+	}
+
+	// Deserialize a priority_queue
+	template <typename T = void>
+	inline typename std::enable_if<is_queue<T>::value, T>::type Read() {
+		using ELEMENT_TYPE = typename is_queue<T>::ELEMENT_TYPE;
+		T queue;
+		auto size = OnListBegin();
+		for (idx_t i = 0; i < size; i++) {
+			queue.emplace(Read<ELEMENT_TYPE>());
+		}
+		OnListEnd();
+		return queue;
+	}
+
+	// Primitive types
+	// Deserialize a bool
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, bool>::value, T>::type Read() {
+		return ReadBool();
+	}
+
+	// Deserialize a char
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, char>::value, T>::type Read() {
+		return ReadChar();
+	}
+
+	// Deserialize a int8_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, int8_t>::value, T>::type Read() {
+		return ReadSignedInt8();
+	}
+
+	// Deserialize a uint8_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, uint8_t>::value, T>::type Read() {
+		return ReadUnsignedInt8();
+	}
+
+	// Deserialize a int16_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, int16_t>::value, T>::type Read() {
+		return ReadSignedInt16();
+	}
+
+	// Deserialize a uint16_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, uint16_t>::value, T>::type Read() {
+		return ReadUnsignedInt16();
+	}
+
+	// Deserialize a int32_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, int32_t>::value, T>::type Read() {
+		return ReadSignedInt32();
+	}
+
+	// Deserialize a uint32_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, uint32_t>::value, T>::type Read() {
+		return ReadUnsignedInt32();
+	}
+
+	// Deserialize a int64_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, int64_t>::value, T>::type Read() {
+		return ReadSignedInt64();
+	}
+
+	// Deserialize a uint64_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, uint64_t>::value, T>::type Read() {
+		return ReadUnsignedInt64();
+	}
+
+	// Deserialize a float
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, float>::value, T>::type Read() {
+		return ReadFloat();
+	}
+
+	// Deserialize a double
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, double>::value, T>::type Read() {
+		return ReadDouble();
+	}
+
+	// Deserialize a string
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, string>::value, T>::type Read() {
+		return ReadString();
+	}
+
+	// Deserialize a Enum
+	template <typename T = void>
+	inline typename std::enable_if<std::is_enum<T>::value, T>::type Read() {
+		if (deserialize_enum_from_string) {
+			auto str = ReadString();
+			return EnumUtil::FromString<T>(str.c_str());
+		} else {
+			return (T)Read<typename std::underlying_type<T>::type>();
+		}
+	}
+
+	// Deserialize a hugeint_t
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, hugeint_t>::value, T>::type Read() {
+		return ReadHugeInt();
+	}
+
+	// Deserialize a uhugeint
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, uhugeint_t>::value, T>::type Read() {
+		return ReadUhugeInt();
+	}
+
+	// Deserialize a LogicalIndex
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, LogicalIndex>::value, T>::type Read() {
+		return LogicalIndex(ReadUnsignedInt64());
+	}
+
+	// Deserialize a PhysicalIndex
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, PhysicalIndex>::value, T>::type Read() {
+		return PhysicalIndex(ReadUnsignedInt64());
+	}
+
+	// Deserialize an optional_idx
+	template <typename T = void>
+	inline typename std::enable_if<std::is_same<T, optional_idx>::value, T>::type Read() {
+		auto idx = ReadUnsignedInt64();
+		return idx == DConstants::INVALID_INDEX ? optional_idx() : optional_idx(idx);
+	}
+
+protected:
+	// Hooks for subclasses to override to implement custom behavior
+	virtual void OnPropertyBegin(const field_id_t field_id, const char *tag) = 0;
+	virtual void OnPropertyEnd() = 0;
+	virtual bool OnOptionalPropertyBegin(const field_id_t field_id, const char *tag) = 0;
+	virtual void OnOptionalPropertyEnd(bool present) = 0;
+
+	virtual void OnObjectBegin() = 0;
+	virtual void OnObjectEnd() = 0;
+	virtual idx_t OnListBegin() = 0;
+	virtual void OnListEnd() = 0;
+	virtual bool OnNullableBegin() = 0;
+	virtual void OnNullableEnd() = 0;
+
+	// Handle primitive types, a serializer needs to implement these.
+	virtual bool ReadBool() = 0;
+	virtual char ReadChar() {
+		throw NotImplementedException("ReadChar not implemented");
+	}
+	virtual int8_t ReadSignedInt8() = 0;
+	virtual uint8_t ReadUnsignedInt8() = 0;
+	virtual int16_t ReadSignedInt16() = 0;
+	virtual uint16_t ReadUnsignedInt16() = 0;
+	virtual int32_t ReadSignedInt32() = 0;
+	virtual uint32_t ReadUnsignedInt32() = 0;
+	virtual int64_t ReadSignedInt64() = 0;
+	virtual uint64_t ReadUnsignedInt64() = 0;
+	virtual hugeint_t ReadHugeInt() = 0;
+	virtual uhugeint_t ReadUhugeInt() = 0;
+	virtual float ReadFloat() = 0;
+	virtual double ReadDouble() = 0;
+	virtual string ReadString() = 0;
+	virtual void ReadDataPtr(data_ptr_t &ptr, idx_t count) = 0;
+};
+
+template <class FUNC>
+void Deserializer::List::ReadObject(FUNC f) {
+	deserializer.OnObjectBegin();
+	f(deserializer);
+	deserializer.OnObjectEnd();
+}
+
+template <class T>
+T Deserializer::List::ReadElement() {
+	return deserializer.Read<T>();
+}
+
+template <class T>
+void Deserializer::List::ReadElement(data_ptr_t &ptr, idx_t size) {
+	deserializer.ReadDataPtr(ptr, size);
+}
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/serializer/serializer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/value_operations/value_operations.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+struct ValueOperations {
+	//===--------------------------------------------------------------------===//
+	// Comparison Operations
+	//===--------------------------------------------------------------------===//
+	// A == B
+	static bool Equals(const Value &left, const Value &right);
+	// A != B
+	static bool NotEquals(const Value &left, const Value &right);
+	// A > B
+	static bool GreaterThan(const Value &left, const Value &right);
+	// A >= B
+	static bool GreaterThanEquals(const Value &left, const Value &right);
+	// A < B
+	static bool LessThan(const Value &left, const Value &right);
+	// A <= B
+	static bool LessThanEquals(const Value &left, const Value &right);
+	//===--------------------------------------------------------------------===//
+	// Distinction Operations
+	//===--------------------------------------------------------------------===//
+	// A == B, NULLs equal
+	static bool NotDistinctFrom(const Value &left, const Value &right);
+	// A != B, NULLs equal
+	static bool DistinctFrom(const Value &left, const Value &right);
+	// A > B, NULLs last
+	static bool DistinctGreaterThan(const Value &left, const Value &right);
+	// A >= B, NULLs last
+	static bool DistinctGreaterThanEquals(const Value &left, const Value &right);
+	// A < B, NULLs last
+	static bool DistinctLessThan(const Value &left, const Value &right);
+	// A <= B, NULLs last
+	static bool DistinctLessThanEquals(const Value &left, const Value &right);
+};
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+class SerializationOptions {
+public:
+	SerializationOptions() = default;
+	explicit SerializationOptions(AttachedDatabase &db);
+
+	bool serialize_enum_as_string = false;
+	bool serialize_default_values = false;
+	SerializationCompatibility serialization_compatibility = SerializationCompatibility::Default();
+};
+
+class Serializer {
+protected:
+	SerializationOptions options;
+	SerializationData data;
+
+public:
+	virtual ~Serializer() {
+	}
+
+	bool ShouldSerialize(idx_t version_added) {
+		return options.serialization_compatibility.Compare(version_added);
+	}
+
+	class List {
+		friend Serializer;
+
+	private:
+		Serializer &serializer;
+		explicit List(Serializer &serializer) : serializer(serializer) {
+		}
+
+	public:
+		// Serialize an element
+		template <class T>
+		void WriteElement(const T &value);
+
+		//! Serialize bytes
+		void WriteElement(data_ptr_t ptr, idx_t size);
+
+		// Serialize an object
+		template <class FUNC>
+		void WriteObject(FUNC f);
+	};
+
+public:
+	SerializationOptions GetOptions() {
+		return options;
+	}
+	SerializationData &GetSerializationData() {
+		return data;
+	}
+
+	void SetSerializationData(const SerializationData &other) {
+		data = other;
+	}
+
+	// Serialize a value
+	template <class T>
+	void WriteProperty(const field_id_t field_id, const char *tag, const T &value) {
+		OnPropertyBegin(field_id, tag);
+		WriteValue(value);
+		OnPropertyEnd();
+	}
+
+	// Default value
+	template <class T>
+	void WritePropertyWithDefault(const field_id_t field_id, const char *tag, const T &value) {
+		// If current value is default, don't write it
+		if (!options.serialize_default_values && SerializationDefaultValue::IsDefault<T>(value)) {
+			OnOptionalPropertyBegin(field_id, tag, false);
+			OnOptionalPropertyEnd(false);
+			return;
+		}
+		OnOptionalPropertyBegin(field_id, tag, true);
+		WriteValue(value);
+		OnOptionalPropertyEnd(true);
+	}
+
+	template <class T>
+	void WritePropertyWithDefault(const field_id_t field_id, const char *tag, const T &value, const T &default_value) {
+		// If current value is default, don't write it
+		if (!options.serialize_default_values && (value == default_value)) {
+			OnOptionalPropertyBegin(field_id, tag, false);
+			OnOptionalPropertyEnd(false);
+			return;
+		}
+		OnOptionalPropertyBegin(field_id, tag, true);
+		WriteValue(value);
+		OnOptionalPropertyEnd(true);
+	}
+
+	// Specialization for Value (default Value comparison throws when comparing nulls)
+	template <class T>
+	void WritePropertyWithDefault(const field_id_t field_id, const char *tag, const CSVOption<T> &value,
+	                              const T &default_value) {
+		// If current value is default, don't write it
+		if (!options.serialize_default_values && (value == default_value)) {
+			OnOptionalPropertyBegin(field_id, tag, false);
+			OnOptionalPropertyEnd(false);
+			return;
+		}
+		OnOptionalPropertyBegin(field_id, tag, true);
+		WriteValue(value.GetValue());
+		OnOptionalPropertyEnd(true);
+	}
+
+	// Special case: data_ptr_T
+	void WriteProperty(const field_id_t field_id, const char *tag, const_data_ptr_t ptr, idx_t count) {
+		OnPropertyBegin(field_id, tag);
+		WriteDataPtr(ptr, count);
+		OnPropertyEnd();
+	}
+
+	// Manually begin an object
+	template <class FUNC>
+	void WriteObject(const field_id_t field_id, const char *tag, FUNC f) {
+		OnPropertyBegin(field_id, tag);
+		OnObjectBegin();
+		f(*this);
+		OnObjectEnd();
+		OnPropertyEnd();
+	}
+
+	template <class FUNC>
+	void WriteList(const field_id_t field_id, const char *tag, idx_t count, FUNC func) {
+		OnPropertyBegin(field_id, tag);
+		OnListBegin(count);
+		List list {*this};
+		for (idx_t i = 0; i < count; i++) {
+			func(list, i);
+		}
+		OnListEnd();
+		OnPropertyEnd();
+	}
+
+protected:
+	template <typename T>
+	typename std::enable_if<std::is_enum<T>::value, void>::type WriteValue(const T value) {
+		if (options.serialize_enum_as_string) {
+			// Use the enum serializer to lookup tostring function
+			auto str = EnumUtil::ToChars(value);
+			WriteValue(str);
+		} else {
+			// Use the underlying type
+			WriteValue(static_cast<typename std::underlying_type<T>::type>(value));
+		}
+	}
+
+	// Optionally Owned Pointer Ref
+	template <typename T>
+	void WriteValue(const optionally_owned_ptr<T> &ptr) {
+		WriteValue(ptr.get());
+	}
+
+	// Unique Pointer Ref
+	template <typename T>
+	void WriteValue(const unique_ptr<T> &ptr) {
+		WriteValue(ptr.get());
+	}
+
+	// Shared Pointer Ref
+	template <typename T>
+	void WriteValue(const shared_ptr<T> &ptr) {
+		WriteValue(ptr.get());
+	}
+
+	// Pointer
+	template <typename T>
+	void WriteValue(const T *ptr) {
+		if (ptr == nullptr) {
+			OnNullableBegin(false);
+			OnNullableEnd();
+		} else {
+			OnNullableBegin(true);
+			WriteValue(*ptr);
+			OnNullableEnd();
+		}
+	}
+
+	// Pair
+	template <class K, class V>
+	void WriteValue(const std::pair<K, V> &pair) {
+		OnObjectBegin();
+		WriteProperty(0, "first", pair.first);
+		WriteProperty(1, "second", pair.second);
+		OnObjectEnd();
+	}
+
+	// Reference Wrapper
+	template <class T>
+	void WriteValue(const reference<T> ref) {
+		WriteValue(ref.get());
+	}
+
+	// Vector
+	template <class T>
+	void WriteValue(const vector<T> &vec) {
+		auto count = vec.size();
+		OnListBegin(count);
+		for (auto &item : vec) {
+			WriteValue(item);
+		}
+		OnListEnd();
+	}
+
+	template <class T>
+	void WriteValue(const unsafe_vector<T> &vec) {
+		auto count = vec.size();
+		OnListBegin(count);
+		for (auto &item : vec) {
+			WriteValue(item);
+		}
+		OnListEnd();
+	}
+
+	// UnorderedSet
+	// Serialized the same way as a list/vector
+	template <class T, class HASH, class CMP>
+	void WriteValue(const duckdb::unordered_set<T, HASH, CMP> &set) {
+		auto count = set.size();
+		OnListBegin(count);
+		for (auto &item : set) {
+			WriteValue(item);
+		}
+		OnListEnd();
+	}
+
+	// Set
+	// Serialized the same way as a list/vector
+	template <class T, class HASH, class CMP>
+	void WriteValue(const duckdb::set<T, HASH, CMP> &set) {
+		auto count = set.size();
+		OnListBegin(count);
+		for (auto &item : set) {
+			WriteValue(item);
+		}
+		OnListEnd();
+	}
+
+	// Map
+	// serialized as a list of pairs
+	template <class K, class V, class HASH, class CMP>
+	void WriteValue(const duckdb::unordered_map<K, V, HASH, CMP> &map) {
+		auto count = map.size();
+		OnListBegin(count);
+		for (auto &item : map) {
+			OnObjectBegin();
+			WriteProperty(0, "key", item.first);
+			WriteProperty(1, "value", item.second);
+			OnObjectEnd();
+		}
+		OnListEnd();
+	}
+
+	// Map
+	// serialized as a list of pairs
+	template <class K, class V, class HASH, class CMP>
+	void WriteValue(const duckdb::map<K, V, HASH, CMP> &map) {
+		auto count = map.size();
+		OnListBegin(count);
+		for (auto &item : map) {
+			OnObjectBegin();
+			WriteProperty(0, "key", item.first);
+			WriteProperty(1, "value", item.second);
+			OnObjectEnd();
+		}
+		OnListEnd();
+	}
+
+	// Insertion Order Preserving Map
+	// serialized as a list of pairs
+	template <class V>
+	void WriteValue(const duckdb::InsertionOrderPreservingMap<V> &map) {
+		auto count = map.size();
+		OnListBegin(count);
+		for (auto &entry : map) {
+			OnObjectBegin();
+			WriteProperty(0, "key", entry.first);
+			WriteProperty(1, "value", entry.second);
+			OnObjectEnd();
+		}
+		OnListEnd();
+	}
+
+	// priority queue
+	template <typename T>
+	void WriteValue(const std::priority_queue<T> &queue) {
+		vector<T> placeholder;
+		auto queue_copy = std::priority_queue<T>(queue);
+		while (queue_copy.size() > 0) {
+			placeholder.emplace_back(queue_copy.top());
+			queue_copy.pop();
+		}
+		WriteValue(placeholder);
+	}
+
+	// class or struct implementing `Serialize(Serializer& Serializer)`;
+	template <typename T>
+	typename std::enable_if<has_serialize<T>::value>::type WriteValue(const T &value) {
+		OnObjectBegin();
+		value.Serialize(*this);
+		OnObjectEnd();
+	}
+
+protected:
+	// Hooks for subclasses to override to implement custom behavior
+	virtual void OnPropertyBegin(const field_id_t field_id, const char *tag) = 0;
+	virtual void OnPropertyEnd() = 0;
+	virtual void OnOptionalPropertyBegin(const field_id_t field_id, const char *tag, bool present) = 0;
+	virtual void OnOptionalPropertyEnd(bool present) = 0;
+	virtual void OnObjectBegin() = 0;
+	virtual void OnObjectEnd() = 0;
+	virtual void OnListBegin(idx_t count) = 0;
+	virtual void OnListEnd() = 0;
+	virtual void OnNullableBegin(bool present) = 0;
+	virtual void OnNullableEnd() = 0;
+
+	// Handle primitive types, a serializer needs to implement these.
+	virtual void WriteNull() = 0;
+	virtual void WriteValue(char value) {
+		throw NotImplementedException("Write char value not implemented");
+	}
+	virtual void WriteValue(bool value) = 0;
+	virtual void WriteValue(uint8_t value) = 0;
+	virtual void WriteValue(int8_t value) = 0;
+	virtual void WriteValue(uint16_t value) = 0;
+	virtual void WriteValue(int16_t value) = 0;
+	virtual void WriteValue(uint32_t value) = 0;
+	virtual void WriteValue(int32_t value) = 0;
+	virtual void WriteValue(uint64_t value) = 0;
+	virtual void WriteValue(int64_t value) = 0;
+	virtual void WriteValue(hugeint_t value) = 0;
+	virtual void WriteValue(uhugeint_t value) = 0;
+	virtual void WriteValue(float value) = 0;
+	virtual void WriteValue(double value) = 0;
+	virtual void WriteValue(const string_t value) = 0;
+	virtual void WriteValue(const string &value) = 0;
+	virtual void WriteValue(const char *str) = 0;
+	virtual void WriteDataPtr(const_data_ptr_t ptr, idx_t count) = 0;
+	void WriteValue(LogicalIndex value) {
+		WriteValue(value.index);
+	}
+	void WriteValue(PhysicalIndex value) {
+		WriteValue(value.index);
+	}
+	void WriteValue(optional_idx value) {
+		WriteValue(value.IsValid() ? value.GetIndex() : DConstants::INVALID_INDEX);
+	}
+};
+
+// We need to special case vector<bool> because elements of vector<bool> cannot be referenced
+template <>
+void Serializer::WriteValue(const vector<bool> &vec);
+
+// Specialization for Value (default Value comparison throws when comparing nulls)
+template <>
+void Serializer::WritePropertyWithDefault<Value>(const field_id_t field_id, const char *tag, const Value &value,
+                                                 const Value &default_value);
+
+// List Impl
+template <class FUNC>
+void Serializer::List::WriteObject(FUNC f) {
+	serializer.OnObjectBegin();
+	f(serializer);
+	serializer.OnObjectEnd();
+}
+
+template <class T>
+void Serializer::List::WriteElement(const T &value) {
+	serializer.WriteValue(value);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+class BaseSecret;
+struct SecretEntry;
+struct FileOpenerInfo;
+struct CreateSecretInfo;
+
+//! Whether a secret is persistent or temporary
+enum class SecretPersistType : uint8_t { DEFAULT, TEMPORARY, PERSISTENT };
+
+//! Input passed to a CreateSecretFunction
+struct CreateSecretInput {
+	//! type
+	string type;
+	//! mode
+	string provider;
+	//! should the secret be persisted?
+	string storage_type;
+	//! (optional) alias provided by user
+	string name;
+	//! (optional) scope provided by user
+	vector<string> scope;
+	//! (optional) named parameter map, each create secret function has defined it's own set of these
+	case_insensitive_map_t<Value> options;
+	//! how to handle conflicts
+	OnCreateConflict on_conflict;
+	//! persistence of secret
+	SecretPersistType persist_type;
+};
+
+typedef unique_ptr<BaseSecret> (*secret_deserializer_t)(Deserializer &deserializer, BaseSecret base_secret);
+typedef unique_ptr<BaseSecret> (*create_secret_function_t)(ClientContext &context, CreateSecretInput &input);
+
+//! A CreateSecretFunction is a function adds a provider for a secret type.
+class CreateSecretFunction {
+public:
+	string secret_type;
+	string provider;
+	create_secret_function_t function;
+	named_parameter_type_map_t named_parameters;
+};
+
+//! CreateSecretFunctionsSet contains multiple functions of a single type, identified by the provider. The provider
+//! should be seen as the method of secret creation. (e.g. user-provided config, env variables, auto-detect)
+class CreateSecretFunctionSet {
+public:
+	explicit CreateSecretFunctionSet(string &name) : name(name) {};
+
+public:
+	bool ProviderExists(const string &provider_name);
+	void AddFunction(CreateSecretFunction &function, OnCreateConflict on_conflict);
+	CreateSecretFunction &GetFunction(const string &provider);
+
+protected:
+	//! Create Secret Function type name
+	string name;
+	//! Maps of provider -> function
+	case_insensitive_map_t<CreateSecretFunction> functions;
+};
+
+//! Determines whether the secrets are allowed to be shown
+enum class SecretDisplayType : uint8_t { REDACTED, UNREDACTED };
+
+//! Secret types contain the base settings of a secret
+struct SecretType {
+	//! Unique name identifying the secret type
+	string name;
+	//! The deserialization function for the type
+	secret_deserializer_t deserializer;
+	//! Provider to use when non is specified
+	string default_provider;
+	//! The extension that registered this secret type
+	string extension;
+};
+
+enum class SecretSerializationType : uint8_t {
+	//! The secret is serialized with a custom serialization function
+	CUSTOM = 0,
+	//! The secret has been serialized as a KeyValueSecret
+	KEY_VALUE_SECRET = 1
+};
+
+//! Base class from which BaseSecret classes can be made.
+class BaseSecret {
+	friend class SecretManager;
+
+public:
+	BaseSecret(vector<string> prefix_paths_p, string type_p, string provider_p, string name_p)
+	    : prefix_paths(std::move(prefix_paths_p)), type(std::move(type_p)), provider(std::move(provider_p)),
+	      name(std::move(name_p)), serializable(false) {
+		D_ASSERT(!type.empty());
+	}
+	BaseSecret(const BaseSecret &other)
+	    : prefix_paths(other.prefix_paths), type(other.type), provider(other.provider), name(other.name),
+	      serializable(other.serializable) {
+		D_ASSERT(!type.empty());
+	}
+	virtual ~BaseSecret() = default;
+
+	//! The score of how well this secret's scope matches the path (by default: the length of the longest matching
+	//! prefix)
+	virtual int64_t MatchScore(const string &path) const;
+	//! Prints the secret as a string
+	virtual string ToString(SecretDisplayType mode = SecretDisplayType::REDACTED) const;
+	//! Serialize this secret
+	virtual void Serialize(Serializer &serializer) const;
+
+	virtual unique_ptr<const BaseSecret> Clone() const {
+		D_ASSERT(typeid(BaseSecret) == typeid(*this));
+		return make_uniq<BaseSecret>(*this);
+	}
+
+	//! Getters
+	const vector<string> &GetScope() const {
+		return prefix_paths;
+	}
+	const string &GetType() const {
+		return type;
+	}
+	const string &GetProvider() const {
+		return provider;
+	}
+	const string &GetName() const {
+		return name;
+	}
+	bool IsSerializable() const {
+		return serializable;
+	}
+
+protected:
+	//! Helper function to serialize the base BaseSecret class variables
+	virtual void SerializeBaseSecret(Serializer &serializer) const final;
+
+	//! prefixes to which the secret applies
+	vector<string> prefix_paths;
+
+	//! Type of secret
+	string type;
+	//! Provider of the secret
+	string provider;
+	//! Name of the secret
+	string name;
+	//! Whether the secret can be serialized/deserialized
+	bool serializable;
+};
+
+//! The KeyValueSecret is a class that implements a Secret as a set of key -> values. This class can be used
+//! for most use-cases of secrets as secrets generally tend to fit in a key value map.
+class KeyValueSecret : public BaseSecret {
+public:
+	KeyValueSecret(const vector<string> &prefix_paths, const string &type, const string &provider, const string &name)
+	    : BaseSecret(prefix_paths, type, provider, name) {
+		D_ASSERT(!type.empty());
+		serializable = true;
+	}
+	explicit KeyValueSecret(const BaseSecret &secret)
+	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
+		serializable = true;
+	};
+	KeyValueSecret(const KeyValueSecret &secret)
+	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
+		secret_map = secret.secret_map;
+		redact_keys = secret.redact_keys;
+		serializable = true;
+	};
+	KeyValueSecret(KeyValueSecret &&secret) noexcept
+	    : BaseSecret(std::move(secret.prefix_paths), std::move(secret.type), std::move(secret.provider),
+	                 std::move(secret.name)) {
+		secret_map = std::move(secret.secret_map);
+		redact_keys = std::move(secret.redact_keys);
+		serializable = true;
+	};
+
+	//! Print the secret as a key value map in the format 'key1=value;key2=value2'
+	string ToString(SecretDisplayType mode = SecretDisplayType::REDACTED) const override;
+	void Serialize(Serializer &serializer) const override;
+
+	//! Tries to get the value at key <key>, depending on error_on_missing will throw or return Value()
+	Value TryGetValue(const string &key, bool error_on_missing = false) const;
+
+	// FIXME: use serialization scripts
+	template <class TYPE>
+	static unique_ptr<BaseSecret> Deserialize(Deserializer &deserializer, BaseSecret base_secret) {
+		auto result = make_uniq<TYPE>(base_secret);
+		Value secret_map_value;
+		deserializer.ReadProperty(201, "secret_map", secret_map_value);
+
+		for (const auto &entry : ListValue::GetChildren(secret_map_value)) {
+			auto kv_struct = StructValue::GetChildren(entry);
+			result->secret_map[kv_struct[0].ToString()] = kv_struct[1];
+		}
+
+		Value redact_set_value;
+		deserializer.ReadProperty(202, "redact_keys", redact_set_value);
+		for (const auto &entry : ListValue::GetChildren(redact_set_value)) {
+			result->redact_keys.insert(entry.ToString());
+		}
+
+		return duckdb::unique_ptr_cast<TYPE, BaseSecret>(std::move(result));
+	}
+
+	unique_ptr<const BaseSecret> Clone() const override {
+		return make_uniq<KeyValueSecret>(*this);
+	}
+
+	// Get a value from the secret
+	bool TryGetValue(const string &key, Value &result) const {
+		auto lookup = secret_map.find(key);
+		if (lookup == secret_map.end()) {
+			return false;
+		}
+		result = lookup->second;
+		return true;
+	}
+
+	bool TrySetValue(const string &key, const CreateSecretInput &input) {
+		auto lookup = input.options.find(key);
+		if (lookup != input.options.end()) {
+			secret_map[key] = lookup->second;
+			return true;
+		}
+		return false;
+	}
+
+	//! the map of key -> values that make up the secret
+	case_insensitive_tree_t<Value> secret_map;
+	//! keys that are sensitive and should be redacted
+	case_insensitive_set_t redact_keys;
+};
+
+// Helper class to fetch secret parameters in a cascading way. The idea being that in many cases there is a direct
+// connection between a KeyValueSecret key and a setting and we want to:
+// - check if the secret has a specific key, if so return the corresponding value
+// - check if a setting exists, if so return its value
+// - return a default value
+
+class KeyValueSecretReader {
+public:
+	//! Manually pass in a secret reference
+	KeyValueSecretReader(const KeyValueSecret &secret_p, FileOpener &opener_p) : secret(secret_p) {};
+
+	//! Initializes the KeyValueSecretReader by fetching the secret automatically
+	KeyValueSecretReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,
+	                     idx_t secret_types_len);
+	KeyValueSecretReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char *secret_type);
+
+	//! Initialize KeyValueSecretReader from a db instance
+	KeyValueSecretReader(DatabaseInstance &db, const char **secret_types, idx_t secret_types_len, string path);
+	KeyValueSecretReader(DatabaseInstance &db, const char *secret_type, string path);
+
+	// Initialize KeyValueSecretReader from a client context
+	KeyValueSecretReader(ClientContext &context, const char **secret_types, idx_t secret_types_len, string path);
+	KeyValueSecretReader(ClientContext &context, const char *secret_type, string path);
+
+	~KeyValueSecretReader();
+
+	//! Lookup a KeyValueSecret value
+	SettingLookupResult TryGetSecretKey(const string &secret_key, Value &result);
+	//! Lookup a KeyValueSecret value or a setting
+	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name, Value &result);
+	//! Lookup a KeyValueSecret value or a setting, throws InvalidInputException on not found
+	Value GetSecretKey(const string &secret_key);
+	//! Lookup a KeyValueSecret value or a setting, throws InvalidInputException on not found
+	Value GetSecretKeyOrSetting(const string &secret_key, const string &setting_name);
+
+	//! Templating around TryGetSecretKey
+	template <class TYPE>
+	SettingLookupResult TryGetSecretKey(const string &secret_key, TYPE &value_out) {
+		Value result;
+		auto lookup_result = TryGetSecretKey(secret_key, result);
+		if (lookup_result) {
+			value_out = result.GetValue<TYPE>();
+		}
+		return lookup_result;
+	}
+
+	//! Templating around TryGetSecretOrSetting
+	template <class TYPE>
+	SettingLookupResult TryGetSecretKeyOrSetting(const string &secret_key, const string &setting_name,
+	                                             TYPE &value_out) {
+		Value result;
+		auto lookup_result = TryGetSecretKeyOrSetting(secret_key, setting_name, result);
+		if (lookup_result) {
+			value_out = result.GetValue<TYPE>();
+		}
+		return lookup_result;
+	}
+
+	// Like a templated GetSecretOrSetting but instead of throwing on not found, return the default value
+	template <class TYPE>
+	TYPE GetSecretKeyOrSettingOrDefault(const string &secret_key, const string &setting_name, TYPE default_value) {
+		TYPE result;
+		if (TryGetSecretKeyOrSetting(secret_key, setting_name, result)) {
+			return result;
+		}
+		return default_value;
+	}
+
+protected:
+	void Initialize(const char **secret_types, idx_t secret_types_len);
+
+	[[noreturn]] void ThrowNotFoundError(const string &secret_key);
+	[[noreturn]] void ThrowNotFoundError(const string &secret_key, const string &setting_name);
+
+	//! Fetching the secret
+	optional_ptr<const KeyValueSecret> secret;
+	//! Optionally an owning pointer to the secret entry
+	shared_ptr<SecretEntry> secret_entry;
+
+	//! Secrets/settings will be fetched either through a context (local + global settings) or a databaseinstance
+	//! (global only)
+	optional_ptr<DatabaseInstance> db;
+	optional_ptr<ClientContext> context;
+
+	string path;
+};
+
+} // namespace duckdb
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/create_type_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct BindLogicalTypeInput {
+	ClientContext &context;
+	const LogicalType &base_type;
+	const vector<Value> &modifiers;
+};
+
+//! The type to bind type modifiers to a type
+typedef LogicalType (*bind_logical_type_function_t)(const BindLogicalTypeInput &input);
+
+struct CreateTypeInfo : public CreateInfo {
+	CreateTypeInfo();
+	CreateTypeInfo(string name_p, LogicalType type_p, bind_logical_type_function_t bind_function_p = nullptr);
+
+	//! Name of the Type
+	string name;
+	//! Logical Type
+	LogicalType type;
+	//! Used by create enum from query
+	unique_ptr<SQLStatement> query;
+	//! Bind type modifiers to the type
+	bind_logical_type_function_t bind_function;
+
+public:
+	unique_ptr<CreateInfo> Copy() const override;
+
+	DUCKDB_API void Serialize(Serializer &serializer) const override;
+	DUCKDB_API static unique_ptr<CreateInfo> Deserialize(Deserializer &deserializer);
+
+	string ToString() const override;
+};
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+struct CreateMacroInfo;
+struct CreateCollationInfo;
+struct CreateAggregateFunctionInfo;
+struct CreateScalarFunctionInfo;
+struct CreateTableFunctionInfo;
+class DatabaseInstance;
+
+//! The ExtensionUtil class contains methods that are useful for extensions
+class ExtensionUtil {
+public:
+	//! Register a new DuckDB extension
+	DUCKDB_API static void RegisterExtension(DatabaseInstance &db, const string &name, const ExtensionLoadedInfo &info);
+	//! Register a new scalar function - merge overloads if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunction function);
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunctionSet function);
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateScalarFunctionInfo info);
+	//! Register a new aggregate function - merge overloads if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, AggregateFunction function);
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, AggregateFunctionSet function);
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateAggregateFunctionInfo info);
+	//! Register a new table function - merge overloads if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, TableFunction function);
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, TableFunctionSet function);
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateTableFunctionInfo info);
+	//! Register a new pragma function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, PragmaFunction function);
+	//! Register a new pragma function set - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, PragmaFunctionSet function);
+
+	//! Register a CreateSecretFunction
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateSecretFunction function);
+
+	//! Register a new copy function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CopyFunction function);
+	//! Register a new macro function - throw an exception if the function already exists
+	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, CreateMacroInfo &info);
+
+	//! Register a new collation
+	DUCKDB_API static void RegisterCollation(DatabaseInstance &db, CreateCollationInfo &info);
+
+	//! Returns a reference to the function in the catalog - throws an exception if it does not exist
+	DUCKDB_API static ScalarFunctionCatalogEntry &GetFunction(DatabaseInstance &db, const string &name);
+	DUCKDB_API static TableFunctionCatalogEntry &GetTableFunction(DatabaseInstance &db, const string &name);
+	DUCKDB_API static optional_ptr<CatalogEntry> TryGetFunction(DatabaseInstance &db, const string &name);
+	DUCKDB_API static optional_ptr<CatalogEntry> TryGetTableFunction(DatabaseInstance &db, const string &name);
+
+	//! Add a function overload
+	DUCKDB_API static void AddFunctionOverload(DatabaseInstance &db, ScalarFunction function);
+	DUCKDB_API static void AddFunctionOverload(DatabaseInstance &db, ScalarFunctionSet function);
+	DUCKDB_API static void AddFunctionOverload(DatabaseInstance &db, TableFunctionSet function);
+
+	//! Registers a new type
+	DUCKDB_API static void RegisterType(DatabaseInstance &db, string type_name, LogicalType type,
+	                                    bind_logical_type_function_t bind_function = nullptr);
+
+	//! Registers a new secret type
+	DUCKDB_API static void RegisterSecretType(DatabaseInstance &db, SecretType secret_type);
+
+	//! Registers a cast between two types
+	DUCKDB_API static void RegisterCastFunction(DatabaseInstance &db, const LogicalType &source,
+	                                            const LogicalType &target, BoundCastInfo function,
+	                                            int64_t implicit_cast_cost = -1);
+};
+
+} // namespace duckdb
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/create_table_function_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/parsed_data/create_function_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+struct FunctionDescription {
+	//! Parameter types (if any)
+	vector<LogicalType> parameter_types;
+	//! Parameter names (if any)
+	vector<string> parameter_names;
+	//! The description (if any)
+	string description;
+	//! Examples (if any)
+	vector<string> examples;
+	//! Categories (if any)
+	vector<string> categories;
+};
+
+struct CreateFunctionInfo : public CreateInfo {
+	explicit CreateFunctionInfo(CatalogType type, string schema = DEFAULT_SCHEMA);
+
+	//! Function name
+	string name;
+	//! The function name of which this function is an alias
+	string alias_of;
+	//! Function description
+	vector<FunctionDescription> descriptions;
+
+	DUCKDB_API void CopyFunctionProperties(CreateFunctionInfo &other) const;
+};
+
+} // namespace duckdb
+
+
 
 namespace duckdb {
 
@@ -41427,6 +51370,7 @@ public:
 
 
 
+
 namespace duckdb {
 
 class QueryNode;
@@ -41436,7 +51380,7 @@ public:
 	static constexpr const ParseInfoType TYPE = ParseInfoType::COPY_INFO;
 
 public:
-	CopyInfo() : ParseInfo(TYPE), catalog(INVALID_CATALOG), schema(DEFAULT_SCHEMA) {
+	CopyInfo() : ParseInfo(TYPE), catalog(INVALID_CATALOG), schema(DEFAULT_SCHEMA), is_format_auto_detected(true) {
 	}
 
 	//! The catalog name to copy to/from
@@ -41451,15 +51395,18 @@ public:
 	bool is_from;
 	//! The file format of the external file
 	string format;
+	//! If the format is manually set (i.e., via the format parameter) or was discovered by inspecting the file path
+	bool is_format_auto_detected;
 	//! The file path to copy to/from
 	string file_path;
 	//! Set of (key, value) options
 	case_insensitive_map_t<vector<Value>> options;
-	// The SQL statement used instead of a table when copying data out to a file
+	//! The SQL statement used instead of a table when copying data out to a file
 	unique_ptr<QueryNode> select_statement;
 
 public:
-	static string CopyOptionsToString(const string &format, const case_insensitive_map_t<vector<Value>> &options);
+	static string CopyOptionsToString(const string &format, bool is_format_auto_detected,
+	                                  const case_insensitive_map_t<vector<Value>> &options);
 
 public:
 	unique_ptr<CopyInfo> Copy() const;
@@ -41514,10 +51461,12 @@ private:
 
 namespace duckdb {
 
-class Binder;
 struct BoundStatement;
+struct CopyFunctionFileStatistics;
+class Binder;
 class ColumnDataCollection;
 class ExecutionContext;
+class PhysicalOperatorLogger;
 
 struct LocalFunctionData {
 	virtual ~LocalFunctionData() = default;
@@ -41616,18 +51565,36 @@ typedef bool (*copy_rotate_files_t)(FunctionData &bind_data, const optional_idx 
 typedef bool (*copy_rotate_next_file_t)(GlobalFunctionData &gstate, FunctionData &bind_data,
                                         const optional_idx &file_size_bytes);
 
+typedef void (*copy_to_get_written_statistics_t)(ClientContext &context, FunctionData &bind_data,
+                                                 GlobalFunctionData &gstate, CopyFunctionFileStatistics &statistics);
+
 typedef vector<unique_ptr<Expression>> (*copy_to_select_t)(CopyToSelectInput &input);
 
-enum class CopyFunctionReturnType : uint8_t { CHANGED_ROWS = 0, CHANGED_ROWS_AND_FILE_LIST = 1 };
+typedef void (*copy_to_initialize_operator_t)(GlobalFunctionData &gstate, const PhysicalOperator &op);
+
+enum class CopyFunctionReturnType : uint8_t {
+	CHANGED_ROWS = 0,
+	CHANGED_ROWS_AND_FILE_LIST = 1,
+	WRITTEN_FILE_STATISTICS = 2
+};
 vector<string> GetCopyFunctionReturnNames(CopyFunctionReturnType return_type);
 vector<LogicalType> GetCopyFunctionReturnLogicalTypes(CopyFunctionReturnType return_type);
+
+struct CopyFunctionFileStatistics {
+	idx_t row_count = 0;
+	idx_t file_size_bytes = 0;
+	Value footer_size_bytes;
+	// map of column name -> statistics name -> statistics value
+	case_insensitive_map_t<case_insensitive_map_t<Value>> column_statistics;
+};
 
 class CopyFunction : public Function { // NOLINT: work-around bug in clang-tidy
 public:
 	explicit CopyFunction(const string &name)
 	    : Function(name), plan(nullptr), copy_to_select(nullptr), copy_to_bind(nullptr),
-	      copy_to_initialize_local(nullptr), copy_to_initialize_global(nullptr), copy_to_sink(nullptr),
-	      copy_to_combine(nullptr), copy_to_finalize(nullptr), execution_mode(nullptr), prepare_batch(nullptr),
+	      copy_to_initialize_local(nullptr), copy_to_initialize_global(nullptr),
+	      copy_to_get_written_statistics(nullptr), copy_to_sink(nullptr), copy_to_combine(nullptr),
+	      copy_to_finalize(nullptr), execution_mode(nullptr), initialize_operator(nullptr), prepare_batch(nullptr),
 	      flush_batch(nullptr), desired_batch_size(nullptr), rotate_files(nullptr), rotate_next_file(nullptr),
 	      serialize(nullptr), deserialize(nullptr), copy_from_bind(nullptr) {
 	}
@@ -41639,10 +51606,12 @@ public:
 	copy_to_bind_t copy_to_bind;
 	copy_to_initialize_local_t copy_to_initialize_local;
 	copy_to_initialize_global_t copy_to_initialize_global;
+	copy_to_get_written_statistics_t copy_to_get_written_statistics;
 	copy_to_sink_t copy_to_sink;
 	copy_to_combine_t copy_to_combine;
 	copy_to_finalize_t copy_to_finalize;
 	copy_to_execution_mode_t execution_mode;
+	copy_to_initialize_operator_t initialize_operator;
 
 	copy_prepare_batch_t prepare_batch;
 	copy_flush_batch_t flush_batch;

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Duckdbex.MixProject do
   use Mix.Project
 
-  @version "0.3.11"
+  @version "0.3.12"
   @duckdb_version "1.3.1"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Duckdbex.MixProject do
   use Mix.Project
 
   @version "0.3.11"
-  @duckdb_version "1.2.2"
+  @duckdb_version "1.3.1"
 
   def project do
     [


### PR DESCRIPTION
This PR will update to use duckdb 1.3.1 and also includes broader support for elixir/otp versions.