### PR TITLE
Prokeep fork fix: Fix duckdbex failing to compile on Alpine Linux 3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+0.4.0-prokeep.1
+  - Add an explicit `#include <cstdint>` in `c_src/term.cpp` so `duckdbex` compiles on Alpine Linux 3.22 / GCC 14 toolchains where `uint8_t` is not provided through transitive includes.
+ 
 0.4.0
   - Breaking change release.
   - Updated to DuckDB 1.5.1.

--- a/c_src/term.cpp
+++ b/c_src/term.cpp
@@ -1,6 +1,7 @@
 #include "term.h"
 #include <cassert>
 #include <cstring>
+#include <cstdint>
 #include <erl_nif.h>
 #include <vector>
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Duckdbex.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.0-prokeep.1"
   @duckdb_version "1.5.1"
 
   def project do
@@ -20,7 +20,7 @@ defmodule Duckdbex.MixProject do
       # elixir_make specific config
       make_precompiler: {:nif, CCPrecompiler},
       make_precompiler_url:
-        "https://github.com/AlexR2D2/duckdbex/releases/download/v#{@version}/@{artefact_filename}",
+        "https://github.com/prokeep/duckdbex/releases/download/v#{@version}/@{artefact_filename}",
       make_precompiler_filename: "duckdb_nif",
       make_precompiler_nif_versions: [
         versions: &nif_versions/1,
@@ -29,8 +29,8 @@ defmodule Duckdbex.MixProject do
       cc_precompiler: cc_precompiler(),
       # Docs
       name: "Duckdbex",
-      source_url: "https://github.com/AlexR2D2/duckdbex/",
-      homepage_url: "https://github.com/AlexR2D2/duckdbex/",
+      source_url: "https://github.com/prokeep/duckdbex/",
+      homepage_url: "https://github.com/prokeep/duckdbex/",
       docs: docs()
     ]
   end
@@ -77,8 +77,8 @@ defmodule Duckdbex.MixProject do
       name: "duckdbex",
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/AlexR2D2/duckdbex",
-        "Changelog" => "https://github.com/AlexR2D2/duckdbex/blob/main/CHANGELOG.md"
+        "GitHub" => "https://github.com/prokeep/duckdbex",
+        "Changelog" => "https://github.com/prokeep/duckdbex/blob/main/CHANGELOG.md"
       }
     ]
   end
@@ -108,7 +108,7 @@ defmodule Duckdbex.MixProject do
         "CHANGELOG.md": []
       ],
       source_ref: "v#{@version}",
-      source_url: "https://github.com/AlexR2D2/duckdbex"
+      source_url: "https://github.com/prokeep/duckdbex"
     ]
   end
 


### PR DESCRIPTION
...using GCC/G++ 14.2.0 because c_src/term.cpp uses uint8_t without explicitly including <cstdint> Apparently other toolchains implicitly include it, but ours does not.

This adds an explicit #include of cstdint