### PR TITLE
fix: handle special float cases

### DIFF
--- a/c_src/value_to_term.cpp
+++ b/c_src/value_to_term.cpp
@@ -134,7 +134,18 @@ bool nif::value_to_term(ErlNifEnv* env, const duckdb::Value& value, ERL_NIF_TERM
 
     case duckdb::LogicalTypeId::FLOAT: {
         auto a_float = value.GetValueUnsafe<float>();
-        sink = enif_make_double(env, a_float);
+
+        if (std::isinf(a_float)) {
+            if (a_float > 0) {
+                sink = make_atom(env, "infinity");
+            } else {
+                sink = make_atom(env, "-infinity");
+            }
+        } else if (std::isnan(a_float)) {
+            sink = make_atom(env, "nan");
+        } else {
+            sink = enif_make_double(env, a_float);
+        }
         return true;
       }
     case duckdb::LogicalTypeId::SMALLINT: {

--- a/test/fetch_test.exs
+++ b/test/fetch_test.exs
@@ -36,6 +36,21 @@ defmodule Duckdbex.FetchTest do
     assert [[:"-infinity"]] == Duckdbex.fetch_all(result_ref)
   end
 
+  test "inf and nan float 32 does not crash", %{conn: conn} do
+    # Test with FLOAT (f32) - this fails
+    {:ok, _} =
+      Duckdbex.query(conn, "CREATE TABLE test_f32 (neg_inf FLOAT, pos_inf FLOAT, nan FLOAT)")
+
+    {:ok, _} =
+      Duckdbex.query(
+        conn,
+        "INSERT INTO test_f32 VALUES (-'Infinity'::FLOAT, 'Infinity'::FLOAT, 'NaN')"
+      )
+
+    {:ok, result_ref} = Duckdbex.query(conn, "SELECT * FROM test_f32")
+    assert [[:"-infinity", :infinity, :nan]] == Duckdbex.fetch_all(result_ref)
+  end
+
   test "fetch_all", %{conn: conn} do
     {:ok, _} =
       Duckdbex.query(conn, """


### PR DESCRIPTION
This fix is similar to 3934a9aa, but for floats.

The new test fails without this fix. 