### PR TITLE
Fix Livebook appender example

### DIFF
--- a/duckdbex_sandbox.livemd
+++ b/duckdbex_sandbox.livemd
@@ -69,18 +69,18 @@ Now we are preparing the huge amount of books data. `MAPs` must have a single ty
 a_looot_of_books_list = [
   [
     1,
-    %{
-      "title" => "Computer Architecture: A Quantitative Approach",
-      "paperback pages" => "856",
-      "dimensions" => "7.5 x 1.75 x 9 inches"
-    }
+    [
+      {"title", "Computer Architecture: A Quantitative Approach"},
+      {"paperback pages", "856"},
+      {"dimensions", "7.5 x 1.75 x 9 inches"}
+    ]
   ],
   [
     2,
-    %{
-      "title" => "The Pragmatic Programmer",
-      "publicher" => "David Thomas"
-    }
+    [
+      {"title", "The Pragmatic Programmer"},
+      {"publicher", "David Thomas"}
+    ]
   ]
 ]
 ```


### PR DESCRIPTION
Duckdb maps are ordered, so they must be represented as List of tuples.

<img width="984" height="918" alt="image" src="https://github.com/user-attachments/assets/2a2081fa-c68c-4399-8338-a006736e2f4d" />
