### PR TITLE
fix: correct NIF resource lifecycle and C++ initialization

### DIFF
--- a/c_src/allocator.h
+++ b/c_src/allocator.h
@@ -3,7 +3,7 @@
 #include "duckdb.hpp"
 
 namespace nif {
-  duckdb::data_ptr_t eddb_allocate(duckdb::PrivateAllocatorData *private_data, duckdb::idx_t n) {
+  inline duckdb::data_ptr_t eddb_allocate(duckdb::PrivateAllocatorData *private_data, duckdb::idx_t n) {
     if(n > std::size_t(-1) / sizeof(duckdb::data_t))
       throw std::bad_alloc();
 
@@ -13,11 +13,11 @@ namespace nif {
     throw std::bad_alloc();
   }
 
-  void eddb_free(duckdb::PrivateAllocatorData *private_data, duckdb::data_ptr_t p, duckdb::idx_t n) {
+  inline void eddb_free(duckdb::PrivateAllocatorData *private_data, duckdb::data_ptr_t p, duckdb::idx_t n) {
     enif_free(p);
   }
 
-  duckdb::data_ptr_t eddb_reallocate(duckdb::PrivateAllocatorData *private_data, duckdb::data_ptr_t p, duckdb::idx_t old_size, duckdb::idx_t n) {
+  inline duckdb::data_ptr_t eddb_reallocate(duckdb::PrivateAllocatorData *private_data, duckdb::data_ptr_t p, duckdb::idx_t old_size, duckdb::idx_t n) {
     if(auto rp = static_cast<duckdb::data_ptr_t>(enif_realloc(p, n * sizeof(duckdb::data_t))))
       return rp;
 

--- a/c_src/nif.cpp
+++ b/c_src/nif.cpp
@@ -6,7 +6,6 @@
 #include "duckdb.hpp"
 #include <erl_nif.h>
 #include <string>
-#include <iostream>
 
 /*
  * DuckDB API
@@ -631,40 +630,6 @@ release(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
 }
 
 /*
- * Resources destructors
- */
-
-static void
-database_type_destructor(ErlNifEnv* env, void* arg) {
-  erlang_resource<duckdb::DuckDB>* resource = static_cast<erlang_resource<duckdb::DuckDB>*>(arg);
-  resource->data = nullptr;
-}
-
-static void
-connection_type_destructor(ErlNifEnv* env, void* arg) {
-  erlang_resource<duckdb::Connection>* resource = static_cast<erlang_resource<duckdb::Connection>*>(arg);
-  resource->data = nullptr;
-}
-
-static void
-appender_type_destructor(ErlNifEnv* env, void* arg) {
-  erlang_resource<duckdb::Appender>* resource = static_cast<erlang_resource<duckdb::Appender>*>(arg);
-  resource->data = nullptr;
-}
-
-static void
-query_result_type_destructor(ErlNifEnv* env, void* arg) {
-  erlang_resource<duckdb::QueryResult>* resource = static_cast<erlang_resource<duckdb::QueryResult>*>(arg);
-  resource->data = nullptr;
-}
-
-static void
-prepared_statement_type_destructor(ErlNifEnv* env, void* arg) {
-  erlang_resource<duckdb::PreparedStatement>* resource = static_cast<erlang_resource<duckdb::PreparedStatement>*>(arg);
-  resource->data = nullptr;
-}
-
-/*
  * Load the nif. Initialize some stuff
  */
 static int
@@ -673,7 +638,7 @@ on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info) {
     env,
     "duckdbex",
     "database_nif_type",
-    database_type_destructor,
+    resource_destructor<duckdb::DuckDB>,
     ERL_NIF_RT_CREATE,
     NULL);
 
@@ -685,7 +650,7 @@ on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info) {
     env,
     "duckdbex",
     "connection_nif_type",
-    connection_type_destructor,
+    resource_destructor<duckdb::Connection>,
     ERL_NIF_RT_CREATE,
     NULL);
 
@@ -697,7 +662,7 @@ on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info) {
     env,
     "duckdbex",
     "appender_nif_type",
-    appender_type_destructor,
+    resource_destructor<duckdb::Appender>,
     ERL_NIF_RT_CREATE,
     NULL);
 
@@ -709,7 +674,7 @@ on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info) {
     env,
     "duckdbex",
     "query_result_nif_type",
-    query_result_type_destructor,
+    resource_destructor<duckdb::QueryResult>,
     ERL_NIF_RT_CREATE,
     NULL);
 
@@ -721,7 +686,7 @@ on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info) {
     env,
     "duckdbex",
     "prepared_statement_nif_type",
-    prepared_statement_type_destructor,
+    resource_destructor<duckdb::PreparedStatement>,
     ERL_NIF_RT_CREATE,
     NULL);
 

--- a/c_src/resource.h
+++ b/c_src/resource.h
@@ -19,7 +19,16 @@ static ErlNifResourceType* appender_nif_type = nullptr;
 template<class T>
 struct erlang_resource {
   std::unique_ptr<T> data;
+
+  erlang_resource(std::unique_ptr<T> d)
+      : data(std::move(d)) {}
 };
+
+template<class T>
+static void resource_destructor(ErlNifEnv*, void* arg) {
+  auto* resource = static_cast<erlang_resource<T>*>(arg);
+  resource->~erlang_resource<T>();
+}
 
 /*
  * Erlang resource builder
@@ -32,28 +41,25 @@ class ErlangResourceBuilder {
 
     ErlangResourceBuilder(ErlNifResourceType* resource_type, duckdb::unique_ptr<Data> data)
       : resource(static_cast<Resource*>(enif_alloc_resource(resource_type, sizeof(Resource)))) {
-      if (resource) {
-        memset(resource, 0, sizeof(Resource));
-        resource->data = std::move(data);
-      } else {
-        throw std::runtime_error("out of memory");
+      if (!resource) {
+        throw std::bad_alloc();
       }
+
+      new (resource) Resource(std::move(data));
     }
 
     template <typename... Args>
     ErlangResourceBuilder(ErlNifResourceType* resource_type, Args&&... args)
       : resource(static_cast<Resource*>(enif_alloc_resource(resource_type, sizeof(Resource)))) {
-      if (resource) {
-        memset(resource, 0, sizeof(Resource));
-        resource->data = duckdb::make_uniq<Data>(std::forward<Args>(args)...);
-      } else {
-        throw std::runtime_error("out of memory");
+      if (!resource) {
+        throw std::bad_alloc();
       }
+
+      new (resource) Resource(duckdb::make_uniq<Data>(std::forward<Args>(args)...));
     }
 
     ~ErlangResourceBuilder() {
       if (resource) {
-        resource->data = nullptr;
         enif_release_resource(resource);
         resource = nullptr;
       }
@@ -85,7 +91,7 @@ template <class T>
 erlang_resource<T>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term);
 
 template <>
-erlang_resource<duckdb::DuckDB>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
+inline erlang_resource<duckdb::DuckDB>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
   erlang_resource<duckdb::DuckDB>* resource = nullptr;
   if(enif_get_resource(env, term, database_nif_type, (void**)&resource) && resource->data)
     return resource;
@@ -93,7 +99,7 @@ erlang_resource<duckdb::DuckDB>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term)
 }
 
 template <>
-erlang_resource<duckdb::Connection>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
+inline erlang_resource<duckdb::Connection>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
   erlang_resource<duckdb::Connection>* resource = nullptr;
   if(enif_get_resource(env, term, connection_nif_type, (void**)&resource) && resource->data)
     return resource;
@@ -101,7 +107,7 @@ erlang_resource<duckdb::Connection>* get_resource(ErlNifEnv* env, ERL_NIF_TERM t
 }
 
 template <>
-erlang_resource<duckdb::QueryResult>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
+inline erlang_resource<duckdb::QueryResult>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
   erlang_resource<duckdb::QueryResult>* resource = nullptr;
   if(enif_get_resource(env, term, query_result_nif_type, (void**)&resource) && resource->data)
     return resource;
@@ -109,7 +115,7 @@ erlang_resource<duckdb::QueryResult>* get_resource(ErlNifEnv* env, ERL_NIF_TERM 
 }
 
 template <>
-erlang_resource<duckdb::PreparedStatement>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
+inline erlang_resource<duckdb::PreparedStatement>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
   erlang_resource<duckdb::PreparedStatement>* resource = nullptr;
   if(enif_get_resource(env, term, prepared_statement_nif_type, (void**)&resource) && resource->data)
     return resource;
@@ -117,7 +123,7 @@ erlang_resource<duckdb::PreparedStatement>* get_resource(ErlNifEnv* env, ERL_NIF
 }
 
 template <>
-erlang_resource<duckdb::Appender>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
+inline erlang_resource<duckdb::Appender>* get_resource(ErlNifEnv* env, ERL_NIF_TERM term) {
   erlang_resource<duckdb::Appender>* resource = nullptr;
   if(enif_get_resource(env, term, appender_nif_type, (void**)&resource) && resource->data)
     return resource;

--- a/c_src/term.cpp
+++ b/c_src/term.cpp
@@ -1,6 +1,7 @@
 #include "term.h"
-#include "duckdb.hpp"
+#include <cassert>
 #include <erl_nif.h>
+#include <vector>
 
 const int64_t POWERS_OF_TEN[] {1,
                               10,
@@ -45,7 +46,7 @@ nif::make_atom(ErlNifEnv* env, const char* atom_name) {
 ERL_NIF_TERM
 nif::make_atom(ErlNifEnv* env, const std::string& atom_name) {
   assert(env);
-  assert(atom_name);
+  assert(!atom_name.empty());
 
   ERL_NIF_TERM atom;
 

--- a/c_src/term_to_value.cpp
+++ b/c_src/term_to_value.cpp
@@ -1,8 +1,6 @@
 #include "term_to_value.h"
 #include "duckdb.hpp"
-#include "map_iterator.h"
 #include "term.h"
-#include <iostream>
 
 namespace {
   template <class T>

--- a/c_src/value_to_term.cpp
+++ b/c_src/value_to_term.cpp
@@ -2,7 +2,6 @@
 #include "duckdb.hpp"
 #include "term.h"
 #include <cmath>
-#include <iostream>
 
 bool nif::value_to_term(ErlNifEnv* env, const duckdb::Value& value, ERL_NIF_TERM& sink) {
   // <dbg>


### PR DESCRIPTION
This PR fixes resource lifecycle handling in the NIF layer and removes unsafe C-style initialization patterns, aligning resource management with proper C++ object lifetime rules.

Resource destructors were consolidated into a single templated `resource_destructor<T>` that explicitly invokes the `erlang_resource<T>` destructor. This ensures that `std::unique_ptr` and the underlying DuckDB objects are correctly destroyed when Erlang releases the resource. Previously, destructors were only nulling pointers, which did not guarantee proper C++ destruction semantics.

Resource initialization was updated to remove `memset()` usage. Since `erlang_resource` contains a `std::unique_ptr`, zeroing memory is unsafe and technically undefined behavior. Resources are now constructed using placement new, ensuring constructors run correctly and eliminating warnings related to non-trivially copyable types.

The `ErlangResourceBuilder` was simplified to rely on RAII instead of manual pointer resetting. Allocation failures now throw `std::bad_alloc`, and cleanup paths no longer manually clear ownership fields.

A few additional cleanup changes were included:

* Added `inline` to header-defined helper functions to avoid potential ODR/linker issues.
* Removed unused includes.
* Added missing headers.
* Fixed invalid string assertion logic by replacing `assert(atom_name)` with `assert(!atom_name.empty())`.